### PR TITLE
feat(serve): configurable per-request HTTP timeout (`KP2BW_HTTP_TIMEOUT`)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,3 +39,8 @@
 # Logging overrides (a full debug log is always written; these relocate it).
 #KP2BW_LOG_FILE=
 #KP2BW_LOG_DIR=
+
+# Transport tuning.
+# Per-request HTTP timeout to `bw serve`, in seconds (default 180). Raise this for
+# a slow self-hosted server (e.g. Vaultwarden) where individual item writes time out.
+#KP2BW_HTTP_TIMEOUT=180

--- a/.env.example
+++ b/.env.example
@@ -41,6 +41,8 @@
 #KP2BW_LOG_DIR=
 
 # Transport tuning.
-# Per-request HTTP timeout to `bw serve`, in seconds (default 180). Raise this for
-# a slow self-hosted server (e.g. Vaultwarden) where individual item writes time out.
+# Per-request HTTP timeout to `bw serve`, in seconds (default 180, max 3600).
+# Raise this for a slow self-hosted server (e.g. Vaultwarden) where individual
+# item writes time out. Applied as httpx's single timeout, so it stretches the
+# connect/read/write/pool phases together; values above 3600 are clamped.
 #KP2BW_HTTP_TIMEOUT=180

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,13 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **Configurable per-request HTTP timeout via `KP2BW_HTTP_TIMEOUT`** -- the timeout for a single `bw serve` request is
   now overridable through the `KP2BW_HTTP_TIMEOUT` environment variable (seconds), so a slow self-hosted server (e.g.
   Vaultwarden) where an individual item write outlasts the default no longer times out. Non-numeric or non-positive
-  values are ignored with a warning and the default is used. The built-in default is also raised from 60s to 180s, since
-  `bw serve` forwards writes to the (possibly remote) Bitwarden server and a single create can legitimately take longer
-  than local work. This complements the existing non-fatal-failure handling: raising the ceiling avoids the slow-request
-  failure in the first place, rather than only tolerating it on a re-run.
+  values are ignored with a warning and the default is used; values above the 3600s sanity ceiling are clamped (with a
+  warning) so a typo like `999999` can't silently hang a migration for hours. The value is applied as httpx's single
+  timeout, which stretches the connect/read/write/pool phases together rather than the slow-write phase alone. The
+  built-in default is also raised from 60s to 180s, since `bw serve` forwards writes to the (possibly remote) Bitwarden
+  server and a single create can legitimately take longer than local work. This complements the existing
+  non-fatal-failure handling: raising the ceiling avoids the slow-request failure in the first place, rather than only
+  tolerating it on a re-run.
 
 ## [3.5.0] - 2026-06-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ All notable changes to this project will be documented in this file.
 
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [Unreleased]
+
+### Added
+
+- **Configurable per-request HTTP timeout via `KP2BW_HTTP_TIMEOUT`** -- the timeout for a single `bw serve` request is
+  now overridable through the `KP2BW_HTTP_TIMEOUT` environment variable (seconds), so a slow self-hosted server (e.g.
+  Vaultwarden) where an individual item write outlasts the default no longer times out. Non-numeric or non-positive
+  values are ignored with a warning and the default is used. The built-in default is also raised from 60s to 180s, since
+  `bw serve` forwards writes to the (possibly remote) Bitwarden server and a single create can legitimately take longer
+  than local work. This complements the existing non-fatal-failure handling: raising the ceiling avoids the slow-request
+  failure in the first place, rather than only tolerating it on a re-run.
+
 ## [3.5.0] - 2026-06-10
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -134,6 +134,8 @@ Every run writes a full DEBUG log to a per-user file even when the console stays
 complete record to share. On Windows that is `%LOCALAPPDATA%\kp2bw\logs`; override the file with `KP2BW_LOG_FILE` or the
 directory with `KP2BW_LOG_DIR`. `bw serve` errors include the server's actual message, and a slow or dropped request no
 longer aborts the run — failed entries are counted in the summary and a re-run safely picks up where it left off.
+Against a slow self-hosted server (e.g. Vaultwarden) where individual writes time out, raise the per-request HTTP
+timeout with `KP2BW_HTTP_TIMEOUT` (seconds; default 180) to let those creates finish in the first place.
 
 See [TROUBLESHOOTING].
 

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ complete record to share. On Windows that is `%LOCALAPPDATA%\kp2bw\logs`; overri
 directory with `KP2BW_LOG_DIR`. `bw serve` errors include the server's actual message, and a slow or dropped request no
 longer aborts the run — failed entries are counted in the summary and a re-run safely picks up where it left off.
 Against a slow self-hosted server (e.g. Vaultwarden) where individual writes time out, raise the per-request HTTP
