### PR TITLE
fix: support npm bw.cmd/.ps1 shims on Windows (#8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **`FileNotFoundError: [WinError 2]` with an npm-installed `bw` on Windows**
+  (#8) -- an npm-global Bitwarden CLI ships only a `bw.cmd` shim (plus `bw.ps1`),
+  with no `bw.exe`. `subprocess` with `shell=False` uses `CreateProcess`, which
+  resolves bare names only to real `.exe`/`.com` images and ignores `PATHEXT`,
+  so `bw login` worked in PowerShell but `kp2bw`'s `bw unlock`/`bw serve` calls
+  crashed with `FileNotFoundError: [WinError 2]`. A new `resolve_bw_command`
+  resolves every shim flavour (`PATHEXT`-aware via `shutil.which`): native
+  `bw.exe`/`bw.com` run directly, `bw.cmd`/`bw.bat` are routed through
+  `cmd.exe /d /c` (invoked by basename from their own directory so install paths
+  with spaces need no quoting), and a `bw.ps1` is run through PowerShell. When a
+  shim is wrapped, `terminate_serve` tears the `bw serve` process tree down with
+  `taskkill /F /T` so the real server isn't orphaned behind the wrapper. A
+  genuinely missing CLI now raises a `BitwardenClientError` with an actionable
+  message instead of a raw `subprocess` traceback.
+
 ## [3.1.0] - 2026-06-08
 
 ### Added

--- a/src/kp2bw/bw_serve.py
+++ b/src/kp2bw/bw_serve.py
@@ -4,7 +4,9 @@ import asyncio
 import atexit
 import copy
 import logging
+import ntpath
 import os
+import shutil
 import signal
 import socket
 import subprocess
@@ -32,6 +34,131 @@ _HTTP_TIMEOUT_S: float = 60.0
 
 # Max length for sanitized CLI output snippets in logs/errors.
 _SANITIZED_OUTPUT_MAX_CHARS: int = 240
+
+# Actionable message shown when the Bitwarden CLI cannot be located.
+BW_NOT_FOUND_MSG: str = (
+    "Bitwarden CLI ('bw') not found on your PATH. Install it and make sure "
+    "'bw' is runnable from your shell, then try again. "
+    "See https://bitwarden.com/help/cli/ for installation instructions."
+)
+
+
+def _find_on_path(filename: str) -> str | None:
+    """Return the first PATH directory entry containing *filename*, or ``None``.
+
+    Used for shims (``.ps1``) whose extension is not in ``PATHEXT`` and so are
+    invisible to :func:`shutil.which`.
+    """
+    for directory in os.environ.get("PATH", "").split(os.pathsep):
+        if not directory:
+            continue
+        candidate = ntpath.join(directory, filename)
+        if os.path.isfile(candidate):
+            return candidate
+    return None
+
+
+def _resolve_bw_command_windows() -> tuple[list[str], str | None]:
+    """Resolve the ``bw`` launch command on Windows across all shim flavours.
+
+    Install methods differ in what they put on ``PATH``:
+
+    * native download / scoop / choco → ``bw.exe`` (runnable directly)
+    * npm → ``bw.cmd`` **and** ``bw.ps1`` (no ``bw.exe``)
+
+    ``CreateProcess`` (``subprocess`` with ``shell=False``) only runs real
+    ``.exe``/``.com`` images, so a ``.cmd``/``.bat`` shim is routed through the
+    command processor and a ``.ps1`` shim through PowerShell. Variants are tried
+    most-reliable first, so when npm ships both we use ``bw.cmd`` rather than
+    paying PowerShell startup. ``.cmd``/``.bat`` is invoked by basename from its
+    own directory so an install path with spaces needs no ``cmd`` quoting.
+    """
+    for name in ("bw.exe", "bw.com"):
+        found = shutil.which(name)
+        if found:
+            return [found], None
+    for name in ("bw.cmd", "bw.bat"):
+        found = shutil.which(name)
+        if found:
+            comspec = os.environ.get("COMSPEC", "cmd.exe")
+            return [comspec, "/d", "/c", ntpath.basename(found)], ntpath.dirname(found)
+    # `.ps1` is not in PATHEXT, so shutil.which can't see it — search manually.
+    ps1 = _find_on_path("bw.ps1")
+    if ps1:
+        powershell = (
+            shutil.which("pwsh") or shutil.which("powershell") or "powershell.exe"
+        )
+        return [
+            powershell,
+            "-NoProfile",
+            "-NonInteractive",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-File",
+            ps1,
+        ], None
+    raise BitwardenClientError(BW_NOT_FOUND_MSG)
+
+
+def resolve_bw_command() -> tuple[list[str], str | None]:
+    """Resolve how to launch the Bitwarden CLI as a subprocess.
+
+    Returns ``(argv_prefix, cwd)``: *argv_prefix* is prepended to the ``bw``
+    arguments for every subprocess call, and *cwd* is the working directory to
+    run from (``None`` keeps the caller's cwd).
+
+    On POSIX the resolved ``bw`` is executed directly. On Windows the various
+    shim flavours (``bw.exe``, ``bw.cmd``/``bw.bat``, ``bw.ps1``) are resolved
+    and wrapped appropriately — see :func:`_resolve_bw_command_windows`. This is
+    what makes an npm-installed CLI (which ships only ``bw.cmd``/``bw.ps1``, no
+    ``bw.exe``) work instead of crashing with ``FileNotFoundError``.
+
+    Raises :class:`BitwardenClientError` if ``bw`` cannot be found.
+    """
+    if os.name == "nt":
+        return _resolve_bw_command_windows()
+    path = shutil.which("bw")
+    if path is None:
+        raise BitwardenClientError(BW_NOT_FOUND_MSG)
+    return [path], None
+
+
+def terminate_serve(
+    process: subprocess.Popen[bytes],
+    *,
+    via_shell: bool = False,
+    timeout: float = 5.0,
+) -> None:
+    """Stop a running ``bw serve`` process together with its descendants.
+
+    When ``bw`` is launched through a Windows shim wrapper (``cmd.exe`` for a
+    ``bw.cmd``/``bw.bat``, or PowerShell for a ``bw.ps1``),
+    :meth:`subprocess.Popen.terminate` reaches only the wrapper and orphans the
+    real ``bw serve``, which keeps holding the port. In that case the whole
+    process tree is killed with ``taskkill /F /T`` instead.
+    """
+    if process.poll() is not None:
+        return
+    if via_shell and os.name == "nt":
+        # terminate() would only kill the cmd.exe wrapper; take down the tree.
+        _ = subprocess.run(
+            ["taskkill", "/F", "/T", "/PID", str(process.pid)],
+            check=False,
+            capture_output=True,
+            stdin=subprocess.DEVNULL,
+        )
+        try:
+            _ = process.wait(timeout=timeout)
+        except subprocess.TimeoutExpired:
+            logger.warning("bw serve did not exit after taskkill /T")
+        return
+    process.terminate()
+    try:
+        _ = process.wait(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        logger.warning("bw serve did not exit on SIGTERM, sending SIGKILL")
+        process.kill()
+        _ = process.wait(timeout=timeout)
 
 
 def sanitize_cli_output(
@@ -81,6 +208,9 @@ class BitwardenServeClient:
     _org_id: str | None
     _collection_id: str | None  # fixed target collection for dedup scoping
     _closed: bool
+    _bw_cmd: list[str]  # argv prefix for invoking bw (handles Windows shims)
+    _bw_cwd: str | None  # cwd for bw subprocess calls (set for shim invocation)
+    _bw_via_shell: bool  # True when bw runs through a cmd.exe/PowerShell wrapper
 
     # ------------------------------------------------------------------
     # Lifecycle
@@ -93,6 +223,14 @@ class BitwardenServeClient:
         org_id: str | None = None,
         collection_id: str | None = None,
     ) -> None:
+        # Resolve how to launch bw before binding sockets, installing signal
+        # handlers, or spawning anything. This transparently wraps Windows
+        # .cmd/.bat/.ps1 shims so an npm-installed CLI works rather than crashing
+        # with FileNotFoundError, and fails fast with an actionable message when
+        # bw is genuinely missing.
+        self._bw_cmd, self._bw_cwd = resolve_bw_command()
+        self._bw_via_shell = len(self._bw_cmd) > 1
+
         self._port = _find_free_port()
         self._base_url = f"http://127.0.0.1:{self._port}"
         self._process = None
@@ -150,14 +288,19 @@ class BitwardenServeClient:
         logger.log(VERBOSE, "Obtaining session key via bw unlock --raw")
         try:
             result = subprocess.run(
-                ["bw", "unlock", "--raw", "--passwordenv", "_KP2BW_BW_PW"],
+                [*self._bw_cmd, "unlock", "--raw", "--passwordenv", "_KP2BW_BW_PW"],
                 check=False,
                 capture_output=True,
                 text=True,
                 timeout=30,
                 stdin=subprocess.DEVNULL,
+                cwd=self._bw_cwd,
                 env={**os.environ, "_KP2BW_BW_PW": password},
             )
+        except FileNotFoundError as exc:
+            # The resolved command (bw, or cmd.exe for a shim) could not be
+            # executed — surface the actionable message, not a raw traceback.
+            raise BitwardenClientError(BW_NOT_FOUND_MSG) from exc
         except subprocess.TimeoutExpired:
             logger.warning("bw unlock timed out while obtaining session key")
             return None
@@ -184,7 +327,14 @@ class BitwardenServeClient:
         Always passes an explicit *env* dict so a stale ``BW_SESSION`` in
         the parent process environment is never leaked to the child.
         """
-        cmd = ["bw", "serve", "--port", str(self._port), "--hostname", "127.0.0.1"]
+        cmd = [
+            *self._bw_cmd,
+            "serve",
+            "--port",
+            str(self._port),
+            "--hostname",
+            "127.0.0.1",
+        ]
         env = {**os.environ}
         if session:
             env["BW_SESSION"] = session
@@ -195,12 +345,16 @@ class BitwardenServeClient:
             f"Starting bw serve on port {self._port} "
             f"(BW_SESSION={'set' if session else 'not set'})",
         )
-        self._process = subprocess.Popen(
-            cmd,
-            stdin=subprocess.DEVNULL,
-            stderr=subprocess.PIPE,
-            env=env,
-        )
+        try:
+            self._process = subprocess.Popen(
+                cmd,
+                stdin=subprocess.DEVNULL,
+                stderr=subprocess.PIPE,
+                cwd=self._bw_cwd,
+                env=env,
+            )
+        except FileNotFoundError as exc:
+            raise BitwardenClientError(BW_NOT_FOUND_MSG) from exc
 
     def _wait_for_ready(self) -> None:
         """Poll ``GET /status`` until the server is responsive."""
@@ -253,13 +407,7 @@ class BitwardenServeClient:
 
         if self._process is not None and self._process.poll() is None:
             logger.log(VERBOSE, "Terminating bw serve process")
-            self._process.terminate()
-            try:
-                self._process.wait(timeout=5)
-            except subprocess.TimeoutExpired:
-                logger.warning("bw serve did not exit on SIGTERM, sending SIGKILL")
-                self._process.kill()
-                self._process.wait(timeout=5)
+            terminate_serve(self._process, via_shell=self._bw_via_shell)
 
         self._process = None
         try:

--- a/tests/bw_serve_command_test.py
+++ b/tests/bw_serve_command_test.py
@@ -1,0 +1,163 @@
+"""Unit tests for bw command resolution and process teardown.
+
+These exercise the platform-branching logic on any OS by patching ``os.name``,
+``shutil.which``, and the PATH, so the Windows shim handling that fixes the
+``FileNotFoundError: [WinError 2]`` crash (issue #8) is verified even off
+Windows.
+"""
+
+import subprocess
+import sys
+from collections.abc import Callable, Mapping
+from unittest.mock import patch
+
+from kp2bw import bw_serve
+from kp2bw.bw_serve import BW_NOT_FOUND_MSG, resolve_bw_command, terminate_serve
+from kp2bw.exceptions import BitwardenClientError
+
+
+def _fake_which(mapping: Mapping[str, str]) -> Callable[..., str | None]:
+    """Build a ``shutil.which`` replacement backed by a name -> path map."""
+
+    def which(name: str, *_args: object, **_kwargs: object) -> str | None:
+        return mapping.get(name)
+
+    return which
+
+
+def _fake_isfile(target: str | None) -> Callable[[str], bool]:
+    """Build an ``os.path.isfile`` replacement that matches a single path."""
+
+    def isfile(path: str) -> bool:
+        return path == target
+
+    return isfile
+
+
+def assert_resolve_plain_on_posix() -> None:
+    with (
+        patch.object(bw_serve.os, "name", "posix"),
+        patch.object(
+            bw_serve.shutil, "which", _fake_which({"bw": "/usr/local/bin/bw"})
+        ),
+    ):
+        argv, cwd = resolve_bw_command()
+    if argv != ["/usr/local/bin/bw"] or cwd is not None:
+        raise AssertionError(f"unexpected resolution: {argv!r}, cwd={cwd!r}")
+
+
+def assert_resolve_windows_exe_direct() -> None:
+    exe = r"C:\Program Files\Bitwarden CLI\bw.exe"
+    with (
+        patch.object(bw_serve.os, "name", "nt"),
+        patch.object(bw_serve.shutil, "which", _fake_which({"bw.exe": exe})),
+    ):
+        argv, cwd = resolve_bw_command()
+    if argv != [exe] or cwd is not None:
+        raise AssertionError(f"native exe should run directly: {argv!r}, cwd={cwd!r}")
+
+
+def assert_resolve_prefers_cmd_over_ps1() -> None:
+    # npm ships both bw.cmd and bw.ps1; we must pick the cmd shim. This is the
+    # exact case from issue #8: an npm-installed CLI with no bw.exe, where a
+    # naive subprocess(["bw", ...]) raises FileNotFoundError: [WinError 2].
+    shim = r"C:\Users\me\AppData\Roaming\npm\bw.cmd"
+    with (
+        patch.object(bw_serve.os, "name", "nt"),
+        patch.object(bw_serve.shutil, "which", _fake_which({"bw.cmd": shim})),
+    ):
+        argv, cwd = resolve_bw_command()
+    # COMSPEC may or may not be set on the test host, so only assert the tail.
+    if argv[1:] != ["/d", "/c", "bw.cmd"]:
+        raise AssertionError(f"shim not routed through cmd.exe: {argv!r}")
+    if not argv[0]:
+        raise AssertionError("missing command processor in argv[0]")
+    if cwd != r"C:\Users\me\AppData\Roaming\npm":
+        raise AssertionError(f"shim should run from its own dir, got cwd={cwd!r}")
+
+
+def assert_resolve_ps1_via_powershell() -> None:
+    # A .ps1-only install: shutil.which can't see it (not in PATHEXT), so it is
+    # found on PATH and routed through PowerShell.
+    ps1 = r"C:\tools\bw.ps1"
+    with (
+        patch.object(bw_serve.os, "name", "nt"),
+        patch.object(bw_serve.os, "pathsep", ";"),
+        patch.object(bw_serve.shutil, "which", _fake_which({})),
+        patch.dict(bw_serve.os.environ, {"PATH": r"C:\tools"}, clear=False),
+        patch.object(bw_serve.os.path, "isfile", _fake_isfile(ps1)),
+    ):
+        argv, cwd = resolve_bw_command()
+    if argv[0].lower() != "powershell.exe":  # pwsh/powershell not on fake PATH
+        raise AssertionError(f"ps1 shim not routed through PowerShell: {argv!r}")
+    if argv[-2:] != ["-File", ps1] or "Bypass" not in argv:
+        raise AssertionError(f"unexpected PowerShell invocation: {argv!r}")
+    if cwd is not None:
+        raise AssertionError(f"ps1 invocation should not set cwd, got {cwd!r}")
+
+
+def assert_resolve_missing_raises_posix() -> None:
+    with (
+        patch.object(bw_serve.os, "name", "posix"),
+        patch.object(bw_serve.shutil, "which", _fake_which({})),
+    ):
+        try:
+            resolve_bw_command()
+        except BitwardenClientError as exc:
+            if str(exc) != BW_NOT_FOUND_MSG:
+                raise AssertionError(f"unexpected message: {exc!r}")
+        else:
+            raise AssertionError("expected BitwardenClientError when bw is missing")
+
+
+def assert_resolve_missing_raises_windows() -> None:
+    with (
+        patch.object(bw_serve.os, "name", "nt"),
+        patch.object(bw_serve.os, "pathsep", ";"),
+        patch.object(bw_serve.shutil, "which", _fake_which({})),
+        patch.dict(bw_serve.os.environ, {"PATH": r"C:\tools"}, clear=False),
+        patch.object(bw_serve.os.path, "isfile", _fake_isfile(None)),
+    ):
+        try:
+            resolve_bw_command()
+        except BitwardenClientError as exc:
+            if str(exc) != BW_NOT_FOUND_MSG:
+                raise AssertionError(f"unexpected message: {exc!r}")
+        else:
+            raise AssertionError("expected BitwardenClientError when bw is missing")
+
+
+def assert_terminate_serve_kills_process() -> None:
+    """The non-shell path terminates a real child process (POSIX + Windows)."""
+    proc = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(30)"])
+    try:
+        terminate_serve(proc, via_shell=False, timeout=5)
+    finally:
+        if proc.poll() is None:  # belt-and-suspenders if assertion below fails
+            proc.kill()
+            _ = proc.wait(timeout=5)
+    if proc.poll() is None:
+        raise AssertionError("terminate_serve did not stop the process")
+
+
+def assert_terminate_serve_noop_when_already_dead() -> None:
+    proc = subprocess.Popen([sys.executable, "-c", "pass"])
+    _ = proc.wait(timeout=5)
+    # Must not raise even though the process has already exited.
+    terminate_serve(proc, via_shell=True, timeout=5)
+
+
+def main() -> None:
+    assert_resolve_plain_on_posix()
+    assert_resolve_windows_exe_direct()
+    assert_resolve_prefers_cmd_over_ps1()
+    assert_resolve_ps1_via_powershell()
+    assert_resolve_missing_raises_posix()
+    assert_resolve_missing_raises_windows()
+    assert_terminate_serve_kills_process()
+    assert_terminate_serve_noop_when_already_dead()
+    print("bw serve command resolution test passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_script_adapters.py
+++ b/tests/test_script_adapters.py
@@ -19,6 +19,10 @@ def test_bw_serve_sanitization_script() -> None:
     _run_script_main("bw_serve_sanitization_test.py")
 
 
+def test_bw_serve_command_script() -> None:
+    _run_script_main("bw_serve_command_test.py")
+
+
 def test_otp_script() -> None:
     _run_script_main("otp_test.py")
 


### PR DESCRIPTION
## Summary

Fixes #8.

An npm-installed Bitwarden CLI on Windows ships only a `bw.cmd` shim (plus
`bw.ps1`) — there is no `bw.exe`. kp2bw shells out with
`subprocess.run(["bw", ...], shell=False)`, which on Windows goes through
`CreateProcess`. `CreateProcess` resolves a bare name only to a real
`.exe`/`.com` image and ignores `PATHEXT`, so `bw login --sso` works in
PowerShell while kp2bw's `bw unlock` / `bw serve` calls crash with
`FileNotFoundError: [WinError 2] The system cannot find the specified file`.

## Changes

- **`resolve_bw_command()`** resolves every shim flavour up front
  (`PATHEXT`-aware via `shutil.which`):
  - native `bw.exe`/`bw.com` run directly;
  - `bw.cmd`/`bw.bat` are routed through `cmd.exe /d /c`, invoked by basename
    from their own directory so an install path with spaces needs no shell
    quoting;
  - `bw.ps1` (not in `PATHEXT`, so invisible to `shutil.which`) is found on
    `PATH` and run through PowerShell.

  When npm ships both `bw.cmd` and `bw.ps1`, the `cmd` shim is preferred.
- **`terminate_serve()`** tears the `bw serve` process tree down with
  `taskkill /F /T` for wrapped shims — a plain `terminate()` would only kill
  the `cmd.exe`/PowerShell wrapper and orphan the real server on its port.
- A genuinely missing CLI now raises `BitwardenClientError` with an actionable
  message instead of a bare `subprocess` traceback.
- The POSIX / native `bw.exe` path is behaviorally unchanged.

## Tests

- New cross-platform unit tests (`tests/bw_serve_command_test.py`) cover argv
  wrapping (posix / Windows `.exe` / Windows `.cmd` / `.ps1` / missing) and
  process teardown; the Windows branch is exercised on any OS by patching
  `os.name`, `shutil.which`, and the `PATH`.
- `ruff`, `ruff format`, `ty`, `basedpyright`, and the existing suite pass
  locally.

## Notes

Focused fix for #8. It overlaps with the Windows-shim portion of #16, which
also bundles the #5 friendly-missing-CLI work and is currently conflicting
with `master`.