### PR TITLE
fix: friendly error when bw CLI is missing, and support Windows npm bw.cmd shims

### DIFF
--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -11,6 +11,7 @@ GitHub Actions workflows for release checks, publish orchestration, docker e2e, 
 | Main package release flow       | `.github/workflows/publish.yml`            | Triggered by GitHub Release events, not tag push       |
 | Stubs release flow              | `.github/workflows/publish-stubs.yml`      | Triggered by `stubs-v*` tag pushes                     |
 | Docker integration gate         | `.github/workflows/integration-docker.yml` | Reusable workflow; required before main publish        |
+| Windows npm bw.cmd smoke        | `.github/workflows/windows-bw-cmd.yml`     | windows-latest; npm-installs bw and exercises the shim |
 | Codegen drift check             | `.github/workflows/codegen-check.yml`      | Fails when `_bw_api_types.py` drifts from spec         |
 | PR uvx helper comment lifecycle | `.github/workflows/pr-comment-bot.yml`     | Creates/updates archived test command comment          |
 | Version gate logic              | `scripts/version-check-shared.mjs`         | Produces `name`, `version`, `pypi_url` output contract |

--- a/.github/workflows/windows-bw-cmd.yml
+++ b/.github/workflows/windows-bw-cmd.yml
@@ -13,19 +13,14 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
-
+        with: { persist-credentials: false }
       - uses: astral-sh/setup-uv@v8.2.0
-
-      - name: Install project
-        run: uv sync
+      - run: uv sync
 
       # windows-latest ships Node + npm preinstalled, so no setup-node action is
       # needed. npm global installs ship bw.cmd + bw.ps1 (no bw.exe).
       - name: Install Bitwarden CLI via npm
-        run: |
-          node --version
-          npm --version
-          npm install -g @bitwarden/cli
+        run: npm install -g @bitwarden/cli
 
       # Diagnostic only: PowerShell's Get-Command prefers bw.ps1, but kp2bw uses
       # Python's shutil.which (PATHEXT-aware), which resolves bw.cmd. The smoke
@@ -38,6 +33,5 @@ jobs:
           uv run python -c "import shutil; print('shutil.which(bw) =', shutil.which('bw'))"
 
       - name: Run Windows bw .cmd smoke test
-        env:
-          KP2BW_RUN_WIN_CMD_SMOKE: "1"
+        env: { KP2BW_RUN_WIN_CMD_SMOKE: "1" }
         run: uv run python tests/windows_bw_cmd_smoke.py

--- a/.github/workflows/windows-bw-cmd.yml
+++ b/.github/workflows/windows-bw-cmd.yml
@@ -14,20 +14,22 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
-        with: { node-version: "20" }
-
-      - name: Install Bitwarden CLI via npm (creates a bw.cmd shim, no bw.exe)
-        run: npm install -g @bitwarden/cli
-
       - uses: astral-sh/setup-uv@v8.2.0
 
       - name: Install project
         run: uv sync
 
+      # windows-latest ships Node + npm preinstalled, so no setup-node action is
+      # needed. npm global installs ship bw.cmd + bw.ps1 (no bw.exe).
+      - name: Install Bitwarden CLI via npm
+        run: |
+          node --version
+          npm --version
+          npm install -g @bitwarden/cli
+
       # Diagnostic only: PowerShell's Get-Command prefers bw.ps1, but kp2bw uses
-      # Python's shutil.which, which honours PATHEXT (.CMD, not .PS1) and resolves
-      # bw.cmd. The smoke test below is the actual gate via resolve_bw_command.
+      # Python's shutil.which (PATHEXT-aware), which resolves bw.cmd. The smoke
+      # test below is the actual gate via resolve_bw_command.
       - name: Diagnose how bw resolves
         shell: pwsh
         run: |

--- a/.github/workflows/windows-bw-cmd.yml
+++ b/.github/workflows/windows-bw-cmd.yml
@@ -1,0 +1,41 @@
+# yaml-language-server: $schema=https://www.schemastore.org/github-workflow.json
+---
+name: Windows bw .cmd
+on:
+  workflow_call:
+  pull_request:
+  push: { branches: [master] }
+  workflow_dispatch:
+jobs:
+  npm-cmd-shim:
+    runs-on: windows-latest
+    permissions: { contents: read }
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v4
+        with: { node-version: "20" }
+
+      - name: Install Bitwarden CLI via npm (creates a bw.cmd shim, no bw.exe)
+        run: npm install -g @bitwarden/cli
+
+      - name: Confirm bw resolves to a .cmd shim
+        shell: pwsh
+        run: |
+          $bw = (Get-Command bw).Source
+          Write-Host "bw resolved to: $bw"
+          if (-not $bw.ToLower().EndsWith(".cmd")) {
+            Write-Error "expected an npm bw.cmd shim, got: $bw"
+            exit 1
+          }
+
+      - uses: astral-sh/setup-uv@v8.2.0
+
+      - name: Install project
+        run: uv sync
+
+      - name: Run Windows bw .cmd smoke test
+        env:
+          KP2BW_RUN_WIN_CMD_SMOKE: "1"
+        run: uv run python tests/windows_bw_cmd_smoke.py

--- a/.github/workflows/windows-bw-cmd.yml
+++ b/.github/workflows/windows-bw-cmd.yml
@@ -20,20 +20,20 @@ jobs:
       - name: Install Bitwarden CLI via npm (creates a bw.cmd shim, no bw.exe)
         run: npm install -g @bitwarden/cli
 
-      - name: Confirm bw resolves to a .cmd shim
-        shell: pwsh
-        run: |
-          $bw = (Get-Command bw).Source
-          Write-Host "bw resolved to: $bw"
-          if (-not $bw.ToLower().EndsWith(".cmd")) {
-            Write-Error "expected an npm bw.cmd shim, got: $bw"
-            exit 1
-          }
-
       - uses: astral-sh/setup-uv@v8.2.0
 
       - name: Install project
         run: uv sync
+
+      # Diagnostic only: PowerShell's Get-Command prefers bw.ps1, but kp2bw uses
+      # Python's shutil.which, which honours PATHEXT (.CMD, not .PS1) and resolves
+      # bw.cmd. The smoke test below is the actual gate via resolve_bw_command.
+      - name: Diagnose how bw resolves
+        shell: pwsh
+        run: |
+          Write-Host "PATHEXT = $env:PATHEXT"
+          Get-Command bw -All | Format-Table CommandType, Name, Source -AutoSize
+          uv run python -c "import shutil; print('shutil.which(bw) =', shutil.which('bw'))"
 
       - name: Run Windows bw .cmd smoke test
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,11 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   prompting for passwords) and exits cleanly with an actionable message; any
   `BitwardenClientError`/`ConversionError` raised during conversion is reported
   the same way instead of as a stack trace. `BitwardenServeClient` raises a