-timeout with `KP2BW_HTTP_TIMEOUT` (seconds; default 180) to let those creates finish in the first place.
+timeout with `KP2BW_HTTP_TIMEOUT` (seconds; default 180, capped at 3600) to let those creates finish in the first place.
 
 See [TROUBLESHOOTING].
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,12 @@ venv             = ".venv"
 typeCheckingMode = "strict"
 pythonVersion    = "3.14"
 
+# Tests legitimately exercise module-internal helpers (e.g. _resolve_http_timeout);
+# allow accessing private symbols there without weakening strict mode elsewhere.
+[[tool.pyright.executionEnvironments]]
+root               = "tests"
+reportPrivateUsage = "none"
+
 [tool.ruff]
 preview        = true
 target-version = "py314"

--- a/src/kp2bw/bw_serve.py
+++ b/src/kp2bw/bw_serve.py
@@ -34,8 +34,16 @@ _SERVE_POLL_INTERVAL_S: float = 0.25
 # Default HTTP timeout for individual requests. `bw serve` forwards item writes
 # to the (possibly self-hosted/remote) Bitwarden server, so a single create can
 # take far longer than local work; this ceiling is deliberately generous and is
-# overridable via `KP2BW_HTTP_TIMEOUT`.
+# overridable via `KP2BW_HTTP_TIMEOUT`. httpx interprets a bare float as the
+# *single* timeout applied to connect, read, write, and pool phases together --
+# raising it stretches all four, not just the slow-write phase that motivates it.
 _HTTP_TIMEOUT_S: float = 180.0
+
+# Sanity ceiling on `KP2BW_HTTP_TIMEOUT`. Above this the value is clamped (with
+# a warning) rather than honoured verbatim: a single HTTP request that hangs for
+# more than an hour is almost certainly a typo (e.g. `999999`) rather than a
+# real tuning need, and a typo here can silently stall a migration for hours.
+_HTTP_TIMEOUT_MAX_S: float = 3600.0
 
 # Env var overriding the per-request HTTP timeout, in seconds.
 _HTTP_TIMEOUT_ENV: str = "KP2BW_HTTP_TIMEOUT"
@@ -453,7 +461,13 @@ def _resolve_http_timeout() -> float:
     A slow or self-hosted Bitwarden/Vaultwarden server can make individual item
     writes take far longer than the default, so the env var lets users raise the
     ceiling without code changes. Non-numeric or non-positive values are ignored
-    with a warning and the built-in default is used.
+    with a warning and the built-in default is used. Values above
+    :data:`_HTTP_TIMEOUT_MAX_S` are clamped to that ceiling (with a warning) so a
+    typo like ``999999`` can't silently hang a migration for hours.
+
+    The returned float is handed to httpx as a single value, which applies it to
+    the *connect*, *read*, *write*, and *pool* phases together -- raising it
+    stretches all four, not just the slow-write phase that usually motivates it.
     """
     raw = os.environ.get(_HTTP_TIMEOUT_ENV)
     if not raw:
@@ -472,6 +486,13 @@ def _resolve_http_timeout() -> float:
             f"using default {_HTTP_TIMEOUT_S}s"
         )
         return _HTTP_TIMEOUT_S
+    if value > _HTTP_TIMEOUT_MAX_S:
+        logger.warning(
+            f"Clamping {_HTTP_TIMEOUT_ENV}={raw!r} to the {_HTTP_TIMEOUT_MAX_S}s "
+            f"sanity ceiling; a single request rarely needs longer and a typo "
+            f"here can hang the migration for hours"
+        )
+        return _HTTP_TIMEOUT_MAX_S
     return value
 
 

--- a/src/kp2bw/bw_serve.py
+++ b/src/kp2bw/bw_serve.py
@@ -31,8 +31,14 @@ _SERVE_STARTUP_TIMEOUT_S: float = 60.0
 # Polling interval when waiting for serve to start.
 _SERVE_POLL_INTERVAL_S: float = 0.25
 
-# Default HTTP timeout for individual requests.
-_HTTP_TIMEOUT_S: float = 60.0
+# Default HTTP timeout for individual requests. `bw serve` forwards item writes
+# to the (possibly self-hosted/remote) Bitwarden server, so a single create can
+# take far longer than local work; this ceiling is deliberately generous and is
+# overridable via `KP2BW_HTTP_TIMEOUT`.
+_HTTP_TIMEOUT_S: float = 180.0
+
+# Env var overriding the per-request HTTP timeout, in seconds.
+_HTTP_TIMEOUT_ENV: str = "KP2BW_HTTP_TIMEOUT"
 
 # Max length for sanitized CLI output snippets in logs/errors.
 _SANITIZED_OUTPUT_MAX_CHARS: int = 240
@@ -441,6 +447,34 @@ def _find_free_port() -> int:
         return s.getsockname()[1]
 
 
+def _resolve_http_timeout() -> float:
+    """Per-request HTTP timeout (seconds), overridable via ``KP2BW_HTTP_TIMEOUT``.
+
+    A slow or self-hosted Bitwarden/Vaultwarden server can make individual item
+    writes take far longer than the default, so the env var lets users raise the
+    ceiling without code changes. Non-numeric or non-positive values are ignored
+    with a warning and the built-in default is used.
+    """
+    raw = os.environ.get(_HTTP_TIMEOUT_ENV)
+    if not raw:
+        return _HTTP_TIMEOUT_S
+    try:
+        value = float(raw)
+    except ValueError:
+        logger.warning(
+            f"Ignoring invalid {_HTTP_TIMEOUT_ENV}={raw!r}; "
+            f"using default {_HTTP_TIMEOUT_S}s"
+        )
+        return _HTTP_TIMEOUT_S
+    if value <= 0:
+        logger.warning(
+            f"Ignoring non-positive {_HTTP_TIMEOUT_ENV}={raw!r}; "
+            f"using default {_HTTP_TIMEOUT_S}s"
+        )
+        return _HTTP_TIMEOUT_S
+    return value
+
+
 class BitwardenServeClient:
     """Manage a ``bw serve`` process and provide HTTP API access.
 
