### PR TITLE
feat: use TimeOtp-Secret-Base32 as TOTP fallback when entry.otp is empty

### DIFF
--- a/src/kp2bw/convert.py
+++ b/src/kp2bw/convert.py
@@ -309,11 +309,18 @@ class Converter:
 
         title: str = prefix + entry.title if entry.title else prefix + "_untitled"
         firstlevel = self._get_folder_firstlevel(entry)
+
+        # Use entry.otp if set; otherwise fall back to TimeOtp-Secret-Base32
+        # (KeePassXC stores TOTP secrets as this custom property)
+        totp: str = entry.otp if entry.otp else (
+            custom_properties.get("TimeOtp-Secret-Base32", (None, 0))[0] or ""
+        )
+
         bw_item_object = self._create_bw_python_object(
             title=title,
             notes=notes,
             url=entry.url if entry.url else "",
-            totp=entry.otp if entry.otp else "",
+            totp=totp,
             username=entry.username if entry.username else "",
             password=entry.password if entry.password else "",
             custom_properties=custom_properties,

--- a/src/kp2bw/convert.py
+++ b/src/kp2bw/convert.py
@@ -282,8 +282,8 @@ class Converter:
 
         custom_properties: dict[str, FieldSpec] = {}
         for key, value in entry.custom_properties.items():
-            # Skip KeePassXC passkey attributes -- handled separately
-            if key.startswith(KPEX_PASSKEY_PREFIX):
+            # Skip KeePassXC passkey attributes and TOTP secret -- handled separately
+            if key.startswith(KPEX_PASSKEY_PREFIX) or key == "TimeOtp-Secret-Base32":
                 continue
             if key in custom_protected:
                 custom_properties[key] = (value, 1)
@@ -312,8 +312,10 @@ class Converter:
 
         # Use entry.otp if set; otherwise fall back to TimeOtp-Secret-Base32
         # (KeePassXC stores TOTP secrets as this custom property)
-        totp: str = entry.otp if entry.otp else (
-            custom_properties.get("TimeOtp-Secret-Base32", (None, 0))[0] or ""
+        totp: str = (
+            entry.otp
+            if entry.otp
+            else entry.custom_properties.get("TimeOtp-Secret-Base32") or ""
         )
 
         bw_item_object = self._create_bw_python_object(


### PR DESCRIPTION
## Summary

- If `entry.otp` is empty, fall back to the `TimeOtp-Secret-Base32` custom
  property to populate the Bitwarden *Authenticator key* field.
- Tested on real KeePass databases from KeePass where TOTP secrets are stored
  in this custom property rather than the standard OTP attribute.

## What Changed

### `src/kp2bw/convert.py`

- In `_add_bw_entry_to_entries_dict`: extract `totp` before building the
  `BwItemCreate` object; fall back to
  `custom_properties.get("TimeOtp-Secret-Base32")` when `entry.otp` is unset.
- Fallback is a no-op when the property is absent — empty string is passed as
  before.

## Validation

- Manually tested against KeePassXC-created `.kdbx` files where TOTP was stored
  in `TimeOtp-Secret-Base32` — Bitwarden *Authenticator key* now populated
  without manual copy-paste.
- No regressions on entries with a standard `entry.otp` value (takes priority).

## More information

KeePass stores TOTP secrets in a custom property named 'TimeOtp-Secret-Base32' rather than the standard otp attribute. If entry.otp is not set, fall back to this property so the Authenticator key field is populated automatically in Bitwarden.

https://keepass.info/help/base/placeholders.html

The {TIMEOTP} placeholder generates a time-based one-time password (TOTP) according to RFC 6238.

The shared secret and other parameters can be specified using the following entry string fields (which can be added/edited in the entry dialog on the 'Advanced' tab page):

TimeOtp-Secret
TimeOtp-Secret-Hex
TimeOtp-Secret-Base32 (most common)
TimeOtp-Secret-Base64
Exactly one of these fields must be present, and its value must be set to the shared secret in the corresponding encoding. In the first case ('TimeOtp-Secret'), the UTF-8 encoding of the value is used as shared secret. Most services use the Base32 encoding.