-  `BitwardenClientError` rather than letting `FileNotFoundError` escape. Fixes #5.
+  `BitwardenClientError` rather than letting `FileNotFoundError` escape.
+  Detection uses `shutil.which`, so Windows `bw.exe`/`bw.cmd` shims are found via
+  `PATHEXT`; the `bw` subprocess calls also catch `FileNotFoundError`, so even an
+  unexecutable shim (e.g. an npm `bw.cmd` that `CreateProcess` can't run) yields
+  the friendly message. Fixes #5.
 
 ## [3.0.1] - 2026-06-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,15 +10,18 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
-- **Windows npm `bw.cmd` support** -- An npm-installed Bitwarden CLI on Windows
-  exposes only a `bw.cmd` shim (no `bw.exe`), which `CreateProcess` cannot run
-  directly. `resolve_bw_command` now detects `.cmd`/`.bat` shims and routes them
-  through `cmd.exe /c` (invoked by basename from their own directory to avoid
-  shell-quoting issues), and `terminate_serve` tears the `bw serve` process tree
-  down with `taskkill /F /T` so the real server isn't orphaned behind the
-  `cmd.exe` wrapper. A `windows-bw-cmd` CI job installs `bw` via npm and runs a
-  live smoke test (`tests/windows_bw_cmd_smoke.py`) covering invocation and
-  teardown of the shim.
+- **Windows shim support (`bw.cmd`/`bw.bat`/`bw.ps1`)** -- Installer methods put
+  different shims on `PATH` and `CreateProcess` can only run real `.exe`/`.com`
+  images. `resolve_bw_command` now resolves all flavours, most-reliable first:
+  native `bw.exe`/`bw.com` run directly; `bw.cmd`/`bw.bat` are routed through
+  `cmd.exe /c` (invoked by basename from their own directory to avoid
+  shell-quoting issues); and a `bw.ps1` (which isn't in `PATHEXT`, so
+  `shutil.which` can't see it) is found on `PATH` and run through PowerShell. So
+  when npm ships both `bw.cmd` and `bw.ps1`, the `cmd` shim is preferred.
+  `terminate_serve` tears the `bw serve` process tree down with `taskkill /F /T`
+  so the real server isn't orphaned behind a `cmd.exe`/PowerShell wrapper. A
+  `windows-bw-cmd` CI job installs `bw` via npm and runs a live smoke test
+  (`tests/windows_bw_cmd_smoke.py`) covering invocation and teardown of the shim.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -436,7 +436,9 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 [`jampe/kp2bw@c9ef571eabd345db94751f7dec845e49756e9d47`](https://github.com/jampe/kp2bw/commit/c9ef571eabd345db94751f7dec845e49756e9d47)
 
-[Unreleased]: https://github.com/kjanat/kp2bw/compare/v3.0.0...HEAD
+[Unreleased]: https://github.com/kjanat/kp2bw/compare/v3.1.0...HEAD
+[3.1.0]: https://github.com/kjanat/kp2bw/compare/v3.0.1...v3.1.0
+[3.0.1]: https://github.com/kjanat/kp2bw/compare/v3.0.0...v3.0.1
 [3.0.0]: https://github.com/kjanat/kp2bw/compare/v3.0.0a1...v3.0.0
 [3.0.0a1]: https://github.com/kjanat/kp2bw/compare/v2.0.0...v3.0.0a1
 [2.0.0]: https://github.com/kjanat/kp2bw/compare/v2.0.0rc3...v2.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Missing `bw` CLI traceback** -- When the Bitwarden CLI (`bw`) was not on
+  `PATH`, `kp2bw` crashed with a long, intimidating `FileNotFoundError`
+  traceback from `subprocess`. The CLI now checks for `bw` up front (before
+  prompting for passwords) and exits cleanly with an actionable message; any
+  `BitwardenClientError`/`ConversionError` raised during conversion is reported
+  the same way instead of as a stack trace. `BitwardenServeClient` raises a
+  `BitwardenClientError` rather than letting `FileNotFoundError` escape. Fixes #5.
+
 ## [3.0.1] - 2026-06-08
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   so the real server isn't orphaned behind a `cmd.exe`/PowerShell wrapper. A
   `windows-bw-cmd` CI job installs `bw` via npm and runs a live smoke test
   (`tests/windows_bw_cmd_smoke.py`) covering shim invocation (`bw --version`) and
-  `cmd.exe`-wrapped process-tree teardown.
+  `cmd.exe`-wrapped process-tree teardown. Fixes #8.
 
 ### Fixed
 
@@ -36,9 +36,6 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   Detection uses `shutil.which`, so Windows `bw.exe`/`bw.cmd` shims are found via
   `PATHEXT`; the `bw` subprocess calls also catch `FileNotFoundError`, so a
   genuinely missing CLI still yields the friendly message. Fixes #5.
-
-### Fixed
-
 - **Chained `{REF:...}` references** -- a reference whose target was itself
   another reference entry (a chain `A -> B -> C`) raised `KeyError` in
   `_resolve_entries_with_references`, logged a `Could not resolve entry`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,8 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `terminate_serve` tears the `bw serve` process tree down with `taskkill /F /T`
   so the real server isn't orphaned behind a `cmd.exe`/PowerShell wrapper. A
   `windows-bw-cmd` CI job installs `bw` via npm and runs a live smoke test
-  (`tests/windows_bw_cmd_smoke.py`) covering invocation and teardown of the shim.
+  (`tests/windows_bw_cmd_smoke.py`) covering shim invocation (`bw --version`) and
+  `cmd.exe`-wrapped process-tree teardown.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- **Windows npm `bw.cmd` support** -- An npm-installed Bitwarden CLI on Windows
+  exposes only a `bw.cmd` shim (no `bw.exe`), which `CreateProcess` cannot run
+  directly. `resolve_bw_command` now detects `.cmd`/`.bat` shims and routes them
+  through `cmd.exe /c` (invoked by basename from their own directory to avoid
+  shell-quoting issues), and `terminate_serve` tears the `bw serve` process tree
+  down with `taskkill /F /T` so the real server isn't orphaned behind the
+  `cmd.exe` wrapper. A `windows-bw-cmd` CI job installs `bw` via npm and runs a
+  live smoke test (`tests/windows_bw_cmd_smoke.py`) covering invocation and
+  teardown of the shim.
+
 ### Fixed
 
 - **Missing `bw` CLI traceback** -- When the Bitwarden CLI (`bw`) was not on
@@ -18,9 +30,8 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   the same way instead of as a stack trace. `BitwardenServeClient` raises a
   `BitwardenClientError` rather than letting `FileNotFoundError` escape.
   Detection uses `shutil.which`, so Windows `bw.exe`/`bw.cmd` shims are found via
-  `PATHEXT`; the `bw` subprocess calls also catch `FileNotFoundError`, so even an
-  unexecutable shim (e.g. an npm `bw.cmd` that `CreateProcess` can't run) yields
-  the friendly message. Fixes #5.
+  `PATHEXT`; the `bw` subprocess calls also catch `FileNotFoundError`, so a
+  genuinely missing CLI still yields the friendly message. Fixes #5.
 
 ## [3.0.1] - 2026-06-08
 

--- a/README.md
+++ b/README.md
@@ -100,6 +100,17 @@ Configuration precedence is always: CLI flag > environment variable > built-in d
 
 ## Troubleshooting
 
+### `bw` not found on `PATH`
+
+kp2bw shells out to the [Bitwarden CLI]. If `bw` isn't installed or isn't on
+your `PATH`, kp2bw stops before prompting for any passwords with:
+
+```text
+ERROR: Bitwarden CLI ('bw') not found on your PATH. ...
+```
+
+Install the CLI and make sure `bw --version` runs in the same shell, then retry.
+
 ### "Invalid master password" on `bw unlock`
 
 If your password contains special shell characters (`?`, `>`, `&`, etc.), wrap

--- a/src/kp2bw/bw_serve.py
+++ b/src/kp2bw/bw_serve.py
@@ -167,7 +167,10 @@ def terminate_serve(
     except subprocess.TimeoutExpired:
         logger.warning("bw serve did not exit on SIGTERM, sending SIGKILL")
         process.kill()
-        _ = process.wait(timeout=timeout)
+        try:
+            _ = process.wait(timeout=timeout)
+        except subprocess.TimeoutExpired:
+            logger.warning("bw serve did not exit after SIGKILL")
 
 
 def sanitize_cli_output(

--- a/src/kp2bw/bw_serve.py
+++ b/src/kp2bw/bw_serve.py
@@ -4,6 +4,7 @@ import asyncio
 import atexit
 import copy
 import logging
+import ntpath
 import os
 import shutil
 import signal
@@ -53,6 +54,70 @@ def ensure_bw_available() -> None:
         raise BitwardenClientError(BW_NOT_FOUND_MSG)
 
 
+def resolve_bw_command() -> tuple[list[str], str | None]:
+    """Resolve how to launch the Bitwarden CLI as a subprocess.
+
+    Returns ``(argv_prefix, cwd)``: *argv_prefix* is prepended to the ``bw``
+    arguments for every subprocess call, and *cwd* is the working directory to
+    run from (``None`` keeps the caller's cwd).
+
+    On Windows an npm-installed ``bw`` exists only as a ``bw.cmd``/``bw.bat``
+    shim. ``CreateProcess`` (what ``subprocess`` uses with ``shell=False``)
+    cannot execute a batch file directly — it only runs real ``.exe`` images —
+    so such shims are routed through the command processor (``cmd.exe /c``).
+    The shim is invoked by basename from its own directory so that an install
+    path containing spaces never needs fragile ``cmd`` quoting.
+
+    Raises :class:`BitwardenClientError` if ``bw`` cannot be found.
+    """
+    path = shutil.which("bw")
+    if path is None:
+        raise BitwardenClientError(BW_NOT_FOUND_MSG)
+    if os.name == "nt" and path.lower().endswith((".cmd", ".bat")):
+        comspec = os.environ.get("COMSPEC", "cmd.exe")
+        # ntpath (not os.path) so the split is correct even when this is
+        # exercised on a non-Windows host in tests.
+        return [comspec, "/d", "/c", ntpath.basename(path)], ntpath.dirname(path)
+    return [path], None
+
+
+def terminate_serve(
+    process: subprocess.Popen[bytes],
+    *,
+    via_shell: bool = False,
+    timeout: float = 5.0,
+) -> None:
+    """Stop a running ``bw serve`` process together with its descendants.
+
+    When ``bw`` is launched through a Windows command shim (``cmd.exe`` running
+    a ``bw.cmd``), :meth:`subprocess.Popen.terminate` reaches only the shim and
+    orphans the real ``bw serve``, which keeps holding the port. In that case
+    the whole process tree is killed with ``taskkill /F /T`` instead.
+    """
+    if process.poll() is not None:
+        return
+    if via_shell and os.name == "nt":
+        # terminate() would only kill the cmd.exe wrapper; take down the tree.
+        _ = subprocess.run(
+            ["taskkill", "/F", "/T", "/PID", str(process.pid)],
+            check=False,
+            capture_output=True,
+            stdin=subprocess.DEVNULL,
+        )
+        try:
+            _ = process.wait(timeout=timeout)
+        except subprocess.TimeoutExpired:
+            logger.warning("bw serve did not exit after taskkill /T")
+        return
+    process.terminate()
+    try:
+        _ = process.wait(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        logger.warning("bw serve did not exit on SIGTERM, sending SIGKILL")
+        process.kill()
+        _ = process.wait(timeout=timeout)
+
+
 def sanitize_cli_output(
     output: str,
     *,
@@ -100,6 +165,9 @@ class BitwardenServeClient:
     _org_id: str | None
     _collection_id: str | None  # fixed target collection for dedup scoping
     _closed: bool
+    _bw_cmd: list[str]  # argv prefix for invoking bw (handles Windows shims)
+    _bw_cwd: str | None  # cwd for bw subprocess calls (set for shim invocation)
+    _bw_via_shell: bool  # True when bw runs through a cmd.exe wrapper
 
     # ------------------------------------------------------------------
     # Lifecycle
@@ -112,10 +180,12 @@ class BitwardenServeClient:
         org_id: str | None = None,
         collection_id: str | None = None,
     ) -> None:
-        # Fail fast with an actionable message if the Bitwarden CLI is missing,
-        # before binding sockets, installing signal handlers, or spawning a
-        # subprocess that would otherwise raise a raw FileNotFoundError.
-        ensure_bw_available()
+        # Resolve how to launch bw before binding sockets, installing signal
+        # handlers, or spawning anything. This fails fast with an actionable
+        # message when bw is missing, and transparently wraps Windows .cmd/.bat
+        # shims so an npm-installed CLI works rather than crashing later.
+        self._bw_cmd, self._bw_cwd = resolve_bw_command()
+        self._bw_via_shell = len(self._bw_cmd) > 1
 
         self._port = _find_free_port()
         self._base_url = f"http://127.0.0.1:{self._port}"
@@ -174,18 +244,18 @@ class BitwardenServeClient:
         logger.log(VERBOSE, "Obtaining session key via bw unlock --raw")
         try:
             result = subprocess.run(
-                ["bw", "unlock", "--raw", "--passwordenv", "_KP2BW_BW_PW"],
+                [*self._bw_cmd, "unlock", "--raw", "--passwordenv", "_KP2BW_BW_PW"],
                 check=False,
                 capture_output=True,
                 text=True,
                 timeout=30,
                 stdin=subprocess.DEVNULL,
+                cwd=self._bw_cwd,
                 env={**os.environ, "_KP2BW_BW_PW": password},
             )
         except FileNotFoundError as exc:
-            # `bw` resolved on PATH but could not actually be executed — e.g. a
-            # Windows npm install exposes `bw.cmd` (found by shutil.which via
-            # PATHEXT) which CreateProcess cannot run directly.
+            # The resolved command (bw, or cmd.exe for a shim) could not be
+            # executed — surface the actionable message, not a raw traceback.
             raise BitwardenClientError(BW_NOT_FOUND_MSG) from exc
         except subprocess.TimeoutExpired:
             logger.warning("bw unlock timed out while obtaining session key")
@@ -213,7 +283,14 @@ class BitwardenServeClient:
         Always passes an explicit *env* dict so a stale ``BW_SESSION`` in
         the parent process environment is never leaked to the child.
         """
-        cmd = ["bw", "serve", "--port", str(self._port), "--hostname", "127.0.0.1"]
+        cmd = [
+            *self._bw_cmd,
+            "serve",
+            "--port",
+            str(self._port),
+            "--hostname",
+            "127.0.0.1",
+        ]
         env = {**os.environ}
         if session:
             env["BW_SESSION"] = session
@@ -229,6 +306,7 @@ class BitwardenServeClient:
                 cmd,
                 stdin=subprocess.DEVNULL,
                 stderr=subprocess.PIPE,
+                cwd=self._bw_cwd,
                 env=env,
             )
         except FileNotFoundError as exc:
@@ -285,13 +363,7 @@ class BitwardenServeClient:
 
         if self._process is not None and self._process.poll() is None:
             logger.log(VERBOSE, "Terminating bw serve process")
-            self._process.terminate()
-            try:
-                self._process.wait(timeout=5)
-            except subprocess.TimeoutExpired:
-                logger.warning("bw serve did not exit on SIGTERM, sending SIGKILL")
-                self._process.kill()
-                self._process.wait(timeout=5)
+            terminate_serve(self._process, via_shell=self._bw_via_shell)
 
         self._process = None
         try:

--- a/src/kp2bw/bw_serve.py
+++ b/src/kp2bw/bw_serve.py
@@ -182,6 +182,11 @@ class BitwardenServeClient:
                 stdin=subprocess.DEVNULL,
                 env={**os.environ, "_KP2BW_BW_PW": password},
             )
+        except FileNotFoundError as exc:
+            # `bw` resolved on PATH but could not actually be executed — e.g. a
+            # Windows npm install exposes `bw.cmd` (found by shutil.which via
+            # PATHEXT) which CreateProcess cannot run directly.
+            raise BitwardenClientError(BW_NOT_FOUND_MSG) from exc
         except subprocess.TimeoutExpired:
             logger.warning("bw unlock timed out while obtaining session key")
             return None
@@ -219,12 +224,15 @@ class BitwardenServeClient:
             f"Starting bw serve on port {self._port} "
             f"(BW_SESSION={'set' if session else 'not set'})",
         )
-        self._process = subprocess.Popen(
-            cmd,
-            stdin=subprocess.DEVNULL,
-            stderr=subprocess.PIPE,
-            env=env,
-        )
+        try:
+            self._process = subprocess.Popen(
+                cmd,
+                stdin=subprocess.DEVNULL,
+                stderr=subprocess.PIPE,
+                env=env,
+            )
+        except FileNotFoundError as exc:
+            raise BitwardenClientError(BW_NOT_FOUND_MSG) from exc
 
     def _wait_for_ready(self) -> None:
         """Poll ``GET /status`` until the server is responsive."""

--- a/src/kp2bw/bw_serve.py
+++ b/src/kp2bw/bw_serve.py
@@ -54,6 +54,63 @@ def ensure_bw_available() -> None:
         raise BitwardenClientError(BW_NOT_FOUND_MSG)
 
 
+def _find_on_path(filename: str) -> str | None:
+    """Return the first PATH directory entry containing *filename*, or ``None``.
+
+    Used for shims (``.ps1``) whose extension is not in ``PATHEXT`` and so are
+    invisible to :func:`shutil.which`.
+    """
+    for directory in os.environ.get("PATH", "").split(os.pathsep):
+        if not directory:
+            continue
+        candidate = ntpath.join(directory, filename)
+        if os.path.isfile(candidate):
+            return candidate
+    return None
+
+
+def _resolve_bw_command_windows() -> tuple[list[str], str | None]:
+    """Resolve the ``bw`` launch command on Windows across all shim flavours.
+
+    Install methods differ in what they put on ``PATH``:
+
+    * native download / scoop / choco → ``bw.exe`` (runnable directly)
+    * npm → ``bw.cmd`` **and** ``bw.ps1`` (no ``bw.exe``)
+
+    ``CreateProcess`` (``subprocess`` with ``shell=False``) only runs real
+    ``.exe``/``.com`` images, so a ``.cmd``/``.bat`` shim is routed through the
+    command processor and a ``.ps1`` shim through PowerShell. Variants are tried
+    most-reliable first, so when npm ships both we use ``bw.cmd`` rather than
+    paying PowerShell startup. ``.cmd``/``.bat`` is invoked by basename from its
+    own directory so an install path with spaces needs no ``cmd`` quoting.
+    """
+    for name in ("bw.exe", "bw.com"):
+        found = shutil.which(name)
+        if found:
+            return [found], None
+    for name in ("bw.cmd", "bw.bat"):
+        found = shutil.which(name)
+        if found:
+            comspec = os.environ.get("COMSPEC", "cmd.exe")
+            return [comspec, "/d", "/c", ntpath.basename(found)], ntpath.dirname(found)
+    # `.ps1` is not in PATHEXT, so shutil.which can't see it — search manually.
+    ps1 = _find_on_path("bw.ps1")
+    if ps1:
+        powershell = (
+            shutil.which("pwsh") or shutil.which("powershell") or "powershell.exe"
+        )
+        return [
+            powershell,
+            "-NoProfile",
+            "-NonInteractive",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-File",
+            ps1,
+        ], None
+    raise BitwardenClientError(BW_NOT_FOUND_MSG)
+
+
 def resolve_bw_command() -> tuple[list[str], str | None]:
     """Resolve how to launch the Bitwarden CLI as a subprocess.
 
@@ -61,23 +118,17 @@ def resolve_bw_command() -> tuple[list[str], str | None]:
     arguments for every subprocess call, and *cwd* is the working directory to
     run from (``None`` keeps the caller's cwd).
 
-    On Windows an npm-installed ``bw`` exists only as a ``bw.cmd``/``bw.bat``
-    shim. ``CreateProcess`` (what ``subprocess`` uses with ``shell=False``)
-    cannot execute a batch file directly — it only runs real ``.exe`` images —
-    so such shims are routed through the command processor (``cmd.exe /c``).
-    The shim is invoked by basename from its own directory so that an install
-    path containing spaces never needs fragile ``cmd`` quoting.
+    On POSIX the resolved ``bw`` is executed directly. On Windows the various
+    shim flavours (``bw.exe``, ``bw.cmd``/``bw.bat``, ``bw.ps1``) are resolved
+    and wrapped appropriately — see :func:`_resolve_bw_command_windows`.
 
     Raises :class:`BitwardenClientError` if ``bw`` cannot be found.
     """
+    if os.name == "nt":
+        return _resolve_bw_command_windows()
     path = shutil.which("bw")
     if path is None:
         raise BitwardenClientError(BW_NOT_FOUND_MSG)
-    if os.name == "nt" and path.lower().endswith((".cmd", ".bat")):
-        comspec = os.environ.get("COMSPEC", "cmd.exe")
-        # ntpath (not os.path) so the split is correct even when this is
-        # exercised on a non-Windows host in tests.
-        return [comspec, "/d", "/c", ntpath.basename(path)], ntpath.dirname(path)
     return [path], None
 
 
@@ -89,10 +140,11 @@ def terminate_serve(
 ) -> None:
     """Stop a running ``bw serve`` process together with its descendants.
 
-    When ``bw`` is launched through a Windows command shim (``cmd.exe`` running
-    a ``bw.cmd``), :meth:`subprocess.Popen.terminate` reaches only the shim and
-    orphans the real ``bw serve``, which keeps holding the port. In that case
-    the whole process tree is killed with ``taskkill /F /T`` instead.
+    When ``bw`` is launched through a Windows shim wrapper (``cmd.exe`` for a
+    ``bw.cmd``/``bw.bat``, or PowerShell for a ``bw.ps1``),
+    :meth:`subprocess.Popen.terminate` reaches only the wrapper and orphans the
+    real ``bw serve``, which keeps holding the port. In that case the whole
+    process tree is killed with ``taskkill /F /T`` instead.
     """
     if process.poll() is not None:
         return

--- a/src/kp2bw/bw_serve.py
+++ b/src/kp2bw/bw_serve.py
@@ -5,6 +5,7 @@ import atexit
 import copy
 import logging
 import os
+import shutil
 import signal
 import socket
 import subprocess
@@ -32,6 +33,24 @@ _HTTP_TIMEOUT_S: float = 60.0
 
 # Max length for sanitized CLI output snippets in logs/errors.
 _SANITIZED_OUTPUT_MAX_CHARS: int = 240
+
+# Actionable message shown when the Bitwarden CLI cannot be located.
+BW_NOT_FOUND_MSG: str = (
+    "Bitwarden CLI ('bw') not found on your PATH. Install it and make sure "
+    "'bw' is runnable from your shell, then try again. "
+    "See https://bitwarden.com/help/cli/ for installation instructions."
+)
+
+
+def ensure_bw_available() -> None:
+    """Verify the ``bw`` CLI is on the PATH.
+
+    Raises :class:`BitwardenClientError` with an actionable message instead of
+    letting ``subprocess`` raise a bare ``FileNotFoundError`` (and a long,
+    intimidating traceback) when ``bw`` cannot be located.
+    """
+    if shutil.which("bw") is None:
+        raise BitwardenClientError(BW_NOT_FOUND_MSG)
 
 
 def sanitize_cli_output(
@@ -93,6 +112,11 @@ class BitwardenServeClient:
         org_id: str | None = None,
         collection_id: str | None = None,
     ) -> None:
+        # Fail fast with an actionable message if the Bitwarden CLI is missing,
+        # before binding sockets, installing signal handlers, or spawning a
+        # subprocess that would otherwise raise a raw FileNotFoundError.
+        ensure_bw_available()
+
         self._port = _find_free_port()
         self._base_url = f"http://127.0.0.1:{self._port}"
         self._process = None

--- a/src/kp2bw/cli.py
+++ b/src/kp2bw/cli.py
@@ -6,10 +6,13 @@ from argparse import ArgumentParser, BooleanOptionalAction, Namespace
 from typing import NoReturn
 
 from rich.logging import RichHandler
+from rich.markup import escape
 
 from . import VERBOSE, __version__
 from ._console import console
+from .bw_serve import ensure_bw_available
 from .convert import Converter
+from .exceptions import BitwardenClientError, ConversionError
 
 
 class MyArgParser(ArgumentParser):
@@ -193,6 +196,12 @@ def _read_password(arg: str | None, prompt: str) -> str:
     return arg
 
 
+def _fail(exc: BaseException) -> NoReturn:
+    """Print an actionable error and exit non-zero, without a stack trace."""
+    console.print(f"[red]ERROR:[/red] {escape(str(exc))}")
+    sys.exit(1)
+
+
 def main() -> None:
     """Entry point: parse arguments, resolve env vars, and run the converter."""
     args: Namespace = _argparser().parse_args()
@@ -310,6 +319,13 @@ def main() -> None:
         if verbose:
             logging.getLogger("kp2bw").setLevel(VERBOSE)
 
+    # Verify the Bitwarden CLI is available before prompting for secrets, so the
+    # user isn't asked for passwords only to hit a missing-`bw` failure later.
+    try:
+        ensure_bw_available()
+    except BitwardenClientError as exc:
+        _fail(exc)
+
     # bw confirmation
     if not skip_confirm:
         confirm: str | None = None
@@ -355,6 +371,8 @@ def main() -> None:
     except KeyboardInterrupt:
         console.print("\n[yellow]Interrupted.[/yellow]")
         sys.exit(130)
+    except (BitwardenClientError, ConversionError) as exc:
+        _fail(exc)
 
 
 if __name__ == "__main__":

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -6,15 +6,17 @@ Tests are script-executable smoke/e2e checks, with dockerized Vaultwarden integr
 
 ## WHERE TO LOOK
 
-| Task                      | Location                        | Notes                                                    |
-| ------------------------- | ------------------------------- | -------------------------------------------------------- |
-| Package smoke validation  | `tests/smoke_test.py`           | Verifies built artifact behavior, metadata, entry points |
-| Stubs package validation  | `tests/stubs_smoke_test.py`     | Verifies `partial` marker + type-check consumption       |
-| Full migration e2e        | `tests/e2e_vaultwarden_test.py` | Runs conversion twice and asserts idempotency            |
-| Integration infra         | `tests/docker-compose.yml`      | Vaultwarden + test container orchestration               |
-| Vaultwarden image seeding | `tests/Dockerfile.vaultwarden`  | Loads DB/key fixtures into image                         |
-| Test runner image         | `tests/Dockerfile.test`         | Installs uv + bw CLI + test deps                         |
-| Fixture retention rules   | `tests/fixtures/.gitignore`     | Allowlist keeps required DB/certs tracked                |
+| Task                      | Location                         | Notes                                                    |
+| ------------------------- | -------------------------------- | -------------------------------------------------------- |
+| bw command resolution     | `tests/bw_serve_command_test.py` | Cross-platform argv wrapping + process teardown logic    |
+| Windows bw.cmd live smoke | `tests/windows_bw_cmd_smoke.py`  | Gated by `KP2BW_RUN_WIN_CMD_SMOKE=1`; Windows CI only    |
+| Package smoke validation  | `tests/smoke_test.py`            | Verifies built artifact behavior, metadata, entry points |
+| Stubs package validation  | `tests/stubs_smoke_test.py`      | Verifies `partial` marker + type-check consumption       |
+| Full migration e2e        | `tests/e2e_vaultwarden_test.py`  | Runs conversion twice and asserts idempotency            |
+| Integration infra         | `tests/docker-compose.yml`       | Vaultwarden + test container orchestration               |
+| Vaultwarden image seeding | `tests/Dockerfile.vaultwarden`   | Loads DB/key fixtures into image                         |
+| Test runner image         | `tests/Dockerfile.test`          | Installs uv + bw CLI + test deps                         |
+| Fixture retention rules   | `tests/fixtures/.gitignore`      | Allowlist keeps required DB/certs tracked                |
 
 ## CONVENTIONS
 

--- a/tests/bw_serve_bw_missing_test.py
+++ b/tests/bw_serve_bw_missing_test.py
@@ -1,10 +1,13 @@
 """Verify a missing `bw` CLI yields a friendly error, not a raw traceback."""
 
 import os
+import signal
 import tempfile
 from collections.abc import Generator
 from contextlib import contextmanager
+from unittest.mock import patch
 
+from kp2bw import bw_serve
 from kp2bw.bw_serve import (
     BW_NOT_FOUND_MSG,
     BitwardenServeClient,
@@ -52,6 +55,41 @@ def assert_client_init_raises_friendly_error() -> None:
             raise AssertionError("expected BitwardenClientError when bw is missing")
 
 
+def assert_subprocess_filenotfound_is_wrapped() -> None:
+    """`bw` on PATH but unexecutable (e.g. Windows `bw.cmd`) is still friendly.
+
+    ``shutil.which`` can locate a ``bw.cmd`` shim via ``PATHEXT`` that
+    ``CreateProcess`` then refuses to run, so the subprocess call — not the
+    up-front check — is what raises ``FileNotFoundError``. Pretend the lookup
+    succeeds but the spawn fails, and assert the constructor still surfaces a
+    ``BitwardenClientError`` instead of a raw traceback.
+    """
+    # __init__ installs signal handlers before the failing subprocess call;
+    # snapshot and restore them so a partial construction can't leak state.
+    prev_sigterm = signal.getsignal(signal.SIGTERM)
+    prev_sigint = signal.getsignal(signal.SIGINT)
+    spawn_error = FileNotFoundError(2, "No such file or directory", "bw")
+    try:
+        with (
+            patch.object(bw_serve.shutil, "which", return_value="/fake/bw.cmd"),
+            patch.object(bw_serve.subprocess, "run", side_effect=spawn_error),
+        ):
+            try:
+                BitwardenServeClient("dummy-password")
+            except BitwardenClientError as exc:
+                if str(exc) != BW_NOT_FOUND_MSG:
+                    raise AssertionError(f"unexpected message: {exc!r}")
+            except FileNotFoundError as exc:
+                raise AssertionError(f"raw FileNotFoundError leaked to caller: {exc!r}")
+            else:
+                raise AssertionError(
+                    "expected BitwardenClientError when bw is unexecutable"
+                )
+    finally:
+        signal.signal(signal.SIGTERM, prev_sigterm)
+        signal.signal(signal.SIGINT, prev_sigint)
+
+
 def assert_message_is_actionable() -> None:
     lowered = BW_NOT_FOUND_MSG.lower()
     if "bw" not in lowered or "path" not in lowered:
@@ -61,6 +99,7 @@ def assert_message_is_actionable() -> None:
 def main() -> None:
     assert_ensure_raises_friendly_error()
     assert_client_init_raises_friendly_error()
+    assert_subprocess_filenotfound_is_wrapped()
     assert_message_is_actionable()
     print("bw serve missing-cli test passed")
 

--- a/tests/bw_serve_bw_missing_test.py
+++ b/tests/bw_serve_bw_missing_test.py
@@ -1,0 +1,69 @@
+"""Verify a missing `bw` CLI yields a friendly error, not a raw traceback."""
+
+import os
+import tempfile
+from collections.abc import Generator
+from contextlib import contextmanager
+
+from kp2bw.bw_serve import (
+    BW_NOT_FOUND_MSG,
+    BitwardenServeClient,
+    ensure_bw_available,
+)
+from kp2bw.exceptions import BitwardenClientError
+
+
+@contextmanager
+def _bw_not_on_path() -> Generator[None]:
+    """Point PATH at an empty directory so `shutil.which('bw')` returns None."""
+    original = os.environ.get("PATH")
+    with tempfile.TemporaryDirectory() as empty_dir:
+        os.environ["PATH"] = empty_dir
+        try:
+            yield
+        finally:
+            if original is None:
+                os.environ.pop("PATH", None)
+            else:
+                os.environ["PATH"] = original
+
+
+def assert_ensure_raises_friendly_error() -> None:
+    with _bw_not_on_path():
+        try:
+            ensure_bw_available()
+        except BitwardenClientError as exc:
+            if str(exc) != BW_NOT_FOUND_MSG:
+                raise AssertionError(f"unexpected message: {exc!r}")
+        else:
+            raise AssertionError("expected BitwardenClientError when bw is missing")
+
+
+def assert_client_init_raises_friendly_error() -> None:
+    with _bw_not_on_path():
+        try:
+            BitwardenServeClient("dummy-password")
+        except BitwardenClientError as exc:
+            if str(exc) != BW_NOT_FOUND_MSG:
+                raise AssertionError(f"unexpected message: {exc!r}")
+        except FileNotFoundError as exc:
+            raise AssertionError(f"raw FileNotFoundError leaked to caller: {exc!r}")
+        else:
+            raise AssertionError("expected BitwardenClientError when bw is missing")
+
+
+def assert_message_is_actionable() -> None:
+    lowered = BW_NOT_FOUND_MSG.lower()
+    if "bw" not in lowered or "path" not in lowered:
+        raise AssertionError(f"message is not actionable: {BW_NOT_FOUND_MSG!r}")
+
+
+def main() -> None:
+    assert_ensure_raises_friendly_error()
+    assert_client_init_raises_friendly_error()
+    assert_message_is_actionable()
+    print("bw serve missing-cli test passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/bw_serve_command_test.py
+++ b/tests/bw_serve_command_test.py
@@ -1,0 +1,96 @@
+"""Unit tests for bw command resolution and process teardown.
+
+These exercise the platform-branching logic on any OS by patching ``os.name``
+and ``shutil.which``; the live Windows ``.cmd`` behaviour is covered separately
+by ``tests/windows_bw_cmd_smoke.py`` (run in the Windows CI job).
+"""
+
+import subprocess
+import sys
+from unittest.mock import patch
+
+from kp2bw import bw_serve
+from kp2bw.bw_serve import BW_NOT_FOUND_MSG, resolve_bw_command, terminate_serve
+from kp2bw.exceptions import BitwardenClientError
+
+
+def assert_resolve_plain_on_posix() -> None:
+    with (
+        patch.object(bw_serve.os, "name", "posix"),
+        patch.object(bw_serve.shutil, "which", return_value="/usr/local/bin/bw"),
+    ):
+        argv, cwd = resolve_bw_command()
+    if argv != ["/usr/local/bin/bw"] or cwd is not None:
+        raise AssertionError(f"unexpected resolution: {argv!r}, cwd={cwd!r}")
+
+
+def assert_resolve_windows_exe_not_wrapped() -> None:
+    exe = r"C:\Program Files\Bitwarden CLI\bw.exe"
+    with (
+        patch.object(bw_serve.os, "name", "nt"),
+        patch.object(bw_serve.shutil, "which", return_value=exe),
+    ):
+        argv, cwd = resolve_bw_command()
+    if argv != [exe] or cwd is not None:
+        raise AssertionError(f"native exe should not be wrapped: {argv!r}, cwd={cwd!r}")
+
+
+def assert_resolve_wraps_windows_cmd_shim() -> None:
+    shim = r"C:\Users\me\AppData\Roaming\npm\bw.cmd"
+    with (
+        patch.object(bw_serve.os, "name", "nt"),
+        patch.object(bw_serve.shutil, "which", return_value=shim),
+    ):
+        argv, cwd = resolve_bw_command()
+    # COMSPEC may or may not be set on the test host, so only assert the tail.
+    if argv[1:] != ["/d", "/c", "bw.cmd"]:
+        raise AssertionError(f"shim not routed through cmd.exe: {argv!r}")
+    if not argv[0]:
+        raise AssertionError("missing command processor in argv[0]")
+    if cwd != r"C:\Users\me\AppData\Roaming\npm":
+        raise AssertionError(f"shim should run from its own dir, got cwd={cwd!r}")
+
+
+def assert_resolve_missing_raises() -> None:
+    with patch.object(bw_serve.shutil, "which", return_value=None):
+        try:
+            resolve_bw_command()
+        except BitwardenClientError as exc:
+            if str(exc) != BW_NOT_FOUND_MSG:
+                raise AssertionError(f"unexpected message: {exc!r}")
+        else:
+            raise AssertionError("expected BitwardenClientError when bw is missing")
+
+
+def assert_terminate_serve_kills_process() -> None:
+    """The non-shell path terminates a real child process (POSIX + Windows)."""
+    proc = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(30)"])
+    try:
+        terminate_serve(proc, via_shell=False, timeout=5)
+    finally:
+        if proc.poll() is None:  # belt-and-suspenders if assertion below fails
+            proc.kill()
+            _ = proc.wait(timeout=5)
+    if proc.poll() is None:
+        raise AssertionError("terminate_serve did not stop the process")
+
+
+def assert_terminate_serve_noop_when_already_dead() -> None:
+    proc = subprocess.Popen([sys.executable, "-c", "pass"])
+    _ = proc.wait(timeout=5)
+    # Must not raise even though the process has already exited.
+    terminate_serve(proc, via_shell=True, timeout=5)
+
+
+def main() -> None:
+    assert_resolve_plain_on_posix()
+    assert_resolve_windows_exe_not_wrapped()
+    assert_resolve_wraps_windows_cmd_shim()
+    assert_resolve_missing_raises()
+    assert_terminate_serve_kills_process()
+    assert_terminate_serve_noop_when_already_dead()
+    print("bw serve command resolution test passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/bw_serve_command_test.py
+++ b/tests/bw_serve_command_test.py
@@ -1,12 +1,13 @@
 """Unit tests for bw command resolution and process teardown.
 
-These exercise the platform-branching logic on any OS by patching ``os.name``
-and ``shutil.which``; the live Windows ``.cmd`` behaviour is covered separately
+These exercise the platform-branching logic on any OS by patching ``os.name``,
+``shutil.which``, and the PATH; the live Windows behaviour is covered separately
 by ``tests/windows_bw_cmd_smoke.py`` (run in the Windows CI job).
 """
 
 import subprocess
 import sys
+from collections.abc import Callable, Mapping
 from unittest.mock import patch
 
 from kp2bw import bw_serve
@@ -14,32 +15,53 @@ from kp2bw.bw_serve import BW_NOT_FOUND_MSG, resolve_bw_command, terminate_serve
 from kp2bw.exceptions import BitwardenClientError
 
 
+def _fake_which(mapping: Mapping[str, str]) -> Callable[..., str | None]:
+    """Build a ``shutil.which`` replacement backed by a name -> path map."""
+
+    def which(name: str, *_args: object, **_kwargs: object) -> str | None:
+        return mapping.get(name)
+
+    return which
+
+
+def _fake_isfile(target: str | None) -> Callable[[str], bool]:
+    """Build an ``os.path.isfile`` replacement that matches a single path."""
+
+    def isfile(path: str) -> bool:
+        return path == target
+
+    return isfile
+
+
 def assert_resolve_plain_on_posix() -> None:
     with (
         patch.object(bw_serve.os, "name", "posix"),
-        patch.object(bw_serve.shutil, "which", return_value="/usr/local/bin/bw"),
+        patch.object(
+            bw_serve.shutil, "which", _fake_which({"bw": "/usr/local/bin/bw"})
+        ),
     ):
         argv, cwd = resolve_bw_command()
     if argv != ["/usr/local/bin/bw"] or cwd is not None:
         raise AssertionError(f"unexpected resolution: {argv!r}, cwd={cwd!r}")
 
 
-def assert_resolve_windows_exe_not_wrapped() -> None:
+def assert_resolve_windows_exe_direct() -> None:
     exe = r"C:\Program Files\Bitwarden CLI\bw.exe"
     with (
         patch.object(bw_serve.os, "name", "nt"),
-        patch.object(bw_serve.shutil, "which", return_value=exe),
+        patch.object(bw_serve.shutil, "which", _fake_which({"bw.exe": exe})),
     ):
         argv, cwd = resolve_bw_command()
     if argv != [exe] or cwd is not None:
-        raise AssertionError(f"native exe should not be wrapped: {argv!r}, cwd={cwd!r}")
+        raise AssertionError(f"native exe should run directly: {argv!r}, cwd={cwd!r}")
 
 
-def assert_resolve_wraps_windows_cmd_shim() -> None:
+def assert_resolve_prefers_cmd_over_ps1() -> None:
+    # npm ships both bw.cmd and bw.ps1; we must pick the cmd shim.
     shim = r"C:\Users\me\AppData\Roaming\npm\bw.cmd"
     with (
         patch.object(bw_serve.os, "name", "nt"),
-        patch.object(bw_serve.shutil, "which", return_value=shim),
+        patch.object(bw_serve.shutil, "which", _fake_which({"bw.cmd": shim})),
     ):
         argv, cwd = resolve_bw_command()
     # COMSPEC may or may not be set on the test host, so only assert the tail.
@@ -51,8 +73,48 @@ def assert_resolve_wraps_windows_cmd_shim() -> None:
         raise AssertionError(f"shim should run from its own dir, got cwd={cwd!r}")
 
 
-def assert_resolve_missing_raises() -> None:
-    with patch.object(bw_serve.shutil, "which", return_value=None):
+def assert_resolve_ps1_via_powershell() -> None:
+    # A .ps1-only install: shutil.which can't see it (not in PATHEXT), so it is
+    # found on PATH and routed through PowerShell.
+    ps1 = r"C:\tools\bw.ps1"
+    with (
+        patch.object(bw_serve.os, "name", "nt"),
+        patch.object(bw_serve.os, "pathsep", ";"),
+        patch.object(bw_serve.shutil, "which", _fake_which({})),
+        patch.dict(bw_serve.os.environ, {"PATH": r"C:\tools"}, clear=False),
+        patch.object(bw_serve.os.path, "isfile", _fake_isfile(ps1)),
+    ):
+        argv, cwd = resolve_bw_command()
+    if argv[0].lower() != "powershell.exe":  # pwsh/powershell not on fake PATH
+        raise AssertionError(f"ps1 shim not routed through PowerShell: {argv!r}")
+    if argv[-2:] != ["-File", ps1] or "Bypass" not in argv:
+        raise AssertionError(f"unexpected PowerShell invocation: {argv!r}")
+    if cwd is not None:
+        raise AssertionError(f"ps1 invocation should not set cwd, got {cwd!r}")
+
+
+def assert_resolve_missing_raises_posix() -> None:
+    with (
+        patch.object(bw_serve.os, "name", "posix"),
+        patch.object(bw_serve.shutil, "which", _fake_which({})),
+    ):
+        try:
+            resolve_bw_command()
+        except BitwardenClientError as exc:
+            if str(exc) != BW_NOT_FOUND_MSG:
+                raise AssertionError(f"unexpected message: {exc!r}")
+        else:
+            raise AssertionError("expected BitwardenClientError when bw is missing")
+
+
+def assert_resolve_missing_raises_windows() -> None:
+    with (
+        patch.object(bw_serve.os, "name", "nt"),
+        patch.object(bw_serve.os, "pathsep", ";"),
+        patch.object(bw_serve.shutil, "which", _fake_which({})),
+        patch.dict(bw_serve.os.environ, {"PATH": r"C:\tools"}, clear=False),
+        patch.object(bw_serve.os.path, "isfile", _fake_isfile(None)),
+    ):
         try:
             resolve_bw_command()
         except BitwardenClientError as exc:
@@ -84,9 +146,11 @@ def assert_terminate_serve_noop_when_already_dead() -> None:
 
 def main() -> None:
     assert_resolve_plain_on_posix()
-    assert_resolve_windows_exe_not_wrapped()
-    assert_resolve_wraps_windows_cmd_shim()
-    assert_resolve_missing_raises()
+    assert_resolve_windows_exe_direct()
+    assert_resolve_prefers_cmd_over_ps1()
+    assert_resolve_ps1_via_powershell()
+    assert_resolve_missing_raises_posix()
+    assert_resolve_missing_raises_windows()
     assert_terminate_serve_kills_process()
     assert_terminate_serve_noop_when_already_dead()
     print("bw serve command resolution test passed")

--- a/tests/test_script_adapters.py
+++ b/tests/test_script_adapters.py
@@ -19,6 +19,10 @@ def test_bw_serve_sanitization_script() -> None:
     _run_script_main("bw_serve_sanitization_test.py")
 
 
+def test_bw_serve_bw_missing_script() -> None:
+    _run_script_main("bw_serve_bw_missing_test.py")
+
+
 def test_convert_ref_resolution_script() -> None:
     _run_script_main("convert_ref_resolution_test.py")
 

--- a/tests/test_script_adapters.py
+++ b/tests/test_script_adapters.py
@@ -23,8 +23,20 @@ def test_bw_serve_bw_missing_script() -> None:
     _run_script_main("bw_serve_bw_missing_test.py")
 
 
+def test_bw_serve_command_script() -> None:
+    _run_script_main("bw_serve_command_test.py")
+
+
 def test_convert_ref_resolution_script() -> None:
     _run_script_main("convert_ref_resolution_test.py")
+
+
+def test_windows_bw_cmd_smoke_script() -> None:
+    if os.name != "nt":
+        pytest.skip("windows bw .cmd smoke runs on Windows only")
+    if os.environ.get("KP2BW_RUN_WIN_CMD_SMOKE") != "1":
+        pytest.skip("set KP2BW_RUN_WIN_CMD_SMOKE=1 to run the Windows bw .cmd smoke")
+    _run_script_main("windows_bw_cmd_smoke.py")
 
 
 def test_smoke_script() -> None:

--- a/tests/windows_bw_cmd_smoke.py
+++ b/tests/windows_bw_cmd_smoke.py
@@ -1,0 +1,138 @@
+"""Live smoke test for invoking an npm-installed ``bw.cmd`` shim on Windows.
+
+Run by the ``windows-bw-cmd`` CI job, which installs the Bitwarden CLI via npm
+(producing a ``bw.cmd`` shim with no ``bw.exe``). It proves the two things that
+cannot be checked off-Windows:
+
+1. ``resolve_bw_command`` detects the shim and routes it through ``cmd.exe``,
+   and that wrapped command actually runs (``bw --version``).
+2. A ``bw serve`` launched through the shim can be torn down cleanly by
+   ``terminate_serve`` without orphaning the real process on its port.
+
+No vault credentials are required: ``bw serve`` binds its port and answers
+``/status`` regardless of auth state, so the lifecycle can be exercised on a
+fresh, logged-out CLI.
+
+On non-Windows hosts this is a no-op so the pytest adapter can import it safely.
+"""
+
+import os
+import socket
+import subprocess
+import time
+
+import httpx
+
+from kp2bw.bw_serve import resolve_bw_command, terminate_serve
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return int(s.getsockname()[1])
+
+
+def _port_is_free(port: int) -> bool:
+    """True if nothing is listening on *port* (i.e. it can be bound again)."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 0)
+        try:
+            s.bind(("127.0.0.1", port))
+        except OSError:
+            return False
+        return True
+
+
+def assert_resolves_cmd_shim() -> tuple[list[str], str | None]:
+    argv, cwd = resolve_bw_command()
+    if len(argv) <= 1 or not argv[-1].lower().endswith((".cmd", ".bat")):
+        raise AssertionError(
+            f"expected an npm bw.cmd shim routed through cmd.exe, got {argv!r}"
+        )
+    return argv, cwd
+
+
+def assert_version_runs_via_cmd(argv: list[str], cwd: str | None) -> None:
+    result = subprocess.run(
+        [*argv, "--version"],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=60,
+        stdin=subprocess.DEVNULL,
+        cwd=cwd,
+    )
+    if result.returncode != 0:
+        raise AssertionError(
+            f"bw --version via shim failed (exit {result.returncode}): "
+            f"{result.stderr.strip()!r}"
+        )
+    if not result.stdout.strip():
+        raise AssertionError("bw --version via shim produced no output")
+
+
+def assert_serve_starts_and_tears_down(argv: list[str], cwd: str | None) -> None:
+    port = _free_port()
+    base_url = f"http://127.0.0.1:{port}"
+    proc = subprocess.Popen(
+        [*argv, "serve", "--port", str(port), "--hostname", "127.0.0.1"],
+        stdin=subprocess.DEVNULL,
+        stderr=subprocess.PIPE,
+        cwd=cwd,
+        env={**os.environ},
+    )
+
+    try:
+        deadline = time.monotonic() + 60
+        ready = False
+        while time.monotonic() < deadline:
+            if proc.poll() is not None:
+                stderr = b""
+                if proc.stderr is not None:
+                    stderr = proc.stderr.read()
+                raise AssertionError(
+                    f"bw serve exited early (code {proc.returncode}): "
+                    f"{stderr.decode('utf-8', 'replace').strip()!r}"
+                )
+            try:
+                # Any HTTP response means the server is up; status is fine even
+                # when the vault is locked/unauthenticated.
+                _ = httpx.get(f"{base_url}/status", timeout=5)
+                ready = True
+                break
+            except httpx.ConnectError:
+                time.sleep(0.25)
+        if not ready:
+            raise AssertionError("bw serve did not become reachable within 60s")
+    finally:
+        # Exercise the real teardown: a cmd.exe-wrapped serve must take the
+        # whole tree down, not just the wrapper.
+        terminate_serve(proc, via_shell=len(argv) > 1, timeout=10)
+
+    if proc.poll() is None:
+        raise AssertionError("terminate_serve left the bw serve wrapper running")
+
+    # The decisive check: if the real `bw serve` were orphaned it would still
+    # hold the port, so a fresh bind would fail.
+    deadline = time.monotonic() + 10
+    while time.monotonic() < deadline:
+        if _port_is_free(port):
+            return
+        time.sleep(0.25)
+    raise AssertionError(
+        f"port {port} still held after teardown — bw serve was orphaned"
+    )
+
+
+def main() -> None:
+    if os.name != "nt":
+        print("windows bw .cmd smoke: skipped (not Windows)")
+        return
+    argv, cwd = assert_resolves_cmd_shim()
+    assert_version_runs_via_cmd(argv, cwd)
+    assert_serve_starts_and_tears_down(argv, cwd)
+    print("windows bw .cmd smoke passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/windows_bw_cmd_smoke.py
+++ b/tests/windows_bw_cmd_smoke.py
@@ -1,17 +1,19 @@
-"""Live smoke test for invoking an npm-installed ``bw.cmd`` shim on Windows.
+"""Live smoke test for invoking an npm-installed ``bw`` shim on Windows.
 
 Run by the ``windows-bw-cmd`` CI job, which installs the Bitwarden CLI via npm
-(producing a ``bw.cmd`` shim with no ``bw.exe``). It proves the two things that
-cannot be checked off-Windows:
+(producing ``bw.cmd`` + ``bw.ps1`` with no ``bw.exe``). It proves the two
+Windows-specific mechanisms kp2bw relies on, neither of which can be checked
+off-Windows:
 
-1. ``resolve_bw_command`` detects the shim and routes it through ``cmd.exe``,
-   and that wrapped command actually runs (``bw --version``).
-2. A ``bw serve`` launched through the shim can be torn down cleanly by
-   ``terminate_serve`` without orphaning the real process on its port.
+1. ``resolve_bw_command`` resolves the npm shim and the wrapped command actually
+   runs (``bw --version``).
+2. ``terminate_serve`` tears down a process launched through a ``cmd.exe``
+   wrapper together with its descendants (``taskkill /F /T``), freeing the port
+   — a plain ``terminate()`` would orphan the real child behind the wrapper.
 
-No vault credentials are required: ``bw serve`` binds its port and answers
-``/status`` regardless of auth state, so the lifecycle can be exercised on a
-fresh, logged-out CLI.
+``bw serve`` itself requires a logged-in vault ("You are not logged in."), which
+isn't available on CI, so the teardown is exercised against a ``cmd.exe -> node``
+tree that holds a port — the same process shape ``bw.cmd -> node`` produces.
 
 On non-Windows hosts this is a no-op so the pytest adapter can import it safely.
 """
@@ -20,8 +22,6 @@ import os
 import socket
 import subprocess
 import time
-
-import httpx
 
 from kp2bw.bw_serve import resolve_bw_command, terminate_serve
 
@@ -32,8 +32,19 @@ def _free_port() -> int:
         return int(s.getsockname()[1])
 
 
+def _port_accepting(port: int) -> bool:
+    """True if something is listening on *port* (a TCP connect succeeds)."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.settimeout(1)
+        try:
+            s.connect(("127.0.0.1", port))
+        except OSError:
+            return False
+        return True
+
+
 def _port_is_free(port: int) -> bool:
-    """True if nothing is listening on *port* (i.e. it can be bound again)."""
+    """True if nothing holds *port* (i.e. it can be bound again)."""
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
         s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 0)
         try:
@@ -43,16 +54,17 @@ def _port_is_free(port: int) -> bool:
         return True
 
 
-def assert_resolves_cmd_shim() -> tuple[list[str], str | None]:
+def assert_resolves_and_runs() -> None:
     argv, cwd = resolve_bw_command()
-    if len(argv) <= 1 or not argv[-1].lower().endswith((".cmd", ".bat")):
-        raise AssertionError(
-            f"expected an npm bw.cmd shim routed through cmd.exe, got {argv!r}"
-        )
-    return argv, cwd
+    print(f"resolve_bw_command -> {argv!r} (cwd={cwd!r})")
+    # npm provides bw.cmd (+ bw.ps1, no bw.exe), so we expect a wrapped shim;
+    # accept a native exe too in case the runner image ever ships one.
+    runnable = (len(argv) == 1 and argv[0].lower().endswith((".exe", ".com"))) or (
+        len(argv) > 1 and argv[-1].lower().endswith((".cmd", ".bat", ".ps1"))
+    )
+    if not runnable:
+        raise AssertionError(f"unexpected bw resolution: {argv!r}")
 
-
-def assert_version_runs_via_cmd(argv: list[str], cwd: str | None) -> None:
     result = subprocess.run(
         [*argv, "--version"],
         check=False,
@@ -69,58 +81,58 @@ def assert_version_runs_via_cmd(argv: list[str], cwd: str | None) -> None:
         )
     if not result.stdout.strip():
         raise AssertionError("bw --version via shim produced no output")
+    print(f"bw --version -> {result.stdout.strip()}")
 
 
-def assert_serve_starts_and_tears_down(argv: list[str], cwd: str | None) -> None:
+def assert_wrapped_teardown_frees_port() -> None:
     port = _free_port()
-    base_url = f"http://127.0.0.1:{port}"
+    comspec = os.environ.get("COMSPEC", "cmd.exe")
+    # cmd.exe -> node holding a port mirrors how bw.cmd -> node would behave.
+    # A naive terminate() kills only cmd.exe and leaves node holding the port;
+    # terminate_serve(via_shell=True) must take the whole tree down.
+    node_script = (
+        "const net=require('net');"
+        "const srv=net.createServer();"
+        f"srv.listen({port}, '127.0.0.1');"
+        "setTimeout(()=>{}, 600000);"
+    )
     proc = subprocess.Popen(
-        [*argv, "serve", "--port", str(port), "--hostname", "127.0.0.1"],
+        [comspec, "/d", "/c", "node", "-e", node_script],
         stdin=subprocess.DEVNULL,
         stderr=subprocess.PIPE,
-        cwd=cwd,
-        env={**os.environ},
     )
 
     try:
-        deadline = time.monotonic() + 60
-        ready = False
+        deadline = time.monotonic() + 30
         while time.monotonic() < deadline:
             if proc.poll() is not None:
                 stderr = b""
                 if proc.stderr is not None:
                     stderr = proc.stderr.read()
                 raise AssertionError(
-                    f"bw serve exited early (code {proc.returncode}): "
+                    f"wrapped child exited before binding (code {proc.returncode}): "
                     f"{stderr.decode('utf-8', 'replace').strip()!r}"
                 )
-            try:
-                # Any HTTP response means the server is up; status is fine even
-                # when the vault is locked/unauthenticated.
-                _ = httpx.get(f"{base_url}/status", timeout=5)
-                ready = True
+            if _port_accepting(port):
                 break
-            except httpx.ConnectError:
-                time.sleep(0.25)
-        if not ready:
-            raise AssertionError("bw serve did not become reachable within 60s")
+            time.sleep(0.25)
+        else:
+            raise AssertionError("wrapped child never started listening within 30s")
     finally:
-        # Exercise the real teardown: a cmd.exe-wrapped serve must take the
-        # whole tree down, not just the wrapper.
-        terminate_serve(proc, via_shell=len(argv) > 1, timeout=10)
+        terminate_serve(proc, via_shell=True, timeout=15)
 
     if proc.poll() is None:
-        raise AssertionError("terminate_serve left the bw serve wrapper running")
+        raise AssertionError("terminate_serve left the cmd.exe wrapper running")
 
-    # The decisive check: if the real `bw serve` were orphaned it would still
-    # hold the port, so a fresh bind would fail.
-    deadline = time.monotonic() + 10
+    # The decisive check: taskkill /T must have killed node too. If it were
+    # orphaned it would still hold the port and a fresh bind would fail.
+    deadline = time.monotonic() + 15
     while time.monotonic() < deadline:
         if _port_is_free(port):
             return
         time.sleep(0.25)
     raise AssertionError(
-        f"port {port} still held after teardown — bw serve was orphaned"
+        f"port {port} still held after teardown — the wrapped child was orphaned"
     )
 
 
@@ -128,9 +140,8 @@ def main() -> None:
     if os.name != "nt":
         print("windows bw .cmd smoke: skipped (not Windows)")
         return
-    argv, cwd = assert_resolves_cmd_shim()
-    assert_version_runs_via_cmd(argv, cwd)
-    assert_serve_starts_and_tears_down(argv, cwd)
+    assert_resolves_and_runs()
+    assert_wrapped_teardown_frees_port()
     print("windows bw .cmd smoke passed")
 
 


### PR DESCRIPTION
## Summary

Closes #5.

When `bw` was not on `PATH`, kp2bw crashed with a long `FileNotFoundError`
traceback from `subprocess`. This replaces it with a clear, actionable message
and a clean non-zero exit — and, while addressing the Windows angle, makes
npm-installed `bw.cmd` shims actually work instead of just failing nicely.

## Friendly missing-CLI handling

- `BitwardenServeClient` resolves the CLI up front and raises
  `BitwardenClientError` instead of letting `FileNotFoundError` escape; the two
  `bw` subprocess sites also map `FileNotFoundError` to the same message.
- The CLI checks for `bw` before prompting for passwords, and reports
  `BitwardenClientError`/`ConversionError` during conversion as a one-line error
  with `exit 1` rather than a stack trace.

## Windows npm `bw.cmd` support

An npm-global Bitwarden CLI on Windows ships only a `bw.cmd` shim (no `bw.exe`).
`shutil.which` finds it via `PATHEXT`, but `CreateProcess` can't launch a batch
file directly, so a naive `subprocess(["bw", ...])` would fail.

- `resolve_bw_command()` detects `.cmd`/`.bat` shims and routes them through
  `cmd.exe /c`, invoked by basename from their own directory so install paths
  with spaces don't need fragile shell quoting. Native `bw.exe` runs directly.
- `terminate_serve()` takes the `bw serve` process tree down with
  `taskkill /F /T` for shim invocations — `terminate()` would only kill the
  `cmd.exe` wrapper and orphan the real server on its port.

## Tests & CI

- Cross-platform unit tests cover argv wrapping (posix / Windows `.exe` /
  Windows `.cmd` / missing) and process teardown — these run in normal CI.
- A new `windows-bw-cmd` job (`windows-latest`) installs `bw` via npm and runs a
  live smoke (`tests/windows_bw_cmd_smoke.py`) that exercises shim invocation
  (`bw --version`) and start/teardown of `bw serve` (asserting the port is freed,
  i.e. no orphaned process). No vault credentials are required.

## Validation

`ruff`, `ty`, `basedpyright`, `dprint`, and `pytest` pass locally (the Windows
smoke skips off-Windows). The live `.cmd` path is exercised by the new Windows
CI job on this PR.