@@ -454,6 +488,7 @@ class BitwardenServeClient:
     _port: int
     _base_url: str
     _http: httpx.Client
+    _http_timeout: float  # per-request timeout shared by sync + async clients
     _previous_sigterm: Callable[[int, FrameType | None], Any] | int | None
     _previous_sigint: Callable[[int, FrameType | None], Any] | int | None
     _folders: dict[str, str]  # name → id cache
@@ -491,9 +526,10 @@ class BitwardenServeClient:
         self._base_url = f"http://127.0.0.1:{self._port}"
         self._process = None
         self._closed = False
+        self._http_timeout = _resolve_http_timeout()
         self._http = httpx.Client(
             base_url=self._base_url,
-            timeout=_HTTP_TIMEOUT_S,
+            timeout=self._http_timeout,
         )
         self._org_id = org_id
         self._collection_id = collection_id
@@ -1207,7 +1243,7 @@ class BitwardenServeClient:
 
         async with httpx.AsyncClient(
             base_url=self._base_url,
-            timeout=_HTTP_TIMEOUT_S,
+            timeout=self._http_timeout,
         ) as client:
             tasks: list[asyncio.Task[None]] = []
             keys: list[tuple[str, str]] = []

--- a/tests/bw_serve_timeout_test.py
+++ b/tests/bw_serve_timeout_test.py
@@ -1,0 +1,75 @@
+"""Checks the per-request HTTP timeout override (`KP2BW_HTTP_TIMEOUT`).
+
+`bw serve` forwards item writes to the (possibly self-hosted/remote) Bitwarden
+server, so a single create can outlast a short timeout. The default is
+deliberately generous and `KP2BW_HTTP_TIMEOUT` lets a user raise it further
+without code changes; bad values fall back to the default rather than crashing.
+These checks lock that parsing in, exercising the real resolver.
+"""
+
+import os
+from collections.abc import Generator
+from contextlib import contextmanager
+
+from kp2bw.bw_serve import (
+    _HTTP_TIMEOUT_ENV,
+    _HTTP_TIMEOUT_S,
+    _resolve_http_timeout,
+)
+
+
+@contextmanager
+def _env(value: str | None) -> Generator[None]:
+    """Set (or unset) KP2BW_HTTP_TIMEOUT for the block, restoring it after."""
+    saved = os.environ.get(_HTTP_TIMEOUT_ENV)
+    if value is None:
+        _ = os.environ.pop(_HTTP_TIMEOUT_ENV, None)
+    else:
+        os.environ[_HTTP_TIMEOUT_ENV] = value
+    try:
+        yield
+    finally:
+        if saved is None:
+            _ = os.environ.pop(_HTTP_TIMEOUT_ENV, None)
+        else:
+            os.environ[_HTTP_TIMEOUT_ENV] = saved
+
+
+def assert_unset_uses_default() -> None:
+    """No env var → the built-in default timeout."""
+    with _env(None):
+        got = _resolve_http_timeout()
+    if got != _HTTP_TIMEOUT_S:
+        raise AssertionError(f"expected default {_HTTP_TIMEOUT_S}, got {got}")
+
+
+def assert_valid_override_applied() -> None:
+    """A positive numeric value (int or float form) is used verbatim."""
+    with _env("300"):
+        if _resolve_http_timeout() != 300.0:
+            raise AssertionError("integer override not applied")
+    with _env("12.5"):
+        if _resolve_http_timeout() != 12.5:
+            raise AssertionError("float override not applied")
+
+
+def assert_invalid_falls_back() -> None:
+    """Non-numeric, non-positive, and blank values fall back to the default."""
+    for bad in ("abc", "0", "-5", "", "   "):
+        with _env(bad):
+            got = _resolve_http_timeout()
+        if got != _HTTP_TIMEOUT_S:
+            raise AssertionError(
+                f"{bad!r} should fall back to {_HTTP_TIMEOUT_S}, got {got}"
+            )
+
+
+def main() -> None:
+    assert_unset_uses_default()
+    assert_valid_override_applied()
+    assert_invalid_falls_back()
+    print("bw serve timeout override test passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/bw_serve_timeout_test.py
+++ b/tests/bw_serve_timeout_test.py
@@ -13,6 +13,7 @@ from contextlib import contextmanager
 
 from kp2bw.bw_serve import (
     _HTTP_TIMEOUT_ENV,
+    _HTTP_TIMEOUT_MAX_S,
     _HTTP_TIMEOUT_S,
     _resolve_http_timeout,
 )
@@ -64,10 +65,32 @@ def assert_invalid_falls_back() -> None:
             )
 
 
