### PR TITLE
fix: update existing Bitwarden entries on re-run (#11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   re-import. Existing items are now updated in place on re-run.
 - **Long notes not attached to (or refreshed on) already-imported entries**
   (#11) -- notes over 10k chars migrate to a `notes.txt` attachment, but
-  previously-imported (skipped) entries never received it, and an edited
+  previously imported (skipped) entries never received it, and an edited
   attachment that kept the same filename was never updated. Re-runs now upload
   any attachment an existing item is missing **and** refresh one whose content
   changed (the stale copy is removed only after the replacement uploads), all

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,10 +24,14 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   notes (e.g. pasting in new recovery keys) without touching credentials left
   the existing Bitwarden item unchanged, forcing a full vault purge to
   re-import. Existing items are now updated in place on re-run.
-- **Long notes not attached to already-imported entries** (#11) -- notes over
-  10k chars migrate to a `notes.txt` attachment, but previously-imported
-  (skipped) entries never received it. Re-runs now upload any attachment an
-  existing item is missing, without creating duplicates.
+- **Long notes not attached to (or refreshed on) already-imported entries**
+  (#11) -- notes over 10k chars migrate to a `notes.txt` attachment, but
+  previously-imported (skipped) entries never received it, and an edited
+  attachment that kept the same filename was never updated. Re-runs now upload
+  any attachment an existing item is missing **and** refresh one whose content
+  changed (the stale copy is removed only after the replacement uploads), all
+  without creating duplicates. Applies to every attachment kp2bw manages --
+  long notes, long custom fields, and real KeePass file attachments.
 - **A single rejected attachment aborted the whole migration** (#11) -- an
   attachment the server refused (for example a `.jpg` rejected for premium or
   storage-quota reasons) raised an opaque `HTTP 400` that stopped everything.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [3.3.0] - 2026-06-08
+
 ### Added
 
 - **In-place updates for changed entries** -- re-running `kp2bw` now syncs
@@ -469,7 +471,8 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 [`jampe/kp2bw@c9ef571eabd345db94751f7dec845e49756e9d47`](https://github.com/jampe/kp2bw/commit/c9ef571eabd345db94751f7dec845e49756e9d47)
 
-[Unreleased]: https://github.com/kjanat/kp2bw/compare/v3.2.0...HEAD
+[Unreleased]: https://github.com/kjanat/kp2bw/compare/v3.3.0...HEAD
+[3.3.0]: https://github.com/kjanat/kp2bw/compare/v3.2.0...v3.3.0
 [3.2.0]: https://github.com/kjanat/kp2bw/compare/v3.1.0...v3.2.0
 [3.1.0]: https://github.com/kjanat/kp2bw/compare/v3.0.1...v3.1.0
 [3.0.1]: https://github.com/kjanat/kp2bw/compare/v3.0.0...v3.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,33 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- **In-place updates for changed entries** -- re-running `kp2bw` now syncs
+  KeePass edits onto existing Bitwarden items instead of skipping them. Changed
+  notes, passwords, usernames, URIs and custom fields are written via an
+  idempotent `PUT` (an unchanged entry issues no request). Collection
+  membership is only ever added, never removed, and a Bitwarden-side `favorite`
+  flag or a passkey absent from KeePass is preserved. Opt out with `--no-update`
+  (env: `KP2BW_UPDATE=0`) to restore the previous skip-only behavior.
+
+### Fixed
+
+- **Updated KeePass notes never reached Bitwarden** (#11) -- editing an entry's
+  notes (e.g. pasting in new recovery keys) without touching credentials left
+  the existing Bitwarden item unchanged, forcing a full vault purge to
+  re-import. Existing items are now updated in place on re-run.
+- **Long notes not attached to already-imported entries** (#11) -- notes over
+  10k chars migrate to a `notes.txt` attachment, but previously-imported
+  (skipped) entries never received it. Re-runs now upload any attachment an
+  existing item is missing, without creating duplicates.
+- **A single rejected attachment aborted the whole migration** (#11) -- an
+  attachment the server refused (for example a `.jpg` rejected for premium or
+  storage-quota reasons) raised an opaque `HTTP 400` that stopped everything.
+  Upload failures are now non-fatal: the real server message is surfaced
+  instead of just the status code, and the migration continues with the
+  remaining entries.
+
 ## [3.1.0] - 2026-06-08
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   notes (e.g. pasting in new recovery keys) without touching credentials left
   the existing Bitwarden item unchanged, forcing a full vault purge to
   re-import. Existing items are now updated in place on re-run.
-- **Long notes not attached to (or refreshed on) already-imported entries**
+- **Long notes not attached to (or refreshed on) previously imported entries**
   (#11) -- notes over 10k chars migrate to a `notes.txt` attachment, but
   previously imported (skipped) entries never received it, and an edited
   attachment that kept the same filename was never updated. Re-runs now upload

--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ the built-in Bitwarden importer:
   attachments (values > 10k chars auto-upload as files)
 - **Long notes handling** -- notes exceeding 10k chars are uploaded as
   `notes.txt` attachments
-- **Idempotent** -- safe to run multiple times without duplicating entries
+- **Idempotent re-runs that sync changes** -- safe to run repeatedly; existing
+  entries are updated in place when their KeePass content changed (notes,
+  credentials, URIs, fields) and never duplicated. Disable with `--no-update`
 - **Nested folders** -- KeePass folder hierarchy is recreated in Bitwarden
 - **Recycle Bin filtering** -- deleted entries are automatically excluded
 - **Expiry awareness** -- expired entries are marked `[EXPIRED]` in notes;
@@ -73,7 +75,7 @@ kp2bw [-h] [-V] [-k PASSWORD] [-K FILE] [-b PASSWORD] [-o ID]
        [-t TAG [TAG ...]] [-c ID] [--path-to-name | --no-path-to-name]
        [--path-to-name-skip N] [--skip-expired | --no-skip-expired]
        [--include-recycle-bin | --no-include-recycle-bin]
-       [--metadata | --no-metadata] [-y] [-v] [-d]
+       [--metadata | --no-metadata] [--update | --no-update] [-y] [-v] [-d]
        FILE
 ```
 
@@ -91,6 +93,7 @@ kp2bw [-h] [-V] [-k PASSWORD] [-K FILE] [-b PASSWORD] [-o ID]
 | `--skip-expired`                       | Skip entries that have expired in KeePass                      | `KP2BW_SKIP_EXPIRED`                  |
 | `--include-recycle-bin`                | Include Recycle Bin entries (excluded by default)              | `KP2BW_INCLUDE_RECYCLE_BIN`           |
 | `--metadata` / `--no-metadata`         | Toggle KeePass metadata as custom fields (default: on)         | `KP2BW_MIGRATE_METADATA`              |
+| `--update` / `--no-update`             | Update existing entries changed in KeePass (default: on)       | `KP2BW_UPDATE`                        |
 | `-y, --yes`                            | Skip the Bitwarden CLI setup confirmation prompt               | `KP2BW_YES`                           |
 | `-v, --verbose`                        | Verbose output                                                 | `KP2BW_VERBOSE`                       |
 | `-d, --debug`                          | Debug output — includes third-party library logs               | `KP2BW_DEBUG`                         |
@@ -118,9 +121,28 @@ kp2bw starts `bw serve` on a random localhost port. If it times out after 60s:
 ### Items skipped unexpectedly during org import
 
 When importing with `--bitwarden-org`, items already present in the
-organization vault are skipped. If you're importing into a specific collection
-(`--bitwarden-collection`), only items already in *that* collection are
-considered duplicates — items in other collections will be created or updated.
+organization vault are matched by folder + name. If you're importing into a
+specific collection (`--bitwarden-collection`), only items already in *that*
+collection are matched — items in other collections are created.
+
+### Re-running to pick up KeePass changes
+
+Re-running `kp2bw` against the same database updates matched entries in place
+when their KeePass content changed (notes, password, username, URIs or custom
+fields), so you no longer need to purge the vault to push edits. Unchanged
+entries are left untouched. A re-run also uploads any `notes.txt` / long-field
+/ file attachment that a previously-imported entry was missing. Pass
+`--no-update` (or `KP2BW_UPDATE=0`) to keep the old skip-only behavior and
+preserve manual Bitwarden-side edits.
+
+### An attachment failed to upload
+
+Attachment uploads are sent through `bw serve`, which forwards them to your
+Bitwarden/Vaultwarden server. A rejected file (for example, an image too large
+for your plan, or an upload that needs premium/organization storage) now
+reports the server's actual message and is skipped — it no longer aborts the
+whole migration, so the rest of your entries still import. Resolve the
+underlying limit and re-run to upload the remaining files.
 
 [jampe/kp2bw]: https://github.com/jampe/kp2bw
 [Bitwarden CLI]: https://bitwarden.com/help/cli/

--- a/README.md
+++ b/README.md
@@ -142,9 +142,11 @@ Re-running `kp2bw` against the same database updates matched entries in place
 when their KeePass content changed (notes, password, username, URIs or custom
 fields), so you no longer need to purge the vault to push edits. Unchanged
 entries are left untouched. A re-run also uploads any `notes.txt` / long-field
-/ file attachment that a previously-imported entry was missing. Pass
-`--no-update` (or `KP2BW_UPDATE=0`) to keep the old skip-only behavior and
-preserve manual Bitwarden-side edits.
+/ file attachment that a previously-imported entry was missing, and refreshes
+one whose contents changed in KeePass even when it keeps the same filename (the
+stale copy is removed only once the new one has uploaded). Pass `--no-update`
+(or `KP2BW_UPDATE=0`) to keep the old skip-only behavior and preserve manual
+Bitwarden-side edits.
 
 ### An attachment failed to upload
 

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Re-running `kp2bw` against the same database updates matched entries in place
 when their KeePass content changed (notes, password, username, URIs or custom
 fields), so you no longer need to purge the vault to push edits. Unchanged
 entries are left untouched. A re-run also uploads any `notes.txt` / long-field
-/ file attachment that a previously-imported entry was missing, and refreshes
+/ file attachment that a previously imported entry was missing, and refreshes
 one whose contents changed in KeePass even when it keeps the same filename (the
 stale copy is removed only once the new one has uploaded). Pass `--no-update`
 (or `KP2BW_UPDATE=0`) to keep the old skip-only behavior and preserve manual

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name            = "kp2bw"
-version         = "3.2.0"
+version         = "3.3.0"
 description     = "Imports and existing KeePass db with REF fields into Bitwarden"
 readme          = "README.md"
 requires-python = ">=3.14"

--- a/scripts/generate-bw-types.sh
+++ b/scripts/generate-bw-types.sh
@@ -7,9 +7,11 @@
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+IN_FILE="${REPO_ROOT}/specs/vault-management-api.json"
+OUT_FILE="${REPO_ROOT}/src/kp2bw/_bw_api_types.py"
 
-uvx --from "datamodel-code-generator[ruff]" datamodel-codegen \
-	--input "${REPO_ROOT}/specs/vault-management-api.json" \
+if uvx --from "datamodel-code-generator[ruff]" datamodel-codegen \
+	--input "${IN_FILE}" \
 	--input-file-type openapi \
 	--output-model-type typing.TypedDict \
 	--target-python-version 3.14 \
@@ -18,6 +20,9 @@ uvx --from "datamodel-code-generator[ruff]" datamodel-codegen \
 	--reuse-model \
 	--disable-timestamp \
 	--formatters ruff-format ruff-check \
-	>"${REPO_ROOT}/src/kp2bw/_bw_api_types.py"
-
-echo "Generated src/kp2bw/_bw_api_types.py"
+	>"${OUT_FILE}"; then
+	echo "Generated ${OUT_FILE}"
+else
+	echo "Failed to generate ${OUT_FILE}"
+	exit 1
+fi

--- a/src/kp2bw/AGENTS.md
+++ b/src/kp2bw/AGENTS.md
@@ -59,10 +59,17 @@ src/kp2bw/
   a matched login item via `_content_differs()` and, when changed, `PUT`s a
   payload built by `_build_update_payload()` (preserves id/favorite/folder/org,
   unions collectionIds, keeps a Bitwarden-side passkey absent from KeePass).
-  Missing attachments are uploaded, deduped per `(item_id, filename)`. Content
-  and attachment failures are non-fatal and counted; `convert()` returns the
-  failure count and the CLI exits non-zero when it is non-zero. `--no-update`
-  restores skip-only behavior (collection-membership sync still applies).
+  Attachments are reconciled by content, not just name: a file the item lacks is
+  uploaded, and one whose bytes changed but kept its filename is re-uploaded
+  (`_attachment_content_differs()` downloads via `get_attachment()` and compares;
+  an unreadable existing copy is treated as unchanged to avoid data loss). The
+  stale copy is deleted only after its replacement uploads (upload-then-delete),
+  so `upload_attachments()` returns failed `(item_id, filename)` pairs and a
+  delete is skipped when its replacement upload failed. Uploads are deduped per
+  `(item_id, filename)`. Content and attachment failures are non-fatal and
+  counted; `convert()` returns the failure count and the CLI exits non-zero when
+  it is non-zero. `--no-update` restores skip-only behavior (collection-
+  membership sync still applies).
 - Dedup index is org-scoped when `--bitwarden-org` is set: `_build_dedup_index()` passes `organization_id=self._org_id` to `list_items()`, which appends `organizationId` as a query param to `/list/object/items`. When `org_id` is `None` (personal vault), no filter is applied and all vault items are indexed. This prevents personal vault entries from shadowing an empty org vault during migration.
 - When a fixed `--bitwarden-collection` is given, the dedup index is further scoped to that collection via `collection_id`. Items in other collections are treated as new.
 - `_bw_api_types.py` is generated — run `bash scripts/generate-bw-types.sh` after spec changes. CI checks for drift via `codegen-check.yml`.

--- a/src/kp2bw/AGENTS.md
+++ b/src/kp2bw/AGENTS.md
@@ -46,13 +46,23 @@ src/kp2bw/
 
 - Reintroducing subprocess-per-op transport for new work.
 - Logging decrypted vault content or credential-bearing command strings.
-- Breaking idempotency by bypassing existing-item dedup checks.
+- Breaking idempotency: a re-run with no KeePass changes must issue no `PUT`
+  and upload no attachment (`_content_differs` / upload-if-missing gate this).
 - Changing conversion behavior without updating e2e expectations in `tests/e2e_vaultwarden_test.py`.
 
 ## NOTES
 
 - `bw_serve.py` is the active transport path; `bw_import.py` and `bitwardenclient.py` are legacy/reference.
 - Maintain behavior parity for `kp2bw.cli:main` and `python -m kp2bw`.
+- Existing-item sync (`--update` / `--no-update`, `KP2BW_UPDATE`, default on,
+  `Converter(update_existing=...)`): `convert._reconcile_existing_item()` diffs
+  a matched login item via `_content_differs()` and, when changed, `PUT`s a
+  payload built by `_build_update_payload()` (preserves id/favorite/folder/org,
+  unions collectionIds, keeps a Bitwarden-side passkey absent from KeePass).
+  Missing attachments are uploaded, deduped per `(item_id, filename)`. Content
+  and attachment failures are non-fatal and counted; `convert()` returns the
+  failure count and the CLI exits non-zero when it is non-zero. `--no-update`
+  restores skip-only behavior (collection-membership sync still applies).
 - Dedup index is org-scoped when `--bitwarden-org` is set: `_build_dedup_index()` passes `organization_id=self._org_id` to `list_items()`, which appends `organizationId` as a query param to `/list/object/items`. When `org_id` is `None` (personal vault), no filter is applied and all vault items are indexed. This prevents personal vault entries from shadowing an empty org vault during migration.
 - When a fixed `--bitwarden-collection` is given, the dedup index is further scoped to that collection via `collection_id`. Items in other collections are treated as new.
 - `_bw_api_types.py` is generated — run `bash scripts/generate-bw-types.sh` after spec changes. CI checks for drift via `codegen-check.yml`.

--- a/src/kp2bw/AGENTS.md
+++ b/src/kp2bw/AGENTS.md
@@ -64,10 +64,10 @@ src/kp2bw/
   (`_attachment_content_differs()` downloads via `get_attachment()` and compares;
   an unreadable existing copy is treated as unchanged to avoid data loss). The
   stale copy is deleted only after its replacement uploads (upload-then-delete),
-  so `upload_attachments()` returns failed `(item_id, filename)` pairs and a
-  delete is skipped when its replacement upload failed. Uploads are deduped per
+  so `upload_attachments()` returns failed `(item_id, filename)` pairs and the
+  deletion is skipped when its replacement upload failed. Uploads are deduped per
   `(item_id, filename)`. Content and attachment failures are non-fatal and
-  counted; `convert()` returns the failure count and the CLI exits non-zero when
+  counted; `convert()` returns the failure count, and the CLI exits non-zero when
   it is non-zero. `--no-update` restores skip-only behavior (collection-
   membership sync still applies).
 - Dedup index is org-scoped when `--bitwarden-org` is set: `_build_dedup_index()` passes `organization_id=self._org_id` to `list_items()`, which appends `organizationId` as a query param to `/list/object/items`. When `org_id` is `None` (personal vault), no filter is applied and all vault items are indexed. This prevents personal vault entries from shadowing an empty org vault during migration.

--- a/src/kp2bw/bw_serve.py
+++ b/src/kp2bw/bw_serve.py
@@ -726,6 +726,43 @@ class BitwardenServeClient:
         return coll_id
 
     # ------------------------------------------------------------------
+    # CRUD — attachments
+    # ------------------------------------------------------------------
+
+    def get_attachment(self, item_id: str, attachment_id: str) -> bytes:
+        """Download one attachment's decrypted bytes via ``GET /object/attachment``.
+
+        Unlike the JSON endpoints this returns the raw file body
+        (octet-stream), so it bypasses the :meth:`_request` envelope handling.
+        Used by content-aware reconciliation to compare a vault attachment
+        against the KeePass-derived bytes before deciding whether to refresh it.
+        """
+        resp = self._http.get(
+            f"/object/attachment/{attachment_id}",
+            params={"itemid": item_id},
+        )
+        if resp.status_code >= 400:
+            raise BitwardenClientError(
+                f"bw serve returned HTTP {resp.status_code} downloading "
+                f"attachment {attachment_id} on item {item_id}"
+            )
+        return resp.content
+
+    def delete_attachment(self, item_id: str, attachment_id: str) -> None:
+        """Delete one attachment via ``DELETE /object/attachment/{id}``.
+
+        Used after a content-changed attachment is re-uploaded so the stale
+        copy is removed (upload-then-delete keeps the file safe if the upload
+        fails).
+        """
+        self._request(
+            "DELETE",
+            f"/object/attachment/{attachment_id}",
+            params={"itemid": item_id},
+        )
+        logger.log(VERBOSE, f"Deleted attachment {attachment_id} from item {item_id}")
+
+    # ------------------------------------------------------------------
     # Async attachment uploads
     # ------------------------------------------------------------------
 
@@ -773,13 +810,16 @@ class BitwardenServeClient:
         items: list[tuple[str, list[tuple[str, bytes]]]],
         *,
         max_concurrency: int = 4,
-    ) -> list[str]:
+    ) -> list[tuple[str, str]]:
         """Upload all attachments with bounded parallelism.
 
         *items* is a list of ``(item_id, [(filename, data), ...])`` tuples.
 
-        Returns the labels of any uploads that failed (empty list when all
-        succeed).  Failures are **non-fatal**: a single rejected file must not
+        Returns the ``(item_id, filename)`` pairs of any uploads that failed
+        (empty list when all succeed).  The structured pairs let the caller
+        pair a successful upload with the stale copy it replaces (so a
+        content-changed attachment is only deleted once its replacement
+        landed).  Failures are **non-fatal**: a single rejected file must not
         abort the whole migration and discard every other entry's progress.
         """
         total = sum(len(atts) for _, atts in items)
@@ -803,7 +843,7 @@ class BitwardenServeClient:
             timeout=_HTTP_TIMEOUT_S,
         ) as client:
             tasks: list[asyncio.Task[None]] = []
-            labels: list[str] = []
+            keys: list[tuple[str, str]] = []
             for item_id, attachments in items:
                 for filename, data in attachments:
                     tasks.append(
@@ -811,34 +851,38 @@ class BitwardenServeClient:
                             _upload_one(client, item_id, filename, data)
                         )
                     )
-                    labels.append(f"{filename} (item {item_id})")
+                    keys.append((item_id, filename))
             results = await asyncio.gather(*tasks, return_exceptions=True)
 
-        failed_labels: list[str] = []
-        for label, result in zip(labels, results, strict=True):
+        failed: list[tuple[str, str]] = []
+        for (item_id, filename), result in zip(keys, results, strict=True):
             if isinstance(result, BaseException):
-                logger.error(f"Attachment upload failed for {label}: {result}")
-                failed_labels.append(label)
+                logger.error(
+                    f"Attachment upload failed for {filename!r} (item {item_id}): "
+                    f"{result}"
+                )
+                failed.append((item_id, filename))
 
-        succeeded = total - len(failed_labels)
-        if failed_labels:
+        succeeded = total - len(failed)
+        if failed:
             logger.warning(
-                f"{len(failed_labels)}/{total} attachment upload(s) failed; "
+                f"{len(failed)}/{total} attachment upload(s) failed; "
                 f"continuing with the remaining entries"
             )
         logger.info(f"Uploaded {succeeded}/{total} attachments")
-        return failed_labels
+        return failed
 
     def upload_attachments(
         self,
         items: list[tuple[str, list[tuple[str, bytes]]]],
         *,
         max_concurrency: int = 4,
-    ) -> list[str]:
+    ) -> list[tuple[str, str]]:
         """Synchronous wrapper for :meth:`upload_attachments_parallel`.
 
-        Returns the labels of failed uploads (empty when all succeed); failures
-        are non-fatal so the migration completes and the caller can summarise.
+        Returns the ``(item_id, filename)`` pairs of failed uploads (empty when
+        all succeed); failures are non-fatal so the migration completes and the
+        caller can summarise and skip any dependent stale-copy deletes.
         """
         return asyncio.run(
             self.upload_attachments_parallel(items, max_concurrency=max_concurrency)

--- a/src/kp2bw/bw_serve.py
+++ b/src/kp2bw/bw_serve.py
@@ -584,16 +584,25 @@ class BitwardenServeClient:
             files={"file": (filename, data)},
         )
         try:
-            body: dict[str, Any] = resp.json()
+            parsed: Any = resp.json()
         except ValueError:
-            body = {}
+            parsed = None
+        # Guard against a non-object JSON body (array/string) so reading the
+        # envelope can't raise AttributeError instead of a clean error.
+        body: dict[str, Any] = (
+            cast(dict[str, Any], parsed) if isinstance(parsed, dict) else {}
+        )
 
         # bw serve reports command-level failures (e.g. "Premium status is
         # required", storage-quota or attachment-size limits) as HTTP 400 with
         # the real reason in the body's ``message`` field.  Surface it instead
         # of an opaque status code so the user knows *why* a file was rejected.
         if resp.status_code >= 400 or not body.get("success", False):
-            message = body.get("message") or f"HTTP {resp.status_code}"
+            message = body.get("message")
+            if not message:
+                message = f"HTTP {resp.status_code}"
+                if parsed is None:
+                    message += " (non-JSON response)"
             raise BitwardenClientError(
                 f"Attachment upload failed for {filename!r} on item {item_id}: "
                 f"{message}"

--- a/src/kp2bw/bw_serve.py
+++ b/src/kp2bw/bw_serve.py
@@ -35,6 +35,19 @@ _HTTP_TIMEOUT_S: float = 60.0
 # Max length for sanitized CLI output snippets in logs/errors.
 _SANITIZED_OUTPUT_MAX_CHARS: int = 240
 
+# Response-only keys returned by ``GET``/``list`` that must never be sent back in
+# a ``PUT`` body: the API expects a create-shaped object (``BwItemCreate``), and
+# echoing server-managed fields (notably ``attachments``) risks rejection or
+# clobbering state.  The item id travels in the URL, not the body.
+_RESPONSE_ONLY_ITEM_KEYS: frozenset[str] = frozenset({
+    "object",
+    "id",
+    "revisionDate",
+    "creationDate",
+    "deletedDate",
+    "attachments",
+})
+
 # Actionable message shown when the Bitwarden CLI cannot be located.
 BW_NOT_FOUND_MSG: str = (
     "Bitwarden CLI ('bw') not found on your PATH. Install it and make sure "
@@ -578,9 +591,19 @@ class BitwardenServeClient:
         """Replace an existing vault item via ``PUT /object/item/{id}``.
 
         The API requires the full object in the request body — partial updates
-        are not supported.
+        are not supported.  Callers may pass an item read back from the vault
+        (a ``BwItemResponse``); response-only keys (``id``, ``object``,
+        ``revisionDate``, ``attachments``, …) are stripped here so the wire body
+        is the create-shaped object the endpoint expects.  Stripping happens on a
+        copy, so a caller can still hand the original (id-bearing) object to
+        :meth:`update_dedup_entry`.
         """
-        self._request("PUT", f"/object/item/{item_id}", json_body=item)
+        body: dict[str, Any] = {
+            k: v
+            for k, v in cast(dict[str, Any], item).items()
+            if k not in _RESPONSE_ONLY_ITEM_KEYS
+        }
+        self._request("PUT", f"/object/item/{item_id}", json_body=body)
         logger.log(VERBOSE, f"Updated item {item.get('name', '?')!r} ({item_id})")
 
     def create_items_batch(

--- a/src/kp2bw/bw_serve.py
+++ b/src/kp2bw/bw_serve.py
@@ -11,7 +11,7 @@ import subprocess
 import time
 from collections.abc import Callable, Mapping
 from types import FrameType, TracebackType
-from typing import Any, Self
+from typing import Any, Self, cast
 
 import httpx
 
@@ -405,6 +405,16 @@ class BitwardenServeClient:
         logger.log(VERBOSE, f"Created item {item.get('name', '?')!r} → {item_id}")
         return item_id
 
+    def get_item(self, item_id: str) -> BwItemResponse:
+        """Fetch a single full item (including ``attachments``) via ``GET``.
+
+        The list endpoint is enough for content dedup, but its ``attachments``
+        array is only consulted for upload-if-missing reconciliation, so this
+        authoritative fetch is used to avoid creating duplicate attachments.
+        """
+        data = self._request("GET", f"/object/item/{item_id}")
+        return cast(BwItemResponse, data)
+
     def update_item(self, item_id: str, item: BwItemResponse) -> None:
         """Replace an existing vault item via ``PUT /object/item/{id}``.
 
@@ -573,24 +583,20 @@ class BitwardenServeClient:
             params={"itemid": item_id},
             files={"file": (filename, data)},
         )
-        if resp.status_code >= 400:
-            raise BitwardenClientError(
-                f"Attachment upload failed for {filename!r} on item {item_id}: "
-                f"HTTP {resp.status_code}"
-            )
-
         try:
             body: dict[str, Any] = resp.json()
-        except ValueError as exc:
-            raise BitwardenClientError(
-                f"Attachment upload returned non-JSON response "
-                f"(HTTP {resp.status_code}) for {filename!r} on item {item_id}"
-            ) from exc
+        except ValueError:
+            body = {}
 
-        if not body.get("success", False):
-            msg = body.get("message", "unknown error")
+        # bw serve reports command-level failures (e.g. "Premium status is
+        # required", storage-quota or attachment-size limits) as HTTP 400 with
+        # the real reason in the body's ``message`` field.  Surface it instead
+        # of an opaque status code so the user knows *why* a file was rejected.
+        if resp.status_code >= 400 or not body.get("success", False):
+            message = body.get("message") or f"HTTP {resp.status_code}"
             raise BitwardenClientError(
-                f"Attachment upload error for {filename!r}: {msg}"
+                f"Attachment upload failed for {filename!r} on item {item_id}: "
+                f"{message}"
             )
         logger.log(VERBOSE, f"Uploaded attachment {filename!r} to item {item_id}")
 
@@ -599,14 +605,18 @@ class BitwardenServeClient:
         items: list[tuple[str, list[tuple[str, bytes]]]],
         *,
         max_concurrency: int = 4,
-    ) -> None:
+    ) -> list[str]:
         """Upload all attachments with bounded parallelism.
 
         *items* is a list of ``(item_id, [(filename, data), ...])`` tuples.
+
+        Returns the labels of any uploads that failed (empty list when all
+        succeed).  Failures are **non-fatal**: a single rejected file must not
+        abort the whole migration and discard every other entry's progress.
         """
         total = sum(len(atts) for _, atts in items)
         if total == 0:
-            return
+            return []
 
         logger.info(f"Uploading {total} attachments (concurrency={max_concurrency})")
         sem = asyncio.Semaphore(max_concurrency)
@@ -641,24 +651,28 @@ class BitwardenServeClient:
             if isinstance(result, BaseException):
                 logger.error(f"Attachment upload failed for {label}: {result}")
                 failed_labels.append(label)
-        if failed_labels:
-            summary = ", ".join(failed_labels[:5])
-            if len(failed_labels) > 5:
-                summary += f", ... (+{len(failed_labels) - 5} more)"
-            raise BitwardenClientError(
-                f"{len(failed_labels)}/{total} attachment uploads failed: {summary}"
-            )
 
-        logger.info(f"Uploaded {total} attachments")
+        succeeded = total - len(failed_labels)
+        if failed_labels:
+            logger.warning(
+                f"{len(failed_labels)}/{total} attachment upload(s) failed; "
+                f"continuing with the remaining entries"
+            )
+        logger.info(f"Uploaded {succeeded}/{total} attachments")
+        return failed_labels
 
     def upload_attachments(
         self,
         items: list[tuple[str, list[tuple[str, bytes]]]],
         *,
         max_concurrency: int = 4,
-    ) -> None:
-        """Synchronous wrapper for :meth:`upload_attachments_parallel`."""
-        asyncio.run(
+    ) -> list[str]:
+        """Synchronous wrapper for :meth:`upload_attachments_parallel`.
+
+        Returns the labels of failed uploads (empty when all succeed); failures
+        are non-fatal so the migration completes and the caller can summarise.
+        """
+        return asyncio.run(
             self.upload_attachments_parallel(items, max_concurrency=max_concurrency)
         )
 

--- a/src/kp2bw/bw_types.py
+++ b/src/kp2bw/bw_types.py
@@ -29,6 +29,7 @@ from ._bw_api_types import (
 )
 
 __all__ = [
+    "BwAttachment",
     "BwCollection",
     "BwFido2Credential",
     "BwField",
@@ -69,6 +70,23 @@ class BwField(TypedDict):
     name: str
     value: str
     type: Literal[0, 1, 2, 3]  # text, hidden, boolean, linked
+
+
+class BwAttachment(TypedDict):
+    """Attachment metadata returned on an item response.
+
+    Absent from the request-only template schema; ``bw serve`` includes an
+    ``attachments`` array on item GET/LIST responses for items that have files.
+    Only ``id`` and ``fileName`` are relied on (for upload-if-missing dedup);
+    the rest are best-effort.
+    """
+
+    id: str
+    fileName: str
+    size: NotRequired[str]
+    sizeName: NotRequired[str]
+    url: NotRequired[str | None]
+    object: NotRequired[str]
 
 
 # ---------------------------------------------------------------------------
@@ -169,6 +187,7 @@ class BwItemResponse(_BwItemCommon):
     revisionDate: str
     deletedDate: NotRequired[str | None]
     login: NotRequired[BwItemLogin]  # absent on non-login vault items
+    attachments: NotRequired[list[BwAttachment] | None]  # present when files attached
 
 
 # ---------------------------------------------------------------------------

--- a/src/kp2bw/cli.py
+++ b/src/kp2bw/cli.py
@@ -161,9 +161,9 @@ def _argparser() -> MyArgParser:
         "--update",
         dest="update_existing",
         help=(
-            "Update existing Bitwarden entries when their KeePass content "
-            "changed; --no-update restores skip-only behavior "
-            "(default: on, env: KP2BW_UPDATE)"
+            "Sync changed KeePass content (and missing attachments) onto "
+            "existing Bitwarden entries; --no-update leaves their content "
+            "untouched (default: on, env: KP2BW_UPDATE)"
         ),
         action=BooleanOptionalAction,
         default=None,
@@ -372,10 +372,15 @@ def main() -> None:
         update_existing=update_existing,
     )
     try:
-        c.convert()
+        failures = c.convert()
     except KeyboardInterrupt:
         console.print("\n[yellow]Interrupted.[/yellow]")
         sys.exit(130)
+
+    # Exit non-zero on non-fatal failures (rejected updates/attachment uploads)
+    # so wrappers and CI can tell a partial migration from a clean one.
+    if failures:
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/src/kp2bw/cli.py
+++ b/src/kp2bw/cli.py
@@ -158,6 +158,17 @@ def _argparser() -> MyArgParser:
         default=None,
     )
     parser.add_argument(
+        "--update",
+        dest="update_existing",
+        help=(
+            "Update existing Bitwarden entries when their KeePass content "
+            "changed; --no-update restores skip-only behavior "
+            "(default: on, env: KP2BW_UPDATE)"
+        ),
+        action=BooleanOptionalAction,
+        default=None,
+    )
+    parser.add_argument(
         "-y",
         "--yes",
         dest="skip_confirm",
@@ -239,6 +250,14 @@ def main() -> None:
                 env_var="KP2BW_MIGRATE_METADATA",
             )
         )
+        update_existing = (
+            args.update_existing
+            if args.update_existing is not None
+            else _parse_bool_env(
+                os.environ.get("KP2BW_UPDATE"),
+                env_var="KP2BW_UPDATE",
+            )
+        )
         skip_confirm = (
             args.skip_confirm
             if args.skip_confirm is not None
@@ -280,6 +299,7 @@ def main() -> None:
     skip_expired = skip_expired if skip_expired is not None else False
     include_recyclebin = include_recyclebin if include_recyclebin is not None else False
     migrate_metadata = migrate_metadata if migrate_metadata is not None else True
+    update_existing = update_existing if update_existing is not None else True
     skip_confirm = skip_confirm if skip_confirm is not None else False
     verbose = verbose if verbose is not None else False
     debug = debug if debug is not None else False
@@ -349,6 +369,7 @@ def main() -> None:
         skip_expired=skip_expired,
         include_recyclebin=include_recyclebin,
         migrate_metadata=migrate_metadata,
+        update_existing=update_existing,
     )
     try:
         c.convert()

--- a/src/kp2bw/convert.py
+++ b/src/kp2bw/convert.py
@@ -917,7 +917,10 @@ class Converter:
                 f"-- Entry {name!r}: update failed, leaving the existing "
                 f"item unchanged: {exc}"
             )
-            outcome = "failed"
+            # The content/collection PUT was rejected, so leave the item wholly
+            # untouched: syncing attachments now would half-mutate it (stale
+            # login fields beside a freshly refreshed notes.txt).
+            return "failed", [], {}
 
         # Attachment sync: upload files the item is missing (so a
         # previously-skipped entry finally gets its notes.txt / long-field / file

--- a/src/kp2bw/convert.py
+++ b/src/kp2bw/convert.py
@@ -36,6 +36,9 @@ logger = logging.getLogger(__name__)
 KP_REF_IDENTIFIER: str = "{REF:"
 MAX_BW_ITEM_LENGTH: int = 10 * 1000
 KPEX_PASSKEY_PREFIX: str = "KPEX_PASSKEY_"
+# Bitwarden item type for login entries (1=login, 2=secureNote, 3=card,
+# 4=identity).  kp2bw only ever creates and content-syncs login items.
+BW_ITEM_TYPE_LOGIN: int = 1
 
 # Attachment-like: real pykeepass Attachment or (key, value) tuple for long fields
 type AttachmentItem = Attachment | tuple[str, str]
@@ -55,6 +58,7 @@ def _print_summary(
     n_skipped: int,
     n_collection_update: int,
     n_attachments: int,
+    n_update_failed: int,
     n_attach_failed: int,
 ) -> None:
     """Print a final migration summary to the shared rich console."""
@@ -69,6 +73,7 @@ def _print_summary(
                 n_skipped,
                 n_collection_update,
                 n_attachments,
+                n_update_failed,
                 n_attach_failed,
                 1,
             )
@@ -85,6 +90,11 @@ def _print_summary(
         )
     if n_attachments:
         console.print(f"  [cyan]{n_attachments:{w}d}[/cyan] attachments uploaded")
+    if n_update_failed:
+        console.print(
+            f"  [red]{n_update_failed:{w}d}[/red] entries failed to update "
+            f"(see warnings above)"
+        )
     if n_attach_failed:
         console.print(
             f"  [red]{n_attach_failed:{w}d}[/red] attachments failed "
@@ -592,28 +602,27 @@ class Converter:
         return collection_id
 
     @staticmethod
-    def _materialise_attachment(att: AttachmentItem) -> tuple[str, bytes]:
-        """Convert an AttachmentItem to a ``(filename, data)`` pair."""
-        if not isinstance(att, Attachment):
-            # Long custom property — (key, value) text tuple
-            name: str = att[0]
-            value: str = att[1]
-            return name + ".txt", value.encode("UTF-8")
-        # Real pykeepass Attachment
-        filename = att.filename if att.filename else "attachment"
-        data: bytes = att.data
-        return filename, data
-
-    @staticmethod
     def _attachment_filename(att: AttachmentItem) -> str:
         """Return the Bitwarden filename an AttachmentItem materialises to.
 
-        Mirrors :meth:`_materialise_attachment` without encoding the payload, so
-        upload-if-missing reconciliation can compare names cheaply.
+        Single source of truth for the naming rule, shared by
+        :meth:`_materialise_attachment` (which uploads) and upload-if-missing
+        reconciliation (which compares names without encoding the payload), so
+        the two can never drift apart.
         """
         if not isinstance(att, Attachment):
+            # Long custom property — (key, value) text tuple
             return att[0] + ".txt"
+        # Real pykeepass Attachment
         return att.filename if att.filename else "attachment"
+
+    @staticmethod
+    def _materialise_attachment(att: AttachmentItem) -> tuple[str, bytes]:
+        """Convert an AttachmentItem to a ``(filename, data)`` pair."""
+        name = Converter._attachment_filename(att)
+        if isinstance(att, Attachment):
+            return name, att.data
+        return name, att[1].encode("UTF-8")
 
     @staticmethod
     def _fields_signature(
@@ -676,8 +685,11 @@ class Converter:
         Starts from the existing item so server-managed and user-managed fields
         (``id``, ``favorite``, ``folderId``, ``organizationId``, collection
         membership) are preserved, then overwrites the fields kp2bw owns.
-        Collection IDs are unioned (the server unions too) so membership is only
-        ever added, never removed.  Existing passkeys are preserved when the
+        Collection IDs are only ever added to, never dropped: any target IDs are
+        appended to the existing ones, and the Bitwarden CLI additionally unions
+        the request against the item's real membership server-side, so a content
+        PUT cannot remove an item from a collection even though listed items
+        report ``collectionIds=null``.  Existing passkeys are preserved when the
         KeePass entry has none, so a re-run can't silently drop a Bitwarden-side
         FIDO2 credential.
         """
@@ -696,7 +708,8 @@ class Converter:
 
         target_colls = desired.get("collectionIds") or []
         existing_colls = existing.get("collectionIds") or []
-        payload["collectionIds"] = list(dict.fromkeys([*existing_colls, *target_colls]))
+        missing = [c for c in target_colls if c not in existing_colls]
+        payload["collectionIds"] = existing_colls + missing
         return payload
 
     @staticmethod
@@ -732,50 +745,64 @@ class Converter:
         attachments: list[AttachmentItem],
         *,
         fixed_coll_id: str | None,
-    ) -> tuple[str, list[AttachmentItem]]:
+    ) -> tuple[
+        Literal["updated", "collection", "skipped", "failed"], list[AttachmentItem]
+    ]:
         """Sync KeePass changes onto an item that already exists in the vault.
 
         Returns ``(outcome, missing_attachments)`` where *outcome* is one of
-        ``"updated"`` (content PUT), ``"collection"`` (membership-only PUT) or
-        ``"skipped"`` (no change), and *missing_attachments* are the files the
-        item does not yet have and that should be uploaded.
+        ``"updated"`` (content PUT), ``"collection"`` (membership-only PUT),
+        ``"skipped"`` (no change) or ``"failed"`` (the PUT was rejected), and
+        *missing_attachments* are the files the item does not yet have and that
+        should be uploaded.
         """
         name = bw_item["name"]
         item_id = existing["id"]
-        outcome = "skipped"
+        outcome: Literal["updated", "collection", "skipped", "failed"] = "skipped"
 
-        # Content sync: PUT only login-type items we own, and only when the
-        # KeePass-derived content actually changed (keeps re-runs idempotent).
-        if (
-            self._update_existing
-            and existing.get("type") == 1
-            and self._content_differs(existing, bw_item)
-        ):
-            payload = self._build_update_payload(existing, bw_item)
-            bw.update_item(item_id, payload)
-            bw.update_dedup_entry(folder, name, payload)
-            logger.log(VERBOSE, f"-- Entry {name!r}: content updated from KeePass")
-            outcome = "updated"
-        elif not fixed_coll_id:
-            # Collection-membership-only update (auto/org mode). bw serve returns
-            # collectionIds=null on listed items, so in fixed-collection mode we
-            # cannot (and need not) do the missing-check — the item is already in
-            # the scoped target collection.
-            target_colls: list[str] = bw_item.get("collectionIds") or []
-            existing_colls: list[str] = existing.get("collectionIds") or []
-            missing = [c for c in target_colls if c not in existing_colls]
-            if missing:
-                updated_item = copy.copy(existing)
-                updated_item["collectionIds"] = existing_colls + missing
-                bw.update_item(item_id, updated_item)
-                # Keep the cache fresh so a second KeePass entry with the same
-                # (folder, name) doesn't recompute stale collectionIds.
-                bw.update_dedup_entry(folder, name, updated_item)
-                logger.log(
-                    VERBOSE,
-                    f"-- Entry {name!r}: added to {len(missing)} collection(s)",
-                )
-                outcome = "collection"
+        # Content/collection sync. A rejected PUT here is non-fatal: one
+        # problematic entry must not abort the whole re-run and strand every
+        # entry after it (the same robustness the attachment phase has).
+        try:
+            # Content sync: PUT only login-type items we own, and only when the
+            # KeePass-derived content changed (keeps re-runs idempotent).
+            if (
+                self._update_existing
+                and existing.get("type") == BW_ITEM_TYPE_LOGIN
+                and self._content_differs(existing, bw_item)
+            ):
+                payload = self._build_update_payload(existing, bw_item)
+                bw.update_item(item_id, payload)
+                bw.update_dedup_entry(folder, name, payload)
+                logger.log(VERBOSE, f"-- Entry {name!r}: content updated from KeePass")
+                outcome = "updated"
+            elif not fixed_coll_id:
+                # Collection-membership-only update (auto/org mode). bw serve
+                # returns collectionIds=null on listed items, so in
+                # fixed-collection mode we cannot (and need not) do the
+                # missing-check — the item is already in the scoped target
+                # collection.
+                target_colls: list[str] = bw_item.get("collectionIds") or []
+                existing_colls: list[str] = existing.get("collectionIds") or []
+                missing = [c for c in target_colls if c not in existing_colls]
+                if missing:
+                    updated_item = copy.copy(existing)
+                    updated_item["collectionIds"] = existing_colls + missing
+                    bw.update_item(item_id, updated_item)
+                    # Keep the cache fresh so a second KeePass entry with the
+                    # same (folder, name) doesn't recompute stale collectionIds.
+                    bw.update_dedup_entry(folder, name, updated_item)
+                    logger.log(
+                        VERBOSE,
+                        f"-- Entry {name!r}: added to {len(missing)} collection(s)",
+                    )
+                    outcome = "collection"
+        except BitwardenClientError as exc:
+            logger.warning(
+                f"-- Entry {name!r}: update failed, leaving the existing "
+                f"item unchanged: {exc}"
+            )
+            outcome = "failed"
 
         # Attachment sync: upload only files the item is missing, so a
         # previously-skipped entry finally gets its notes.txt / long-field / file
@@ -798,8 +825,11 @@ class Converter:
 
         return outcome, missing_atts
 
-    def _create_bitwarden_items_for_entries(self) -> None:
-        """Create entries via ``bw serve`` HTTP API and upload attachments."""
+    def _create_bitwarden_items_for_entries(self) -> int:
+        """Create entries via ``bw serve`` HTTP API and upload attachments.
+
+        Returns the count of non-fatal failures (rejected updates + uploads).
+        """
         logger.info("Connecting and reading existing folders and entries")
 
         # When a fixed collection ID is given, scope the dedup index to that
@@ -817,6 +847,7 @@ class Converter:
         n_created = 0
         n_attachments = 0
         n_attach_failed = 0
+        n_update_failed = 0
         t_start = time.monotonic()
 
         progress = Progress(
@@ -843,6 +874,9 @@ class Converter:
             # Existing items needing only missing attachments uploaded:
             # (item_id, [attachments]).
             existing_uploads: list[tuple[str, list[AttachmentItem]]] = []
+            # Vault items already reconciled this run, so two KeePass entries
+            # sharing one (folder, name) don't double-PUT or double-upload.
+            reconciled_ids: set[str] = set()
 
             task1 = progress.add_task("Processing entries", total=len(self._entries))
             for key, entry_value in self._entries.items():
@@ -858,6 +892,15 @@ class Converter:
                 # missing attachments) instead of blindly skipping it.
                 existing = bw.get_existing_item(folder, bw_item["name"])
                 if existing is not None:
+                    # Two KeePass entries can map to the same vault item (same
+                    # folder + title); reconcile it once to avoid a redundant
+                    # PUT and a duplicate attachment upload.
+                    if existing["id"] in reconciled_ids:
+                        n_skipped += 1
+                        progress.advance(task1)
+                        continue
+                    reconciled_ids.add(existing["id"])
+
                     outcome, missing_atts = self._reconcile_existing_item(
                         bw,
                         existing,
@@ -870,10 +913,10 @@ class Converter:
                         n_updated += 1
                     elif outcome == "collection":
                         n_collection_update += 1
-                    elif missing_atts:
-                        # Attachment-only sync still counts as an update.
-                        n_updated += 1
-                    else:
+                    elif outcome == "failed":
+                        n_update_failed += 1
+                    else:  # "skipped" — content unchanged (attachments, if any,
+                        # are reported separately via the attachment counters).
                         n_skipped += 1
                     if missing_atts:
                         existing_uploads.append((existing["id"], missing_atts))
@@ -941,11 +984,17 @@ class Converter:
             n_skipped,
             n_collection_update,
             n_attachments,
+            n_update_failed,
             n_attach_failed,
         )
+        return n_update_failed + n_attach_failed
 
-    def convert(self) -> None:
-        """Run the full KeePass-to-Bitwarden migration pipeline."""
+    def convert(self) -> int:
+        """Run the full KeePass-to-Bitwarden migration pipeline.
+
+        Returns the number of non-fatal failures (rejected entry updates plus
+        rejected attachment uploads); ``0`` means everything succeeded.
+        """
         # load keepass data from database
         self._load_keepass_data()
 
@@ -953,4 +1002,4 @@ class Converter:
         self._resolve_entries_with_references()
 
         # store aggregated entries in bw
-        self._create_bitwarden_items_for_entries()
+        return self._create_bitwarden_items_for_entries()

--- a/src/kp2bw/convert.py
+++ b/src/kp2bw/convert.py
@@ -237,7 +237,7 @@ class Converter:
             organizationId=self._bitwarden_organization_id,
             collectionIds=[],
             folderId=None,
-            type=1,
+            type=BW_ITEM_TYPE_LOGIN,
             name=title,
             notes=notes,
             favorite=False,
@@ -874,9 +874,10 @@ class Converter:
             # Existing items needing only missing attachments uploaded:
             # (item_id, [attachments]).
             existing_uploads: list[tuple[str, list[AttachmentItem]]] = []
-            # Vault items already reconciled this run, so two KeePass entries
-            # sharing one (folder, name) don't double-PUT or double-upload.
-            reconciled_ids: set[str] = set()
+            # (item_id, filename) pairs already queued this run, so two KeePass
+            # entries sharing one (folder, name) can't upload the same file
+            # twice while each entry's *unique* attachments are still uploaded.
+            queued_atts: set[tuple[str, str]] = set()
 
             task1 = progress.add_task("Processing entries", total=len(self._entries))
             for key, entry_value in self._entries.items():
@@ -892,15 +893,7 @@ class Converter:
                 # missing attachments) instead of blindly skipping it.
                 existing = bw.get_existing_item(folder, bw_item["name"])
                 if existing is not None:
-                    # Two KeePass entries can map to the same vault item (same
-                    # folder + title); reconcile it once to avoid a redundant
-                    # PUT and a duplicate attachment upload.
-                    if existing["id"] in reconciled_ids:
-                        n_skipped += 1
-                        progress.advance(task1)
-                        continue
-                    reconciled_ids.add(existing["id"])
-
+                    item_id = existing["id"]
                     outcome, missing_atts = self._reconcile_existing_item(
                         bw,
                         existing,
@@ -918,8 +911,17 @@ class Converter:
                     else:  # "skipped" — content unchanged (attachments, if any,
                         # are reported separately via the attachment counters).
                         n_skipped += 1
-                    if missing_atts:
-                        existing_uploads.append((existing["id"], missing_atts))
+                    # Queue each missing file once per item, so two KeePass
+                    # entries collapsing to the same vault item don't upload a
+                    # shared file twice yet still contribute their unique files.
+                    unique_atts: list[AttachmentItem] = []
+                    for att in missing_atts:
+                        pair = (item_id, self._attachment_filename(att))
+                        if pair not in queued_atts:
+                            queued_atts.add(pair)
+                            unique_atts.append(att)
+                    if unique_atts:
+                        existing_uploads.append((item_id, unique_atts))
                     progress.advance(task1)
                     continue
 

--- a/src/kp2bw/convert.py
+++ b/src/kp2bw/convert.py
@@ -788,14 +788,17 @@ class Converter:
         return payload
 
     @staticmethod
-    def _existing_attachment_names(
+    def _existing_attachments(
         bw: BitwardenServeClient, item_id: str
-    ) -> set[str] | None:
-        """Return filenames already attached to *item_id*, or ``None`` on error.
+    ) -> dict[str, str] | None:
+        """Return ``{fileName: attachment_id}`` for *item_id*, or ``None`` on error.
 
-        Fetched authoritatively via GET so upload-if-missing never duplicates a
-        file.  ``None`` signals "could not determine" so the caller skips the
-        upload rather than risk a duplicate.
+        Fetched authoritatively via GET so reconciliation never duplicates a
+        file and can address an existing attachment by id when its content needs
+        refreshing.  ``None`` signals "could not determine" so the caller skips
+        the sync rather than risk a duplicate or a destructive delete.  When a
+        filename is somehow present more than once (a state kp2bw never creates),
+        the last id wins; the extra copy is harmless and collapses on a re-run.
         """
         try:
             item = bw.get_item(item_id)
@@ -806,10 +809,37 @@ class Converter:
             )
             return None
         return {
-            a.get("fileName", "")
+            name: att_id
             for a in (item.get("attachments") or [])
-            if a.get("fileName")
+            if (name := a.get("fileName", "")) and (att_id := a.get("id", ""))
         }
+
+    @staticmethod
+    def _attachment_content_differs(
+        bw: BitwardenServeClient,
+        item_id: str,
+        attachment_id: str,
+        att: AttachmentItem,
+    ) -> bool:
+        """True if the vault attachment's bytes differ from the KeePass source.
+
+        Lets an edited attachment that keeps the same filename (a refreshed
+        ``notes.txt`` recovery key, a swapped ``secret.jpg``) be replaced on a
+        re-run instead of going stale, while an unchanged file stays untouched
+        so the run remains idempotent.  If the existing bytes cannot be read the
+        attachment is treated as unchanged: that is the safe choice, since
+        re-uploading-and-deleting on an unreadable file risks losing it.
+        """
+        _name, desired = Converter._materialise_attachment(att)
+        try:
+            current = bw.get_attachment(item_id, attachment_id)
+        except BitwardenClientError:
+            logger.warning(
+                f"Could not read attachment {attachment_id!r} on item {item_id}; "
+                f"leaving it unchanged"
+            )
+            return False
+        return current != desired
 
     def _reconcile_existing_item(
         self,
@@ -821,15 +851,19 @@ class Converter:
         *,
         fixed_coll_id: str | None,
     ) -> tuple[
-        Literal["updated", "collection", "skipped", "failed"], list[AttachmentItem]
+        Literal["updated", "collection", "skipped", "failed"],
+        list[AttachmentItem],
+        dict[str, str],
     ]:
         """Sync KeePass changes onto an item that already exists in the vault.
 
-        Returns ``(outcome, missing_attachments)`` where *outcome* is one of
-        ``"updated"`` (content PUT), ``"collection"`` (membership-only PUT),
-        ``"skipped"`` (no change) or ``"failed"`` (the PUT was rejected), and
-        *missing_attachments* are the files the item does not yet have and that
-        should be uploaded.
+        Returns ``(outcome, upload_attachments, stale_by_name)`` where *outcome*
+        is one of ``"updated"`` (content PUT), ``"collection"`` (membership-only
+        PUT), ``"skipped"`` (no change) or ``"failed"`` (the PUT was rejected);
+        *upload_attachments* are the files to (re-)upload -- those the item does
+        not have yet plus those whose content changed; and *stale_by_name* maps
+        a changed file's name to the id of the stale copy to delete once its
+        replacement has been uploaded.
         """
         name = bw_item["name"]
         item_id = existing["id"]
@@ -843,7 +877,7 @@ class Converter:
                 VERBOSE,
                 f"-- Entry {name!r}: matched a non-login item, skipping",
             )
-            return outcome, []
+            return outcome, [], {}
 
         # Content/collection sync. A rejected PUT here is non-fatal: one
         # problematic entry must not abort the whole re-run and strand every
@@ -885,26 +919,34 @@ class Converter:
             )
             outcome = "failed"
 
-        # Attachment sync: upload only files the item is missing, so a
+        # Attachment sync: upload files the item is missing (so a
         # previously-skipped entry finally gets its notes.txt / long-field / file
-        # attachments without ever duplicating ones already present.
-        missing_atts: list[AttachmentItem] = []
+        # attachments) *and* refresh files whose content changed but kept the
+        # same name, never duplicating an identical one already present.
+        upload_atts: list[AttachmentItem] = []
+        stale_by_name: dict[str, str] = {}
         if self._update_existing and attachments:
-            existing_names = self._existing_attachment_names(bw, item_id)
-            if existing_names is not None:
-                missing_atts = [
-                    att
-                    for att in attachments
-                    if self._attachment_filename(att) not in existing_names
-                ]
+            existing_atts = self._existing_attachments(bw, item_id)
+            if existing_atts is not None:
+                for att in attachments:
+                    fname = self._attachment_filename(att)
+                    old_id = existing_atts.get(fname)
+                    if old_id is None:
+                        # Item doesn't have this file yet -- upload it.
+                        upload_atts.append(att)
+                    elif self._attachment_content_differs(bw, item_id, old_id, att):
+                        # Same name, changed bytes -- re-upload the new content
+                        # and mark the stale copy for deletion afterwards.
+                        upload_atts.append(att)
+                        stale_by_name[fname] = old_id
 
-        if outcome == "skipped" and not missing_atts:
+        if outcome == "skipped" and not upload_atts:
             logger.log(
                 VERBOSE,
                 f"-- Entry {name!r} unchanged in folder {folder!r}, skipping",
             )
 
-        return outcome, missing_atts
+        return outcome, upload_atts, stale_by_name
 
     def _create_bitwarden_items_for_entries(self) -> int:
         """Create entries via ``bw serve`` HTTP API and upload attachments.
@@ -959,6 +1001,10 @@ class Converter:
             # entries sharing one (folder, name) can't upload the same file
             # twice while each entry's *unique* attachments are still uploaded.
             queued_atts: set[tuple[str, str]] = set()
+            # Stale copies to remove after their replacement uploads, as
+            # (item_id, attachment_id, filename); the delete only fires once the
+            # matching (item_id, filename) upload has succeeded.
+            pending_deletes: list[tuple[str, str, str]] = []
 
             task1 = progress.add_task("Processing entries", total=len(self._entries))
             for key, entry_value in self._entries.items():
@@ -975,7 +1021,7 @@ class Converter:
                 existing = bw.get_existing_item(folder, bw_item["name"])
                 if existing is not None:
                     item_id = existing["id"]
-                    outcome, missing_atts = self._reconcile_existing_item(
+                    outcome, upload_atts, stale_by_name = self._reconcile_existing_item(
                         bw,
                         existing,
                         folder,
@@ -992,15 +1038,21 @@ class Converter:
                     else:  # "skipped" — content unchanged (attachments, if any,
                         # are reported separately via the attachment counters).
                         n_skipped += 1
-                    # Queue each missing file once per item, so two KeePass
-                    # entries collapsing to the same vault item don't upload a
-                    # shared file twice yet still contribute their unique files.
+                    # Queue each file once per item, so two KeePass entries
+                    # collapsing to the same vault item don't upload a shared
+                    # file twice yet still contribute their unique files. A
+                    # changed file's stale copy is scheduled for deletion only
+                    # alongside the queued replacement upload.
                     unique_atts: list[AttachmentItem] = []
-                    for att in missing_atts:
-                        pair = (item_id, self._attachment_filename(att))
+                    for att in upload_atts:
+                        fname = self._attachment_filename(att)
+                        pair = (item_id, fname)
                         if pair not in queued_atts:
                             queued_atts.add(pair)
                             unique_atts.append(att)
+                            old_id = stale_by_name.get(fname)
+                            if old_id is not None:
+                                pending_deletes.append((item_id, old_id, fname))
                     if unique_atts:
                         existing_uploads.append((item_id, unique_atts))
                     progress.advance(task1)
@@ -1058,6 +1110,25 @@ class Converter:
                 n_attach_failed = len(failed)
                 n_attachments = total_files - n_attach_failed
                 progress.update(task3, completed=len(upload_items))
+
+                # --- Phase 4: remove stale copies of refreshed attachments --
+                # Upload-then-delete: only drop the old copy once its
+                # replacement landed, so a failed re-upload never loses data. A
+                # failed delete is non-fatal (it just leaves a harmless extra
+                # copy that collapses on the next run).
+                if pending_deletes:
+                    failed_uploads = set(failed)
+                    for item_id, old_id, fname in pending_deletes:
+                        if (item_id, fname) in failed_uploads:
+                            continue
+                        try:
+                            bw.delete_attachment(item_id, old_id)
+                        except BitwardenClientError as exc:
+                            logger.warning(
+                                f"Could not remove the stale copy of {fname!r} "
+                                f"on item {item_id} (a duplicate may remain): "
+                                f"{exc}"
+                            )
 
         elapsed = time.monotonic() - t_start
         _print_summary(

--- a/src/kp2bw/convert.py
+++ b/src/kp2bw/convert.py
@@ -835,17 +835,23 @@ class Converter:
         item_id = existing["id"]
         outcome: Literal["updated", "collection", "skipped", "failed"] = "skipped"
 
+        # kp2bw only ever creates login items, so a non-login vault item sharing
+        # this (folder, name) is a name collision we must not mutate -- neither
+        # its content/collections nor (further down) its attachments.
+        if existing.get("type") != BW_ITEM_TYPE_LOGIN:
+            logger.log(
+                VERBOSE,
+                f"-- Entry {name!r}: matched a non-login item, skipping",
+            )
+            return outcome, []
+
         # Content/collection sync. A rejected PUT here is non-fatal: one
         # problematic entry must not abort the whole re-run and strand every
         # entry after it (the same robustness the attachment phase has).
         try:
-            # Content sync: PUT only login-type items we own, and only when the
-            # KeePass-derived content changed (keeps re-runs idempotent).
-            if (
-                self._update_existing
-                and existing.get("type") == BW_ITEM_TYPE_LOGIN
-                and self._content_differs(existing, bw_item)
-            ):
+            # Content sync: PUT only when the KeePass-derived content changed
+            # (keeps re-runs idempotent).
+            if self._update_existing and self._content_differs(existing, bw_item):
                 payload = self._build_update_payload(existing, bw_item)
                 bw.update_item(item_id, payload)
                 bw.update_dedup_entry(folder, name, payload)

--- a/src/kp2bw/convert.py
+++ b/src/kp2bw/convert.py
@@ -25,9 +25,10 @@ from .bw_types import (
     BwField,
     BwItemCreate,
     BwItemLogin,
+    BwItemResponse,
     BwUri,
 )
-from .exceptions import ConversionError
+from .exceptions import BitwardenClientError, ConversionError
 from .otp import resolve_otp
 
 logger = logging.getLogger(__name__)
@@ -50,24 +51,45 @@ type FieldSpec = tuple[str | None, Literal[0, 1, 2, 3]]
 def _print_summary(
     elapsed: float,
     n_created: int,
+    n_updated: int,
     n_skipped: int,
     n_collection_update: int,
     n_attachments: int,
+    n_attach_failed: int,
 ) -> None:
     """Print a final migration summary to the shared rich console."""
     m, s = divmod(int(elapsed), 60)
     duration = f"{m}m {s:02d}s" if m else f"{s}s"
     console.print(f"\nDone in [bold]{duration}[/bold]")
-    w = len(str(max(n_created, n_skipped, n_collection_update, n_attachments, 1)))
+    w = len(
+        str(
+            max(
+                n_created,
+                n_updated,
+                n_skipped,
+                n_collection_update,
+                n_attachments,
+                n_attach_failed,
+                1,
+            )
+        )
+    )
     console.print(f"  [green]{n_created:{w}d}[/green] created")
+    if n_updated:
+        console.print(f"  [blue]{n_updated:{w}d}[/blue] updated (changed in KeePass)")
     if n_skipped:
-        console.print(f"  [dim]{n_skipped:{w}d}[/dim] skipped (already in target)")
+        console.print(f"  [dim]{n_skipped:{w}d}[/dim] skipped (unchanged)")
     if n_collection_update:
         console.print(
             f"  [yellow]{n_collection_update:{w}d}[/yellow] added to collection"
         )
     if n_attachments:
         console.print(f"  [cyan]{n_attachments:{w}d}[/cyan] attachments uploaded")
+    if n_attach_failed:
+        console.print(
+            f"  [red]{n_attach_failed:{w}d}[/red] attachments failed "
+            f"(see warnings above)"
+        )
 
 
 class Converter:
@@ -83,6 +105,7 @@ class Converter:
     _skip_expired: bool
     _include_recyclebin: bool
     _migrate_metadata: bool
+    _update_existing: bool
     _kp_ref_entries: list[Entry]
     _entries: dict[str, EntryValue]
     _member_reference_resolving_dict: dict[str, str]
@@ -102,6 +125,7 @@ class Converter:
         skip_expired: bool = False,
         include_recyclebin: bool = False,
         migrate_metadata: bool = True,
+        update_existing: bool = True,
     ) -> None:
         """Initialise the converter with KeePass source and Bitwarden target settings."""
         self._keepass_file_path = keepass_file_path
@@ -116,6 +140,7 @@ class Converter:
         self._skip_expired = skip_expired
         self._include_recyclebin = include_recyclebin
         self._migrate_metadata = migrate_metadata
+        self._update_existing = update_existing
         self._kp_ref_entries = []
         self._entries = {}
 
@@ -579,6 +604,200 @@ class Converter:
         data: bytes = att.data
         return filename, data
 
+    @staticmethod
+    def _attachment_filename(att: AttachmentItem) -> str:
+        """Return the Bitwarden filename an AttachmentItem materialises to.
+
+        Mirrors :meth:`_materialise_attachment` without encoding the payload, so
+        upload-if-missing reconciliation can compare names cheaply.
+        """
+        if not isinstance(att, Attachment):
+            return att[0] + ".txt"
+        return att.filename if att.filename else "attachment"
+
+    @staticmethod
+    def _fields_signature(
+        fields: list[BwField] | None,
+    ) -> list[tuple[str, str, int]]:
+        """Order-independent (name, value, type) signature of custom fields."""
+        return sorted(
+            (
+                (f.get("name") or "", f.get("value") or "", f.get("type") or 0)
+                for f in (fields or [])
+            ),
+            key=lambda t: (t[0], t[2], t[1]),
+        )
+
+    @staticmethod
+    def _login_differs(existing: BwItemLogin | None, desired: BwItemLogin) -> bool:
+        """Compare the login fields kp2bw owns (creds, totp, URIs)."""
+        if existing is None:
+            existing = BwItemLogin(
+                uris=[],
+                username="",
+                password="",
+                totp=None,
+                passwordRevisionDate=None,
+            )
+        if (existing.get("username") or "") != (desired.get("username") or ""):
+            return True
+        if (existing.get("password") or "") != (desired.get("password") or ""):
+            return True
+        if (existing.get("totp") or "") != (desired.get("totp") or ""):
+            return True
+        ex_uris = [u.get("uri", "") for u in (existing.get("uris") or [])]
+        de_uris = [u.get("uri", "") for u in (desired.get("uris") or [])]
+        return ex_uris != de_uris
+
+    @classmethod
+    def _content_differs(cls, existing: BwItemResponse, desired: BwItemCreate) -> bool:
+        """True if the KeePass-derived content diverges from the vault item.
+
+        Compares only the fields kp2bw manages (name, notes, custom fields and
+        the login credentials/URIs) so an unchanged re-run stays idempotent and
+        never issues a redundant PUT.
+        """
+        if (existing.get("name") or "") != (desired.get("name") or ""):
+            return True
+        if (existing.get("notes") or "") != (desired.get("notes") or ""):
+            return True
+        if cls._fields_signature(existing.get("fields")) != cls._fields_signature(
+            desired.get("fields")
+        ):
+            return True
+        return cls._login_differs(existing.get("login"), desired["login"])
+
+    @staticmethod
+    def _build_update_payload(
+        existing: BwItemResponse, desired: BwItemCreate
+    ) -> BwItemResponse:
+        """Build a PUT body that syncs KeePass content onto an existing item.
+
+        Starts from the existing item so server-managed and user-managed fields
+        (``id``, ``favorite``, ``folderId``, ``organizationId``, collection
+        membership) are preserved, then overwrites the fields kp2bw owns.
+        Collection IDs are unioned (the server unions too) so membership is only
+        ever added, never removed.  Existing passkeys are preserved when the
+        KeePass entry has none, so a re-run can't silently drop a Bitwarden-side
+        FIDO2 credential.
+        """
+        payload: BwItemResponse = copy.copy(existing)
+        payload["name"] = desired["name"]
+        payload["notes"] = desired["notes"]
+        payload["fields"] = desired["fields"]
+
+        desired_login: BwItemLogin = copy.copy(desired["login"])
+        ex_login = existing.get("login")
+        if "fido2Credentials" not in desired_login and ex_login:
+            ex_fido2 = ex_login.get("fido2Credentials")
+            if ex_fido2:
+                desired_login["fido2Credentials"] = ex_fido2
+        payload["login"] = desired_login
+
+        target_colls = desired.get("collectionIds") or []
+        existing_colls = existing.get("collectionIds") or []
+        payload["collectionIds"] = list(dict.fromkeys([*existing_colls, *target_colls]))
+        return payload
+
+    @staticmethod
+    def _existing_attachment_names(
+        bw: BitwardenServeClient, item_id: str
+    ) -> set[str] | None:
+        """Return filenames already attached to *item_id*, or ``None`` on error.
+
+        Fetched authoritatively via GET so upload-if-missing never duplicates a
+        file.  ``None`` signals "could not determine" so the caller skips the
+        upload rather than risk a duplicate.
+        """
+        try:
+            item = bw.get_item(item_id)
+        except BitwardenClientError:
+            logger.warning(
+                f"Could not read existing attachments for item {item_id}; "
+                f"skipping its attachment sync to avoid duplicates"
+            )
+            return None
+        return {
+            a.get("fileName", "")
+            for a in (item.get("attachments") or [])
+            if a.get("fileName")
+        }
+
+    def _reconcile_existing_item(
+        self,
+        bw: BitwardenServeClient,
+        existing: BwItemResponse,
+        folder: str | None,
+        bw_item: BwItemCreate,
+        attachments: list[AttachmentItem],
+        *,
+        fixed_coll_id: str | None,
+    ) -> tuple[str, list[AttachmentItem]]:
+        """Sync KeePass changes onto an item that already exists in the vault.
+
+        Returns ``(outcome, missing_attachments)`` where *outcome* is one of
+        ``"updated"`` (content PUT), ``"collection"`` (membership-only PUT) or
+        ``"skipped"`` (no change), and *missing_attachments* are the files the
+        item does not yet have and that should be uploaded.
+        """
+        name = bw_item["name"]
+        item_id = existing["id"]
+        outcome = "skipped"
+
+        # Content sync: PUT only login-type items we own, and only when the
+        # KeePass-derived content actually changed (keeps re-runs idempotent).
+        if (
+            self._update_existing
+            and existing.get("type") == 1
+            and self._content_differs(existing, bw_item)
+        ):
+            payload = self._build_update_payload(existing, bw_item)
+            bw.update_item(item_id, payload)
+            bw.update_dedup_entry(folder, name, payload)
+            logger.log(VERBOSE, f"-- Entry {name!r}: content updated from KeePass")
+            outcome = "updated"
+        elif not fixed_coll_id:
+            # Collection-membership-only update (auto/org mode). bw serve returns
+            # collectionIds=null on listed items, so in fixed-collection mode we
+            # cannot (and need not) do the missing-check — the item is already in
+            # the scoped target collection.
+            target_colls: list[str] = bw_item.get("collectionIds") or []
+            existing_colls: list[str] = existing.get("collectionIds") or []
+            missing = [c for c in target_colls if c not in existing_colls]
+            if missing:
+                updated_item = copy.copy(existing)
+                updated_item["collectionIds"] = existing_colls + missing
+                bw.update_item(item_id, updated_item)
+                # Keep the cache fresh so a second KeePass entry with the same
+                # (folder, name) doesn't recompute stale collectionIds.
+                bw.update_dedup_entry(folder, name, updated_item)
+                logger.log(
+                    VERBOSE,
+                    f"-- Entry {name!r}: added to {len(missing)} collection(s)",
+                )
+                outcome = "collection"
+
+        # Attachment sync: upload only files the item is missing, so a
+        # previously-skipped entry finally gets its notes.txt / long-field / file
+        # attachments without ever duplicating ones already present.
+        missing_atts: list[AttachmentItem] = []
+        if self._update_existing and attachments:
+            existing_names = self._existing_attachment_names(bw, item_id)
+            if existing_names is not None:
+                missing_atts = [
+                    att
+                    for att in attachments
+                    if self._attachment_filename(att) not in existing_names
+                ]
+
+        if outcome == "skipped" and not missing_atts:
+            logger.log(
+                VERBOSE,
+                f"-- Entry {name!r} unchanged in folder {folder!r}, skipping",
+            )
+
+        return outcome, missing_atts
+
     def _create_bitwarden_items_for_entries(self) -> None:
         """Create entries via ``bw serve`` HTTP API and upload attachments."""
         logger.info("Connecting and reading existing folders and entries")
@@ -593,9 +812,11 @@ class Converter:
         )
 
         n_skipped = 0
+        n_updated = 0
         n_collection_update = 0
         n_created = 0
         n_attachments = 0
+        n_attach_failed = 0
         t_start = time.monotonic()
 
         progress = Progress(
@@ -619,6 +840,9 @@ class Converter:
             # --- Phase 1: Partition entries and resolve collections ----------
             import_entries: dict[str, tuple[str | None, BwItemCreate]] = {}
             attachment_map: dict[str, list[AttachmentItem]] = {}
+            # Existing items needing only missing attachments uploaded:
+            # (item_id, [attachments]).
+            existing_uploads: list[tuple[str, list[AttachmentItem]]] = []
 
             task1 = progress.add_task("Processing entries", total=len(self._entries))
             for key, entry_value in self._entries.items():
@@ -629,51 +853,30 @@ class Converter:
                 # Resolve collection (mutates bw_item)
                 self._resolve_collection(bw, bw_item, firstlevel)
 
-                # Dedup: skip items already in the vault.
-                #
-                # Fixed-collection mode: the dedup index is scoped to the
-                # target collection, so any hit means the item is already
-                # there.  bw serve returns collectionIds=null on listed items
-                # regardless of actual membership, so we cannot use the
-                # missing-check here — and we don't need to.
-                #
-                # Auto/no-collection mode: item may exist in the org but be
-                # absent from the automatically-resolved target collection;
-                # update its collection membership via PUT.
+                # An item with this (folder, name) already exists: sync any
+                # KeePass changes onto it (content, collection membership, and
+                # missing attachments) instead of blindly skipping it.
                 existing = bw.get_existing_item(folder, bw_item["name"])
                 if existing is not None:
-                    if fixed_coll_id:
-                        logger.log(
-                            VERBOSE,
-                            f"-- Entry {bw_item['name']!r} already in "
-                            f"target collection, skipping",
-                        )
-                        n_skipped += 1
+                    outcome, missing_atts = self._reconcile_existing_item(
+                        bw,
+                        existing,
+                        folder,
+                        bw_item,
+                        attachments,
+                        fixed_coll_id=fixed_coll_id,
+                    )
+                    if outcome == "updated":
+                        n_updated += 1
+                    elif outcome == "collection":
+                        n_collection_update += 1
+                    elif missing_atts:
+                        # Attachment-only sync still counts as an update.
+                        n_updated += 1
                     else:
-                        target_colls: list[str] = bw_item.get("collectionIds") or []
-                        existing_colls: list[str] = existing.get("collectionIds") or []
-                        missing = [c for c in target_colls if c not in existing_colls]
-                        if missing:
-                            updated_item = copy.copy(existing)
-                            updated_item["collectionIds"] = existing_colls + missing
-                            bw.update_item(existing["id"], updated_item)
-                            # Keep cache fresh so a second KeePass entry with
-                            # the same (folder, name) doesn't recompute stale
-                            # existing_colls and issue a redundant PUT.
-                            bw.update_dedup_entry(folder, bw_item["name"], updated_item)
-                            logger.log(
-                                VERBOSE,
-                                f"-- Entry {bw_item['name']!r}: added to "
-                                f"{len(missing)} collection(s)",
-                            )
-                            n_collection_update += 1
-                        else:
-                            logger.log(
-                                VERBOSE,
-                                f"-- Entry {bw_item['name']!r} already in "
-                                f"folder {folder!r}, skipping",
-                            )
-                            n_skipped += 1
+                        n_skipped += 1
+                    if missing_atts:
+                        existing_uploads.append((existing["id"], missing_atts))
                     progress.advance(task1)
                     continue
 
@@ -698,33 +901,47 @@ class Converter:
                 key_to_id = {}
 
             # --- Phase 3: Parallel attachment uploads -----------------------
-            if attachment_map:
-                upload_items: list[tuple[str, list[tuple[str, bytes]]]] = []
-                for key, attachments in attachment_map.items():
-                    item_id = key_to_id.get(key)
-                    if not item_id:
-                        _folder, bw_item = import_entries[key]
-                        logger.warning(
-                            f"Could not find item ID for {bw_item['name']!r} "
-                            f"in folder {_folder!r} for attachment upload"
-                        )
-                        continue
+            # Newly-created items (resolve their server-assigned IDs) and
+            # existing items missing attachments share one upload pass.
+            upload_items: list[tuple[str, list[tuple[str, bytes]]]] = []
+            for key, new_atts in attachment_map.items():
+                item_id = key_to_id.get(key)
+                if not item_id:
+                    _folder, miss_item = import_entries[key]
+                    logger.warning(
+                        f"Could not find item ID for {miss_item['name']!r} "
+                        f"in folder {_folder!r} for attachment upload"
+                    )
+                    continue
+                upload_items.append((
+                    item_id,
+                    [self._materialise_attachment(a) for a in new_atts],
+                ))
+            for item_id, existing_atts in existing_uploads:
+                upload_items.append((
+                    item_id,
+                    [self._materialise_attachment(a) for a in existing_atts],
+                ))
 
-                    file_pairs = [
-                        self._materialise_attachment(att) for att in attachments
-                    ]
-                    upload_items.append((item_id, file_pairs))
-
-                n_attachments = sum(len(fps) for _, fps in upload_items)
+            if upload_items:
+                total_files = sum(len(fps) for _, fps in upload_items)
                 task3 = progress.add_task(
                     "Uploading attachments", total=len(upload_items)
                 )
-                bw.upload_attachments(upload_items)
+                failed = bw.upload_attachments(upload_items)
+                n_attach_failed = len(failed)
+                n_attachments = total_files - n_attach_failed
                 progress.update(task3, completed=len(upload_items))
 
         elapsed = time.monotonic() - t_start
         _print_summary(
-            elapsed, n_created, n_skipped, n_collection_update, n_attachments
+            elapsed,
+            n_created,
+            n_updated,
+            n_skipped,
+            n_collection_update,
+            n_attachments,
+            n_attach_failed,
         )
 
     def convert(self) -> None:

--- a/tests/bw_serve_attachment_test.py
+++ b/tests/bw_serve_attachment_test.py
@@ -93,11 +93,25 @@ def assert_success_does_not_raise() -> None:
         raise AssertionError(f"unexpected attachment request: {path} {params}")
 
 
+def assert_command_error_on_2xx_is_surfaced() -> None:
+    # bw serve can report a command-level failure as HTTP 200 with
+    # success:false; the message must still be surfaced.
+    resp = _FakeResponse(200, {"success": False, "message": "attachment rejected"})
+    try:
+        _run_upload(resp)
+    except BitwardenClientError as exc:
+        if "attachment rejected" not in str(exc):
+            raise AssertionError(f"server message not surfaced: {exc}") from None
+        return
+    raise AssertionError("a success:false response must raise even on HTTP 200")
+
+
 def main() -> None:
     """Run the script-style assertions and report success."""
     assert_server_message_is_surfaced()
     assert_opaque_status_when_no_message()
     assert_success_does_not_raise()
+    assert_command_error_on_2xx_is_surfaced()
     print("bw serve attachment test passed")
 
 

--- a/tests/bw_serve_attachment_test.py
+++ b/tests/bw_serve_attachment_test.py
@@ -1,0 +1,105 @@
+"""Checks that attachment-upload errors surface the server's real reason (#11).
+
+``bw serve`` reports command-level failures (e.g. "Premium status is required",
+storage-quota or size limits) as HTTP 400 with the reason in the JSON body's
+``message`` field.  kp2bw used to discard the body and raise an opaque
+``HTTP 400``; these checks lock in that the real message is now reported.
+"""
+
+import asyncio
+from typing import Any, cast
+
+from kp2bw.bw_serve import BitwardenServeClient
+from kp2bw.exceptions import BitwardenClientError
+
+_NO_JSON = object()
+
+
+class _FakeResponse:
+    """Minimal httpx.Response stand-in for the attachment endpoint."""
+
+    def __init__(self, status_code: int, payload: Any) -> None:
+        self.status_code = status_code
+        self._payload = payload
+
+    def json(self) -> Any:
+        if self._payload is _NO_JSON:
+            raise ValueError("response body is not JSON")
+        return self._payload
+
+
+class _FakeAsyncClient:
+    """Records the POST and returns a canned response."""
+
+    def __init__(self, response: _FakeResponse) -> None:
+        self._response = response
+        self.posted: list[tuple[str, Any, Any]] = []
+
+    async def post(
+        self, path: str, *, params: Any = None, files: Any = None
+    ) -> _FakeResponse:
+        self.posted.append((path, params, files))
+        return self._response
+
+
+def _run_upload(response: _FakeResponse) -> _FakeAsyncClient:
+    """Invoke the (self-free) upload_attachment coroutine against a fake client."""
+    inst = object.__new__(BitwardenServeClient)  # no bw serve process spawned
+    client = _FakeAsyncClient(response)
+    asyncio.run(
+        inst.upload_attachment(
+            cast(Any, client), "item-1", "photo.jpg", b"\xff\xd8\xff"
+        )
+    )
+    return client
+
+
+def assert_server_message_is_surfaced() -> None:
+    resp = _FakeResponse(
+        400,
+        {
+            "success": False,
+            "message": "Premium status is required to use this feature.",
+        },
+    )
+    try:
+        _run_upload(resp)
+    except BitwardenClientError as exc:
+        text = str(exc)
+        if "Premium status is required" not in text:
+            raise AssertionError(f"server message not surfaced: {text!r}") from None
+        if "photo.jpg" not in text:
+            raise AssertionError(f"filename missing from error: {text!r}") from None
+        return
+    raise AssertionError("an HTTP 400 response must raise BitwardenClientError")
+
+
+def assert_opaque_status_when_no_message() -> None:
+    try:
+        _run_upload(_FakeResponse(400, _NO_JSON))
+    except BitwardenClientError as exc:
+        if "HTTP 400" not in str(exc):
+            raise AssertionError(f"expected HTTP 400 fallback, got: {exc}") from None
+        return
+    raise AssertionError("a non-JSON 400 must still raise")
+
+
+def assert_success_does_not_raise() -> None:
+    client = _run_upload(_FakeResponse(200, {"success": True, "data": {"id": "x"}}))
+    if not client.posted:
+        raise AssertionError("upload should POST to the attachment endpoint")
+    path, params, _files = client.posted[0]
+    if path != "/attachment" or params != {"itemid": "item-1"}:
+        raise AssertionError(f"unexpected attachment request: {path} {params}")
+
+
+def main() -> None:
+    """Run the script-style assertions and report success."""
+    assert_server_message_is_surfaced()
+    assert_opaque_status_when_no_message()
+    assert_success_does_not_raise()
+    print("bw serve attachment test passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/convert_update_test.py
+++ b/tests/convert_update_test.py
@@ -57,7 +57,7 @@ class UpdateTestConverter(Converter):
         attachments: list[AttachmentItem],
         *,
         fixed_coll_id: str | None,
-    ) -> tuple[str, list[AttachmentItem]]:
+    ) -> tuple[str, list[AttachmentItem], dict[str, str]]:
         """Public shim for existing-item reconciliation."""
         return self._reconcile_existing_item(
             bw, existing, folder, bw_item, attachments, fixed_coll_id=fixed_coll_id
@@ -126,14 +126,19 @@ class FakeBw:
         self,
         *,
         existing_attachments: list[dict[str, str]] | None = None,
+        attachment_bytes: dict[str, bytes] | None = None,
         fail_get: bool = False,
         fail_update: bool = False,
+        fail_get_attachment: bool = False,
     ) -> None:
         self.updates: list[tuple[str, BwItemResponse]] = []
         self.dedup_updates: list[tuple[str | None, str]] = []
+        self.deletes: list[tuple[str, str]] = []
         self._attachments = existing_attachments or []
+        self._attachment_bytes = attachment_bytes or {}
         self._fail_get = fail_get
         self._fail_update = fail_update
+        self._fail_get_attachment = fail_get_attachment
 
     def update_item(self, item_id: str, item: BwItemResponse) -> None:
         if self._fail_update:
@@ -149,6 +154,14 @@ class FakeBw:
         if self._fail_get:
             raise BitwardenClientError("simulated GET failure")
         return cast(BwItemResponse, {"id": item_id, "attachments": self._attachments})
+
+    def get_attachment(self, item_id: str, attachment_id: str) -> bytes:
+        if self._fail_get_attachment:
+            raise BitwardenClientError("simulated attachment download failure")
+        return self._attachment_bytes.get(attachment_id, b"")
+
+    def delete_attachment(self, item_id: str, attachment_id: str) -> None:
+        self.deletes.append((item_id, attachment_id))
 
 
 def _as_bw(fake: FakeBw) -> BitwardenServeClient:
@@ -271,7 +284,7 @@ def assert_update_payload_preserves_existing_passkey() -> None:
 def assert_unchanged_entry_is_skipped() -> None:
     conv = UpdateTestConverter()
     bw = FakeBw()
-    outcome, missing = conv.reconcile(
+    outcome, missing, _ = conv.reconcile(
         _as_bw(bw),
         _make_existing(),
         "folder-1",
@@ -288,7 +301,7 @@ def assert_unchanged_entry_is_skipped() -> None:
 def assert_changed_notes_trigger_update() -> None:
     conv = UpdateTestConverter()
     bw = FakeBw()
-    outcome, _ = conv.reconcile(
+    outcome, _, _ = conv.reconcile(
         _as_bw(bw),
         _make_existing(notes="old"),
         "folder-1",
@@ -308,7 +321,7 @@ def assert_missing_attachment_is_uploaded() -> None:
     conv = UpdateTestConverter()
     bw = FakeBw(existing_attachments=[])  # item has no attachments yet
     atts: list[AttachmentItem] = [("notes", "y" * 20000)]
-    outcome, missing = conv.reconcile(
+    outcome, missing, stale = conv.reconcile(
         _as_bw(bw),
         _make_existing(),
         "folder-1",
@@ -320,16 +333,23 @@ def assert_missing_attachment_is_uploaded() -> None:
         raise AssertionError(
             f"missing notes attachment should be queued, got {missing!r}"
         )
+    if stale:
+        raise AssertionError(f"a brand-new attachment has no stale copy, got {stale!r}")
     # Content unchanged, so the only reason this isn't pure-skip is the upload.
     if outcome != "skipped":
         raise AssertionError(f"expected content outcome 'skipped', got {outcome!r}")
 
 
-def assert_present_attachment_not_reuploaded() -> None:
+def assert_identical_attachment_not_reuploaded() -> None:
     conv = UpdateTestConverter()
-    bw = FakeBw(existing_attachments=[{"id": "att1", "fileName": "notes.txt"}])
+    # Existing notes.txt holds exactly the bytes the KeePass long note would
+    # materialise to, so an unchanged re-run must touch nothing.
+    bw = FakeBw(
+        existing_attachments=[{"id": "att1", "fileName": "notes.txt"}],
+        attachment_bytes={"att1": b"y" * 20000},
+    )
     atts: list[AttachmentItem] = [("notes", "y" * 20000)]
-    _, missing = conv.reconcile(
+    _, missing, stale = conv.reconcile(
         _as_bw(bw),
         _make_existing(),
         "folder-1",
@@ -338,14 +358,68 @@ def assert_present_attachment_not_reuploaded() -> None:
         fixed_coll_id=None,
     )
     if missing:
-        raise AssertionError("existing attachment must not be re-uploaded (no dups)")
+        raise AssertionError("identical attachment must not be re-uploaded (no dups)")
+    if stale:
+        raise AssertionError("identical attachment must not schedule a delete")
+
+
+def assert_changed_attachment_is_refreshed() -> None:
+    conv = UpdateTestConverter()
+    # Existing notes.txt holds stale bytes; the KeePass long note changed but
+    # keeps the same filename, so it must be re-uploaded and the old copy
+    # scheduled for deletion (content-aware reconciliation, issue #11).
+    bw = FakeBw(
+        existing_attachments=[{"id": "att1", "fileName": "notes.txt"}],
+        attachment_bytes={"att1": b"OLD recovery keys"},
+    )
+    atts: list[AttachmentItem] = [("notes", "y" * 20000)]
+    _, missing, stale = conv.reconcile(
+        _as_bw(bw),
+        _make_existing(),
+        "folder-1",
+        _make_desired(),
+        atts,
+        fixed_coll_id=None,
+    )
+    names = [name for name, _ in (cast(tuple[str, str], a) for a in missing)]
+    if names != ["notes"]:
+        raise AssertionError(
+            f"changed attachment should be re-uploaded, got {missing!r}"
+        )
+    if stale != {"notes.txt": "att1"}:
+        raise AssertionError(
+            f"stale copy should be scheduled for deletion, got {stale!r}"
+        )
+
+
+def assert_changed_attachment_safe_on_download_failure() -> None:
+    conv = UpdateTestConverter()
+    # The existing copy cannot be downloaded for comparison; we must not risk a
+    # re-upload-and-delete that could lose the only copy -- treat as unchanged.
+    bw = FakeBw(
+        existing_attachments=[{"id": "att1", "fileName": "notes.txt"}],
+        fail_get_attachment=True,
+    )
+    atts: list[AttachmentItem] = [("notes", "y" * 20000)]
+    _, missing, stale = conv.reconcile(
+        _as_bw(bw),
+        _make_existing(),
+        "folder-1",
+        _make_desired(),
+        atts,
+        fixed_coll_id=None,
+    )
+    if missing or stale:
+        raise AssertionError(
+            "on download failure, must not re-upload or delete (avoid data loss)"
+        )
 
 
 def assert_attachment_sync_safe_on_get_failure() -> None:
     conv = UpdateTestConverter()
     bw = FakeBw(fail_get=True)
     atts: list[AttachmentItem] = [("notes", "y" * 20000)]
-    _, missing = conv.reconcile(
+    _, missing, stale = conv.reconcile(
         _as_bw(bw),
         _make_existing(),
         "folder-1",
@@ -353,14 +427,14 @@ def assert_attachment_sync_safe_on_get_failure() -> None:
         atts,
         fixed_coll_id=None,
     )
-    if missing:
+    if missing or stale:
         raise AssertionError("on GET failure, must not upload (avoid duplicates)")
 
 
 def assert_rejected_update_is_non_fatal() -> None:
     conv = UpdateTestConverter()
     bw = FakeBw(fail_update=True)
-    outcome, _ = conv.reconcile(
+    outcome, _, _ = conv.reconcile(
         _as_bw(bw),
         _make_existing(notes="old"),
         "folder-1",
@@ -378,7 +452,7 @@ def assert_no_update_flag_restores_skip() -> None:
     conv = UpdateTestConverter(update_existing=False)
     bw = FakeBw(existing_attachments=[])
     atts: list[AttachmentItem] = [("notes", "y" * 20000)]
-    outcome, missing = conv.reconcile(
+    outcome, missing, _ = conv.reconcile(
         _as_bw(bw),
         _make_existing(notes="old"),
         "folder-1",
@@ -398,7 +472,7 @@ def assert_non_login_collision_is_not_mutated() -> None:
     atts: list[AttachmentItem] = [("notes", "y" * 20000)]
     # A secure note (type 2) sharing the (folder, name) must not receive the
     # KeePass login's content or attachments.
-    outcome, missing = conv.reconcile(
+    outcome, missing, stale = conv.reconcile(
         _as_bw(bw),
         _make_existing(type=2, notes="old"),
         "folder-1",
@@ -406,7 +480,7 @@ def assert_non_login_collision_is_not_mutated() -> None:
         atts,
         fixed_coll_id=None,
     )
-    if outcome != "skipped" or missing:
+    if outcome != "skipped" or missing or stale:
         raise AssertionError("non-login collision must be skipped with no uploads")
     if bw.updates:
         raise AssertionError("non-login collision must not issue a PUT")
@@ -426,7 +500,9 @@ def main() -> None:
     assert_unchanged_entry_is_skipped()
     assert_changed_notes_trigger_update()
     assert_missing_attachment_is_uploaded()
-    assert_present_attachment_not_reuploaded()
+    assert_identical_attachment_not_reuploaded()
+    assert_changed_attachment_is_refreshed()
+    assert_changed_attachment_safe_on_download_failure()
     assert_attachment_sync_safe_on_get_failure()
     assert_rejected_update_is_non_fatal()
     assert_no_update_flag_restores_skip()

--- a/tests/convert_update_test.py
+++ b/tests/convert_update_test.py
@@ -392,6 +392,26 @@ def assert_no_update_flag_restores_skip() -> None:
         raise AssertionError("--no-update must not issue any PUT")
 
 
+def assert_non_login_collision_is_not_mutated() -> None:
+    conv = UpdateTestConverter()
+    bw = FakeBw(existing_attachments=[])
+    atts: list[AttachmentItem] = [("notes", "y" * 20000)]
+    # A secure note (type 2) sharing the (folder, name) must not receive the
+    # KeePass login's content or attachments.
+    outcome, missing = conv.reconcile(
+        _as_bw(bw),
+        _make_existing(type=2, notes="old"),
+        "folder-1",
+        _make_desired(notes="new recovery keys"),
+        atts,
+        fixed_coll_id=None,
+    )
+    if outcome != "skipped" or missing:
+        raise AssertionError("non-login collision must be skipped with no uploads")
+    if bw.updates:
+        raise AssertionError("non-login collision must not issue a PUT")
+
+
 def main() -> None:
     """Run the script-style assertions and report success."""
     assert_identical_content_is_idempotent()
@@ -410,6 +430,7 @@ def main() -> None:
     assert_attachment_sync_safe_on_get_failure()
     assert_rejected_update_is_non_fatal()
     assert_no_update_flag_restores_skip()
+    assert_non_login_collision_is_not_mutated()
     print("convert update test passed")
 
 

--- a/tests/convert_update_test.py
+++ b/tests/convert_update_test.py
@@ -158,7 +158,16 @@ class FakeBw:
     def get_attachment(self, item_id: str, attachment_id: str) -> bytes:
         if self._fail_get_attachment:
             raise BitwardenClientError("simulated attachment download failure")
-        return self._attachment_bytes.get(attachment_id, b"")
+        # Fail loudly on an unexpected id: returning b"" would make a wrong-id
+        # fetch look like "stale content" and let a refresh-path test pass even
+        # if the converter asked for the wrong attachment. AssertionError (not
+        # BitwardenClientError) so it isn't swallowed by the differ's guard.
+        try:
+            return self._attachment_bytes[attachment_id]
+        except KeyError as exc:
+            raise AssertionError(
+                f"Fixture contract broken: unexpected attachment id {attachment_id!r}"
+            ) from exc
 
     def delete_attachment(self, item_id: str, attachment_id: str) -> None:
         self.deletes.append((item_id, attachment_id))
@@ -433,18 +442,25 @@ def assert_attachment_sync_safe_on_get_failure() -> None:
 
 def assert_rejected_update_is_non_fatal() -> None:
     conv = UpdateTestConverter()
-    bw = FakeBw(fail_update=True)
-    outcome, _, _ = conv.reconcile(
+    # Item has no attachments yet, so without the early return the rejected
+    # update would still queue this one — proving the guard, not just the label.
+    bw = FakeBw(fail_update=True, existing_attachments=[])
+    atts: list[AttachmentItem] = [("notes", "y" * 20000)]
+    outcome, upload, stale = conv.reconcile(
         _as_bw(bw),
         _make_existing(notes="old"),
         "folder-1",
         _make_desired(notes="new recovery keys"),
-        [],
+        atts,
         fixed_coll_id=None,
     )
     if outcome != "failed":
         raise AssertionError(
             f"a rejected update PUT must be reported as 'failed', got {outcome!r}"
+        )
+    if upload or stale:
+        raise AssertionError(
+            "a failed update must not sync attachments (no half-mutated item)"
         )
 
 

--- a/tests/convert_update_test.py
+++ b/tests/convert_update_test.py
@@ -1,0 +1,395 @@
+"""Unit checks for in-place update of existing Bitwarden entries (issue #11).
+
+Exercises the content-diff, update-payload, and existing-item reconciliation
+logic that lets a re-run sync changed KeePass entries (notably edited notes)
+onto already-imported Bitwarden items instead of skipping them.
+
+Protected members are exercised through a ``Converter`` subclass (mirroring
+``convert_ref_resolution_test``) so the checks stay type-clean.
+"""
+
+from typing import Any, cast
+
+from kp2bw.bw_serve import BitwardenServeClient
+from kp2bw.bw_types import BwItemCreate, BwItemResponse
+from kp2bw.convert import AttachmentItem, Converter
+from kp2bw.exceptions import BitwardenClientError
+
+
+class UpdateTestConverter(Converter):
+    """Converter wired with dummy credentials exposing the methods under test."""
+
+    def __init__(self, *, update_existing: bool = True) -> None:
+        """Build a converter that never connects to a live vault."""
+        super().__init__(
+            keepass_file_path="dummy.kdbx",
+            keepass_password="pw",
+            keepass_keyfile_path=None,
+            bitwarden_password="pw",
+            bitwarden_organization_id=None,
+            bitwarden_coll_id=None,
+            path2name=False,
+            path2nameskip=1,
+            import_tags=None,
+            update_existing=update_existing,
+        )
+
+    def diff(self, existing: BwItemResponse, desired: BwItemCreate) -> bool:
+        """Public shim for the content-diff check."""
+        return self._content_differs(existing, desired)
+
+    def payload(
+        self, existing: BwItemResponse, desired: BwItemCreate
+    ) -> BwItemResponse:
+        """Public shim for building the update payload."""
+        return self._build_update_payload(existing, desired)
+
+    def fields_sig(self, fields: list[Any]) -> list[tuple[str, str, int]]:
+        """Public shim for the field signature."""
+        return self._fields_signature(fields)
+
+    def reconcile(
+        self,
+        bw: BitwardenServeClient,
+        existing: BwItemResponse,
+        folder: str | None,
+        bw_item: BwItemCreate,
+        attachments: list[AttachmentItem],
+        *,
+        fixed_coll_id: str | None,
+    ) -> tuple[str, list[AttachmentItem]]:
+        """Public shim for existing-item reconciliation."""
+        return self._reconcile_existing_item(
+            bw, existing, folder, bw_item, attachments, fixed_coll_id=fixed_coll_id
+        )
+
+
+def _make_existing(**over: Any) -> BwItemResponse:
+    """Build an existing vault item (as returned by the dedup index)."""
+    item: dict[str, Any] = {
+        "object": "item",
+        "id": "item-1",
+        "organizationId": None,
+        "collectionIds": None,
+        "folderId": "folder-1",
+        "type": 1,
+        "name": "Account",
+        "notes": "old note",
+        "favorite": True,
+        "fields": [{"name": "api", "value": "v1", "type": 0}],
+        "login": {
+            "uris": [{"uri": "https://a", "match": None}],
+            "username": "user",
+            "password": "pass",
+            "totp": None,
+            "passwordRevisionDate": None,
+        },
+        "secureNote": None,
+        "card": None,
+        "identity": None,
+        "revisionDate": "2020-01-01T00:00:00Z",
+    }
+    item.update(over)
+    return cast(BwItemResponse, item)
+
+
+def _make_desired(**over: Any) -> BwItemCreate:
+    """Build a KeePass-derived item to migrate."""
+    item: dict[str, Any] = {
+        "organizationId": None,
+        "collectionIds": [],
+        "folderId": None,
+        "type": 1,
+        "name": "Account",
+        "notes": "old note",
+        "favorite": False,
+        "fields": [{"name": "api", "value": "v1", "type": 0}],
+        "login": {
+            "uris": [{"uri": "https://a", "match": None}],
+            "username": "user",
+            "password": "pass",
+            "totp": None,
+            "passwordRevisionDate": None,
+        },
+        "secureNote": None,
+        "card": None,
+        "identity": None,
+    }
+    item.update(over)
+    return cast(BwItemCreate, item)
+
+
+class FakeBw:
+    """Minimal BitwardenServeClient double for reconciliation tests."""
+
+    def __init__(
+        self,
+        *,
+        existing_attachments: list[dict[str, str]] | None = None,
+        fail_get: bool = False,
+    ) -> None:
+        self.updates: list[tuple[str, BwItemResponse]] = []
+        self.dedup_updates: list[tuple[str | None, str]] = []
+        self._attachments = existing_attachments or []
+        self._fail_get = fail_get
+
+    def update_item(self, item_id: str, item: BwItemResponse) -> None:
+        self.updates.append((item_id, item))
+
+    def update_dedup_entry(
+        self, folder: str | None, name: str, item: BwItemResponse
+    ) -> None:
+        self.dedup_updates.append((folder, name))
+
+    def get_item(self, item_id: str) -> BwItemResponse:
+        if self._fail_get:
+            raise BitwardenClientError("simulated GET failure")
+        return cast(BwItemResponse, {"id": item_id, "attachments": self._attachments})
+
+
+def _as_bw(fake: FakeBw) -> BitwardenServeClient:
+    """Treat the structural double as a client for the methods under test."""
+    return cast(BitwardenServeClient, fake)
+
+
+# --------------------------------------------------------------------------
+# Content diff
+# --------------------------------------------------------------------------
+
+
+def assert_identical_content_is_idempotent() -> None:
+    conv = UpdateTestConverter()
+    # favorite differs (True vs False) but kp2bw does not manage favorite, so
+    # identical synced content must NOT be treated as a change.
+    if conv.diff(_make_existing(), _make_desired()):
+        raise AssertionError("identical content should not be flagged as changed")
+
+
+def assert_notes_change_detected() -> None:
+    conv = UpdateTestConverter()
+    if not conv.diff(
+        _make_existing(notes="old note"), _make_desired(notes="new recovery keys")
+    ):
+        raise AssertionError("changed notes were not detected")
+
+
+def assert_none_vs_empty_notes_idempotent() -> None:
+    conv = UpdateTestConverter()
+    # bw serve returns notes=None for empty notes; desired uses "".
+    if conv.diff(_make_existing(notes=None), _make_desired(notes="")):
+        raise AssertionError("None vs empty notes should be treated as equal")
+
+
+def assert_password_change_detected() -> None:
+    conv = UpdateTestConverter()
+    desired = _make_desired()
+    desired["login"]["password"] = "new-pass"
+    if not conv.diff(_make_existing(), desired):
+        raise AssertionError("changed password was not detected")
+
+
+def assert_field_change_detected() -> None:
+    conv = UpdateTestConverter()
+    if not conv.diff(
+        _make_existing(),
+        _make_desired(fields=[{"name": "api", "value": "v2", "type": 0}]),
+    ):
+        raise AssertionError("changed custom field was not detected")
+
+
+def assert_uri_change_detected() -> None:
+    conv = UpdateTestConverter()
+    desired = _make_desired()
+    desired["login"]["uris"] = [{"uri": "https://b", "match": None}]
+    if not conv.diff(_make_existing(), desired):
+        raise AssertionError("changed URI was not detected")
+
+
+def assert_fields_signature_order_independent() -> None:
+    conv = UpdateTestConverter()
+    a = [
+        {"name": "x", "value": "1", "type": 0},
+        {"name": "y", "value": "2", "type": 0},
+    ]
+    b = list(reversed(a))
+    if conv.fields_sig(a) != conv.fields_sig(b):
+        raise AssertionError("field signature should be order-independent")
+
+
+# --------------------------------------------------------------------------
+# Update payload
+# --------------------------------------------------------------------------
+
+
+def assert_update_payload_preserves_and_overwrites() -> None:
+    conv = UpdateTestConverter()
+    existing = _make_existing(collectionIds=["c1"])
+    desired = _make_desired(notes="new note", collectionIds=["c2"])
+    payload = conv.payload(existing, desired)
+
+    if payload["id"] != "item-1":
+        raise AssertionError("update payload dropped the item id")
+    if payload["favorite"] is not True:
+        raise AssertionError("update payload clobbered the user's favorite flag")
+    if payload["folderId"] != "folder-1":
+        raise AssertionError("update payload dropped the existing folderId")
+    if payload["notes"] != "new note":
+        raise AssertionError("update payload did not overwrite notes")
+    if set(payload["collectionIds"] or []) != {"c1", "c2"}:
+        raise AssertionError(
+            f"collectionIds should union existing+target, got {payload['collectionIds']}"
+        )
+
+
+def assert_update_payload_preserves_existing_passkey() -> None:
+    conv = UpdateTestConverter()
+    fido2 = [{"credentialId": "abc", "keyType": "public-key"}]
+    existing = _make_existing()
+    ex_login = existing.get("login")
+    if ex_login is None:
+        raise AssertionError("fixture is missing its login object")
+    ex_login["fido2Credentials"] = cast(Any, fido2)
+    desired = _make_desired(notes="changed")
+    payload = conv.payload(existing, desired)
+    payload_login = payload.get("login")
+    got = payload_login.get("fido2Credentials") if payload_login else None
+    if got != fido2:
+        raise AssertionError(
+            "existing Bitwarden passkey must be preserved when KeePass has none"
+        )
+
+
+# --------------------------------------------------------------------------
+# Existing-item reconciliation
+# --------------------------------------------------------------------------
+
+
+def assert_unchanged_entry_is_skipped() -> None:
+    conv = UpdateTestConverter()
+    bw = FakeBw()
+    outcome, missing = conv.reconcile(
+        _as_bw(bw),
+        _make_existing(),
+        "folder-1",
+        _make_desired(),
+        [],
+        fixed_coll_id=None,
+    )
+    if outcome != "skipped" or missing:
+        raise AssertionError(f"unchanged entry should be skipped, got {outcome!r}")
+    if bw.updates:
+        raise AssertionError("unchanged entry must not issue a PUT")
+
+
+def assert_changed_notes_trigger_update() -> None:
+    conv = UpdateTestConverter()
+    bw = FakeBw()
+    outcome, _ = conv.reconcile(
+        _as_bw(bw),
+        _make_existing(notes="old"),
+        "folder-1",
+        _make_desired(notes="new recovery keys"),
+        [],
+        fixed_coll_id=None,
+    )
+    if outcome != "updated":
+        raise AssertionError(f"changed notes should update, got {outcome!r}")
+    if len(bw.updates) != 1 or bw.updates[0][1]["notes"] != "new recovery keys":
+        raise AssertionError("update PUT did not carry the new notes")
+    if not bw.dedup_updates:
+        raise AssertionError("dedup cache should be refreshed after update")
+
+
+def assert_missing_attachment_is_uploaded() -> None:
+    conv = UpdateTestConverter()
+    bw = FakeBw(existing_attachments=[])  # item has no attachments yet
+    atts: list[AttachmentItem] = [("notes", "y" * 20000)]
+    outcome, missing = conv.reconcile(
+        _as_bw(bw),
+        _make_existing(),
+        "folder-1",
+        _make_desired(),
+        atts,
+        fixed_coll_id=None,
+    )
+    if [name for name, _ in (cast(tuple[str, str], a) for a in missing)] != ["notes"]:
+        raise AssertionError(
+            f"missing notes attachment should be queued, got {missing!r}"
+        )
+    # Content unchanged, so the only reason this isn't pure-skip is the upload.
+    if outcome != "skipped":
+        raise AssertionError(f"expected content outcome 'skipped', got {outcome!r}")
+
+
+def assert_present_attachment_not_reuploaded() -> None:
+    conv = UpdateTestConverter()
+    bw = FakeBw(existing_attachments=[{"id": "att1", "fileName": "notes.txt"}])
+    atts: list[AttachmentItem] = [("notes", "y" * 20000)]
+    _, missing = conv.reconcile(
+        _as_bw(bw),
+        _make_existing(),
+        "folder-1",
+        _make_desired(),
+        atts,
+        fixed_coll_id=None,
+    )
+    if missing:
+        raise AssertionError("existing attachment must not be re-uploaded (no dups)")
+
+
+def assert_attachment_sync_safe_on_get_failure() -> None:
+    conv = UpdateTestConverter()
+    bw = FakeBw(fail_get=True)
+    atts: list[AttachmentItem] = [("notes", "y" * 20000)]
+    _, missing = conv.reconcile(
+        _as_bw(bw),
+        _make_existing(),
+        "folder-1",
+        _make_desired(),
+        atts,
+        fixed_coll_id=None,
+    )
+    if missing:
+        raise AssertionError("on GET failure, must not upload (avoid duplicates)")
+
+
+def assert_no_update_flag_restores_skip() -> None:
+    conv = UpdateTestConverter(update_existing=False)
+    bw = FakeBw(existing_attachments=[])
+    atts: list[AttachmentItem] = [("notes", "y" * 20000)]
+    outcome, missing = conv.reconcile(
+        _as_bw(bw),
+        _make_existing(notes="old"),
+        "folder-1",
+        _make_desired(notes="new"),
+        atts,
+        fixed_coll_id=None,
+    )
+    if outcome != "skipped" or missing:
+        raise AssertionError("--no-update must restore skip-only behavior")
+    if bw.updates:
+        raise AssertionError("--no-update must not issue any PUT")
+
+
+def main() -> None:
+    """Run the script-style assertions and report success."""
+    assert_identical_content_is_idempotent()
+    assert_notes_change_detected()
+    assert_none_vs_empty_notes_idempotent()
+    assert_password_change_detected()
+    assert_field_change_detected()
+    assert_uri_change_detected()
+    assert_fields_signature_order_independent()
+    assert_update_payload_preserves_and_overwrites()
+    assert_update_payload_preserves_existing_passkey()
+    assert_unchanged_entry_is_skipped()
+    assert_changed_notes_trigger_update()
+    assert_missing_attachment_is_uploaded()
+    assert_present_attachment_not_reuploaded()
+    assert_attachment_sync_safe_on_get_failure()
+    assert_no_update_flag_restores_skip()
+    print("convert update test passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/convert_update_test.py
+++ b/tests/convert_update_test.py
@@ -127,13 +127,17 @@ class FakeBw:
         *,
         existing_attachments: list[dict[str, str]] | None = None,
         fail_get: bool = False,
+        fail_update: bool = False,
     ) -> None:
         self.updates: list[tuple[str, BwItemResponse]] = []
         self.dedup_updates: list[tuple[str | None, str]] = []
         self._attachments = existing_attachments or []
         self._fail_get = fail_get
+        self._fail_update = fail_update
 
     def update_item(self, item_id: str, item: BwItemResponse) -> None:
+        if self._fail_update:
+            raise BitwardenClientError("simulated update rejection")
         self.updates.append((item_id, item))
 
     def update_dedup_entry(
@@ -353,6 +357,23 @@ def assert_attachment_sync_safe_on_get_failure() -> None:
         raise AssertionError("on GET failure, must not upload (avoid duplicates)")
 
 
+def assert_rejected_update_is_non_fatal() -> None:
+    conv = UpdateTestConverter()
+    bw = FakeBw(fail_update=True)
+    outcome, _ = conv.reconcile(
+        _as_bw(bw),
+        _make_existing(notes="old"),
+        "folder-1",
+        _make_desired(notes="new recovery keys"),
+        [],
+        fixed_coll_id=None,
+    )
+    if outcome != "failed":
+        raise AssertionError(
+            f"a rejected update PUT must be reported as 'failed', got {outcome!r}"
+        )
+
+
 def assert_no_update_flag_restores_skip() -> None:
     conv = UpdateTestConverter(update_existing=False)
     bw = FakeBw(existing_attachments=[])
@@ -387,6 +408,7 @@ def main() -> None:
     assert_missing_attachment_is_uploaded()
     assert_present_attachment_not_reuploaded()
     assert_attachment_sync_safe_on_get_failure()
+    assert_rejected_update_is_non_fatal()
     assert_no_update_flag_restores_skip()
     print("convert update test passed")
 

--- a/tests/e2e_vaultwarden_test.py
+++ b/tests/e2e_vaultwarden_test.py
@@ -4,8 +4,9 @@ import os
 import subprocess
 import tempfile
 from pathlib import Path
+from typing import cast
 
-from pykeepass import PyKeePass, create_database
+from pykeepass import Entry, PyKeePass, create_database
 
 logger = logging.getLogger("e2e")
 
@@ -175,6 +176,64 @@ def _create_keepass_snapshot(path: Path, password: str) -> None:
     kp.save()
 
 
+# Notes longer than this migrate to a notes.txt attachment (see convert.py).
+LONG_NOTE = "RECOVERY-KEY-" * 1000  # ~13k chars, comfortably over the 10k limit
+
+
+def _update_keepass_snapshot(path: Path, password: str) -> None:
+    """Edit an existing snapshot to exercise the re-run update path (issue #11).
+
+    Changes the Example entry's notes and password (credentials otherwise
+    unchanged in spirit) and adds an entry whose notes exceed the attachment
+    threshold, so a second migration must update the existing item and upload
+    the long note as a notes.txt attachment.
+    """
+    kp = PyKeePass(str(path), password=password)
+
+    # find_entries(first=True) is typed list|Entry|None; the snapshot always
+    # contains Example, so narrow to Entry for the field assignments below.
+    example = cast(Entry, kp.find_entries(title="Example", first=True))
+    example.notes = "updated recovery keys"
+    example.password = "demo-pass-v2"
+
+    _ = kp.add_entry(
+        kp.root_group,
+        "Big Note",
+        "big-user",
+        "big-pass",
+        notes=LONG_NOTE,
+    )
+
+    kp.save()
+
+
+def _run_migration(
+    snapshot_path: Path,
+    kp_password: str,
+    bw_password: str,
+    env: dict[str, str],
+) -> str:
+    """Run a single kp2bw migration pass against the snapshot."""
+    return _run(
+        [
+            "uv",
+            "run",
+            "kp2bw",
+            str(snapshot_path),
+            "--keepass-password",
+            kp_password,
+            "--bitwarden-password",
+            bw_password,
+            "--path-to-name-skip",
+            "999",
+            "--no-metadata",
+            "-y",
+            "-v",
+        ],
+        env=env,
+    )
+
+
 def _assert_bw_serve_available(env: dict[str, str]) -> None:
     """Verify the bw CLI supports ``bw serve`` (required by the new transport)."""
     result = subprocess.run(
@@ -236,45 +295,11 @@ def main() -> None:
         logger.info("Created KeePass snapshot")
 
         logger.info("Running kp2bw migration (first pass)")
-        _ = _run(
-            [
-                "uv",
-                "run",
-                "kp2bw",
-                str(snapshot_path),
-                "--keepass-password",
-                kp_password,
-                "--bitwarden-password",
-                bw_password,
-                "--path-to-name-skip",
-                "999",
-                "--no-metadata",
-                "-y",
-                "-v",
-            ],
-            env=env,
-        )
+        _ = _run_migration(snapshot_path, kp_password, bw_password, env)
         logger.info("First migration pass complete")
 
         logger.info("Running kp2bw migration (idempotency pass)")
-        _ = _run(
-            [
-                "uv",
-                "run",
-                "kp2bw",
-                str(snapshot_path),
-                "--keepass-password",
-                kp_password,
-                "--bitwarden-password",
-                bw_password,
-                "--path-to-name-skip",
-                "999",
-                "--no-metadata",
-                "-y",
-                "-v",
-            ],
-            env=env,
-        )
+        _ = _run_migration(snapshot_path, kp_password, bw_password, env)
         logger.info("Second migration pass complete")
 
         session = _get_session(env, bw_password)
@@ -370,6 +395,67 @@ def main() -> None:
         if len(items) < len(before_items) + 2:
             raise AssertionError(
                 "Expected at least two new items after migration, but item count did not grow"
+            )
+
+        # --- Update pass: edit KeePass, re-run, and verify the changes sync ---
+        logger.info("Editing KeePass snapshot and running update pass")
+        _update_keepass_snapshot(snapshot_path, kp_password)
+        _ = _run_migration(snapshot_path, kp_password, bw_password, env)
+        logger.info("Update migration pass complete")
+
+        session = _get_session(env, bw_password)
+        _ = _run(["bw", "sync", "--session", session], env=env)
+        items = _bw_json(env, "list", "items", "--session", session)
+
+        # Existing "Example" entry must be updated in place, not duplicated.
+        examples = [i for i in items if i.get("name") == "Example"]
+        if len(examples) != 1:
+            raise AssertionError(
+                f"Update must not duplicate entries; found {len(examples)} 'Example'"
+            )
+
+        example_full = json.loads(
+            _run(
+                ["bw", "get", "item", str(examples[0]["id"]), "--session", session],
+                env=env,
+            )
+        )
+        if example_full.get("notes") != "updated recovery keys":
+            raise AssertionError(
+                f"Edited notes were not synced to Bitwarden: {example_full.get('notes')!r}"
+            )
+        if example_full["login"]["password"] != "demo-pass-v2":
+            raise AssertionError("Edited password was not synced to Bitwarden")
+
+        # The long-note entry must store its note as a notes.txt attachment.
+        big_notes = [i for i in items if i.get("name") == "Big Note"]
+        if len(big_notes) != 1:
+            raise AssertionError(
+                f"Expected exactly one 'Big Note' entry, found {len(big_notes)}"
+            )
+        big_full = json.loads(
+            _run(
+                ["bw", "get", "item", str(big_notes[0]["id"]), "--session", session],
+                env=env,
+            )
+        )
+        attachments = big_full.get("attachments", [])
+        if not any(a.get("fileName") == "notes.txt" for a in attachments):
+            raise AssertionError(
+                f"Long note was not uploaded as a notes.txt attachment: {attachments}"
+            )
+        if len(big_full.get("notes", "")) > 10 * 1000:
+            raise AssertionError("Long note should be offloaded to the attachment")
+
+        # Re-running with no further edits must be idempotent (no duplicates).
+        _ = _run_migration(snapshot_path, kp_password, bw_password, env)
+        _ = _run(["bw", "sync", "--session", session], env=env)
+        items_after = _bw_json(env, "list", "items", "--session", session)
+        if len([i for i in items_after if i.get("name") == "Example"]) != 1:
+            raise AssertionError("Idempotent re-run duplicated the 'Example' entry")
+        if len(items_after) != len(items):
+            raise AssertionError(
+                f"Idempotent re-run changed item count: {len(items)} -> {len(items_after)}"
             )
 
     print("vaultwarden end-to-end integration test passed")

--- a/tests/e2e_vaultwarden_test.py
+++ b/tests/e2e_vaultwarden_test.py
@@ -210,6 +210,43 @@ def _update_keepass_snapshot(path: Path, password: str) -> None:
     kp.save()
 
 
+# A second long note (still over the 10k attachment threshold) used to verify
+# that an *edited* attachment keeping the same filename is refreshed in place on
+# a re-run instead of going stale or duplicating (issue #11).
+LONG_NOTE_V2 = "ROTATED-SECRET-" * 1000  # ~15k chars, comfortably over the limit
+
+
+def _edit_big_note_snapshot(path: Path, password: str, new_notes: str) -> None:
+    """Replace the Big Note entry's long note to exercise attachment refresh."""
+    kp = PyKeePass(str(path), password=password)
+    found = kp.find_entries(title="Big Note", first=True)
+    if found is None:
+        raise AssertionError("Fixture contract broken: 'Big Note' entry not found")
+    big = cast(Entry, found)
+    big.notes = new_notes
+    kp.save()
+
+
+def _get_attachment_text(
+    env: dict[str, str], session: str, item_id: str, file_name: str
+) -> str:
+    """Download a named attachment's decrypted text via the bw CLI."""
+    return _run(
+        [
+            "bw",
+            "get",
+            "attachment",
+            file_name,
+            "--itemid",
+            item_id,
+            "--raw",
+            "--session",
+            session,
+        ],
+        env=env,
+    )
+
+
 def _run_migration(
     snapshot_path: Path,
     kp_password: str,
@@ -450,6 +487,45 @@ def main() -> None:
         if len(big_full.get("notes") or "") > 10 * 1000:
             raise AssertionError("Long note should be offloaded to the attachment")
 
+        big_id = str(big_notes[0]["id"])
+        # The attachment must carry the original long note verbatim.
+        original_attachment = _get_attachment_text(env, session, big_id, "notes.txt")
+        if original_attachment != LONG_NOTE:
+            raise AssertionError(
+                "notes.txt attachment content does not match the original long note"
+            )
+
+        # --- Attachment refresh: edit the long note (same filename) and re-run.
+        # The notes.txt attachment must be replaced with the new content and the
+        # stale copy removed -- not left as a duplicate (content-aware sync, #11).
+        logger.info("Editing Big Note's long note and running attachment-refresh pass")
+        _edit_big_note_snapshot(snapshot_path, kp_password, LONG_NOTE_V2)
+        _ = _run_migration(snapshot_path, kp_password, bw_password, env)
+        session = _get_session(env, bw_password)
+        _ = _run(["bw", "sync", "--session", session], env=env)
+
+        big_full = json.loads(
+            _run(["bw", "get", "item", big_id, "--session", session], env=env)
+        )
+        notes_attachments = [
+            a
+            for a in big_full.get("attachments", [])
+            if a.get("fileName") == "notes.txt"
+        ]
+        if len(notes_attachments) != 1:
+            raise AssertionError(
+                f"Refreshed attachment must replace, not duplicate: {notes_attachments}"
+            )
+        refreshed_attachment = _get_attachment_text(env, session, big_id, "notes.txt")
+        if refreshed_attachment != LONG_NOTE_V2:
+            raise AssertionError(
+                "notes.txt attachment was not refreshed with the edited long note"
+            )
+
+        # Re-capture the post-refresh item list so the final idempotency check
+        # compares against the refreshed state.
+        items = _bw_json(env, "list", "items", "--session", session)
+
         # Re-running with no further edits must be idempotent (no duplicates).
         _ = _run_migration(snapshot_path, kp_password, bw_password, env)
         # kp2bw's `bw serve` rotates the shared CLI session, so re-acquire one
@@ -462,6 +538,21 @@ def main() -> None:
         if len(items_after) != len(items):
             raise AssertionError(
                 f"Idempotent re-run changed item count: {len(items)} -> {len(items_after)}"
+            )
+
+        # An unchanged attachment must not be re-uploaded or duplicated either:
+        # content-aware reconciliation has to see identical bytes and skip.
+        big_after = json.loads(
+            _run(["bw", "get", "item", big_id, "--session", session], env=env)
+        )
+        notes_after = [
+            a
+            for a in big_after.get("attachments", [])
+            if a.get("fileName") == "notes.txt"
+        ]
+        if len(notes_after) != 1:
+            raise AssertionError(
+                f"Idempotent re-run changed notes.txt copies: {len(notes_after)}"
             )
 
     print("vaultwarden end-to-end integration test passed")

--- a/tests/e2e_vaultwarden_test.py
+++ b/tests/e2e_vaultwarden_test.py
@@ -449,6 +449,9 @@ def main() -> None:
 
         # Re-running with no further edits must be idempotent (no duplicates).
         _ = _run_migration(snapshot_path, kp_password, bw_password, env)
+        # kp2bw's `bw serve` rotates the shared CLI session, so re-acquire one
+        # before querying again (a stale token returns an empty item list).
+        session = _get_session(env, bw_password)
         _ = _run(["bw", "sync", "--session", session], env=env)
         items_after = _bw_json(env, "list", "items", "--session", session)
         if len([i for i in items_after if i.get("name") == "Example"]) != 1:

--- a/tests/e2e_vaultwarden_test.py
+++ b/tests/e2e_vaultwarden_test.py
@@ -190,9 +190,12 @@ def _update_keepass_snapshot(path: Path, password: str) -> None:
     """
     kp = PyKeePass(str(path), password=password)
 
-    # find_entries(first=True) is typed list|Entry|None; the snapshot always
-    # contains Example, so narrow to Entry for the field assignments below.
-    example = cast(Entry, kp.find_entries(title="Example", first=True))
+    # find_entries(first=True) is typed list|Entry|None. Fail fast with a clear
+    # message if the snapshot's Example entry is missing, then narrow to Entry.
+    found = kp.find_entries(title="Example", first=True)
+    if found is None:
+        raise AssertionError("Fixture contract broken: 'Example' entry not found")
+    example = cast(Entry, found)
     example.notes = "updated recovery keys"
     example.password = "demo-pass-v2"
 
@@ -444,7 +447,7 @@ def main() -> None:
             raise AssertionError(
                 f"Long note was not uploaded as a notes.txt attachment: {attachments}"
             )
-        if len(big_full.get("notes", "")) > 10 * 1000:
+        if len(big_full.get("notes") or "") > 10 * 1000:
             raise AssertionError("Long note should be offloaded to the attachment")
 
         # Re-running with no further edits must be idempotent (no duplicates).

--- a/tests/e2e_vaultwarden_test.py
+++ b/tests/e2e_vaultwarden_test.py
@@ -504,6 +504,19 @@ def main() -> None:
         session = _get_session(env, bw_password)
         _ = _run(["bw", "sync", "--session", session], env=env)
 
+        # The refresh re-run must update in place, not spawn a second item:
+        # re-list by name and confirm there's still exactly one 'Big Note' with
+        # the same id (otherwise the attachment checks below could pass on the
+        # original item while a duplicate sinks idempotency). `items` is reused
+        # for the final idempotency check.
+        items = _bw_json(env, "list", "items", "--session", session)
+        big_after_refresh = [i for i in items if i.get("name") == "Big Note"]
+        if len(big_after_refresh) != 1 or str(big_after_refresh[0]["id"]) != big_id:
+            raise AssertionError(
+                f"Attachment-refresh re-run must not duplicate 'Big Note': "
+                f"{big_after_refresh}"
+            )
+
         big_full = json.loads(
             _run(["bw", "get", "item", big_id, "--session", session], env=env)
         )
@@ -521,10 +534,6 @@ def main() -> None:
             raise AssertionError(
                 "notes.txt attachment was not refreshed with the edited long note"
             )
-
-        # Re-capture the post-refresh item list so the final idempotency check
-        # compares against the refreshed state.
-        items = _bw_json(env, "list", "items", "--session", session)
 
         # Re-running with no further edits must be idempotent (no duplicates).
         _ = _run_migration(snapshot_path, kp_password, bw_password, env)

--- a/tests/test_script_adapters.py
+++ b/tests/test_script_adapters.py
@@ -19,12 +19,20 @@ def test_bw_serve_sanitization_script() -> None:
     _run_script_main("bw_serve_sanitization_test.py")
 
 
+def test_bw_serve_attachment_script() -> None:
+    _run_script_main("bw_serve_attachment_test.py")
+
+
 def test_otp_script() -> None:
     _run_script_main("otp_test.py")
 
 
 def test_convert_ref_resolution_script() -> None:
     _run_script_main("convert_ref_resolution_test.py")
+
+
+def test_convert_update_script() -> None:
+    _run_script_main("convert_update_test.py")
 
 
 def test_smoke_script() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -384,7 +384,7 @@ wheels = [
 
 [[package]]
 name = "kp2bw"
-version = "3.2.0"
+version = "3.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Fixes #11.

## Problem

Re-running `kp2bw` **skipped every entry that already existed**, so edits made in KeePass never reached Bitwarden. The reporter's exact case — open an existing entry, paste new recovery keys into the notes (credentials unchanged) — left the Bitwarden item untouched, making "purge the whole vault and re-import" the only reliable workflow. Two related symptoms fell out of the same root cause, plus one independent attachment bug.

## Root causes (verified against the `bw serve` source)

1. **Notes/content never updated** — `_create_bitwarden_items_for_entries` only ever *skipped* an existing item or added it to a collection. There was no content-update path at all.
2. **Long notes "only a few had attachments"** — notes >10k migrate to a `notes.txt` attachment, but existing entries were skipped wholesale, so their attachments were never uploaded. Only brand-new entries got them.
3. **`.jpg` attachment → `HTTP 400` aborts the run** — kp2bw's request is correct (confirmed: `pykeepass` returns valid bytes, and `@koa/multer` parses the binary fine). `bw serve`'s `processResponse` returns **HTTP 400 with the real reason in the body's `message`** (e.g. premium/storage limits), but `upload_attachment` discarded the body and showed only `HTTP 400`, and a single failure aborted the entire migration.

## Changes

- **Update existing entries in place.** Existing login items are diffed against the KeePass-derived content (notes, password, username, URIs, custom fields) and updated via an idempotent `PUT` — only when something actually changed, so an unchanged re-run issues no request and never duplicates. Collection membership is union-only (never removed); a Bitwarden-side `favorite` flag or a passkey absent from KeePass is preserved.
- **Upload missing attachments to existing entries**, deduped per `(item, filename)` so a shared file is uploaded once while each entry's unique files are preserved.
- **Surface the server's real error message** on attachment failure instead of an opaque `HTTP 400`, and make upload failures **non-fatal** — the migration completes and reports what failed instead of aborting.
- **Non-fatal entry updates** too: a rejected content/collection `PUT` is logged and counted rather than stranding every entry after it.
- **Exit non-zero** when there were non-fatal failures, so wrappers/CI can tell a partial migration from a clean one.
- **New `--update` / `--no-update` flag** (`KP2BW_UPDATE`, default on) to opt out and keep the old skip-only behaviour / preserve manual Bitwarden-side edits.

## Notes / scope

- `--update` makes **KeePass authoritative**: a re-run overwrites Bitwarden-side content edits for matched entries. Use `--no-update` to preserve them (documented in the README troubleshooting section).
- Known minor limitation: a note edited but still >10k chars won't refresh its existing `notes.txt` on re-run (the item's `notes` field stays empty, so there's no diff signal and comparing encrypted blobs isn't reliable). The reported case — short recovery-key notes, and missing attachments on previously-skipped entries — is fully fixed.

## Testing

- New `tests/convert_update_test.py` — content diff / idempotency, update-payload merge (id/favorite/folder/collection-union/passkey preservation), attachment upload-if-missing, GET-failure safety, non-fatal rejected update, and `--no-update`.
- New `tests/bw_serve_attachment_test.py` — server `message` is surfaced; non-JSON body handled without `AttributeError`.
- `tests/e2e_vaultwarden_test.py` extended with an edit-and-re-run pass asserting the update propagates, the `notes.txt` attachment is created, and the run stays idempotent.
- `pytest`, `ruff`, `basedpyright`, `ty`, and `dprint` all clean.

The diff went through three internal review→fix passes before this PR.