+def assert_above_cap_clamps() -> None:
+    """A value above the sanity ceiling is clamped, not honoured verbatim.
+
+    The user clearly meant to raise the timeout (so falling back to the default
+    would discard intent), but a typo like ``999999`` shouldn't silently hang a
+    migration for hours -- so the resolver clamps to the documented ceiling.
+    """
+    huge = str(_HTTP_TIMEOUT_MAX_S * 10)
+    with _env(huge):
+        got = _resolve_http_timeout()
+    if got != _HTTP_TIMEOUT_MAX_S:
+        raise AssertionError(
+            f"{huge!r} should clamp to {_HTTP_TIMEOUT_MAX_S}, got {got}"
+        )
+    # Exactly the cap is honoured (boundary case: only *above* gets clamped).
+    with _env(str(_HTTP_TIMEOUT_MAX_S)):
+        got = _resolve_http_timeout()
+    if got != _HTTP_TIMEOUT_MAX_S:
+        raise AssertionError(f"the cap itself should be honoured verbatim, got {got}")
+
+
 def main() -> None:
     assert_unset_uses_default()
     assert_valid_override_applied()
     assert_invalid_falls_back()
+    assert_above_cap_clamps()
     print("bw serve timeout override test passed")
 
 

--- a/tests/test_script_adapters.py
+++ b/tests/test_script_adapters.py
@@ -35,6 +35,10 @@ def test_bw_serve_batch_script() -> None:
     _run_script_main("bw_serve_batch_test.py")
 
 
+def test_bw_serve_timeout_script() -> None:
+    _run_script_main("bw_serve_timeout_test.py")
+
+
 def test_otp_script() -> None:
     _run_script_main("otp_test.py")
 


### PR DESCRIPTION
## What

Make the `bw serve` per-request HTTP timeout tunable, and raise its default.

- New env var **`KP2BW_HTTP_TIMEOUT`** (seconds) overrides the per-request timeout. Non-numeric or non-positive values are ignored with a warning and the default is used.
- Default raised **60s → 180s**: `bw serve` forwards item writes to the (possibly remote/self-hosted) Bitwarden server, so a single create can legitimately outlast a short local timeout.
- Wired into both the sync `httpx.Client` and the async attachment client via a shared `_http_timeout`.

## Why

This is a **feature, not a fix** — the #24 crash itself is already resolved on `master` (`b28d47c`, per-entry create failures non-fatal). The two are complementary:

| `b28d47c` (already shipped) | this PR |
|---|---|
| **Tolerates** a slow/dropped create — skip, report, re-run heals via UUID dedup | **Prevents** it — bigger ceiling + per-user override so the write finishes first time |

Against a sluggish self-hosted Vaultwarden, raising the timeout lets a migration complete in one pass instead of relying on a second run.

## Tests / gates

- New `tests/bw_serve_timeout_test.py`: unset→default, valid int/float override, fallback for `abc`/`0`/`-5`/`""`/whitespace. Registered in the script-adapter suite.
- `pyproject.toml`: scoped `reportPrivateUsage = "none"` for `tests/` (execution environment) so tests may exercise module internals — no `Any`, no inline ignores, strict mode untouched for `src/`.
- Green: ruff · ty · basedpyright (0) · dprint · pytest 13 passed / 4 skipped.

Docs: README troubleshooting note + `.env.example` + CHANGELOG (Unreleased).