### PR TITLE
feat(cli): `--strip-ids` finalize mode to remove `KP2BW_ID` dedup stamps

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,3 +39,8 @@
 # Logging overrides (a full debug log is always written; these relocate it).
 #KP2BW_LOG_FILE=
 #KP2BW_LOG_DIR=
+
+# Finalize mode. When set, kp2bw removes the KP2BW_ID dedup stamp from every
+# migrated item and exits (no migration; no KeePass database needed). Run once
+# the migration is complete and you're ready to fully adopt Bitwarden.
+#KP2BW_STRIP_IDS=0

--- a/.gitignore
+++ b/.gitignore
@@ -395,3 +395,4 @@ $RECYCLE.BIN/
 .envrc
 .env
 !.env.example
+vendor/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ All notable changes to this project will be documented in this file.
 
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [Unreleased]
+
+### Added
+
+- **`--strip-ids` finalize mode (env `KP2BW_STRIP_IDS`) to remove kp2bw's `KP2BW_ID` dedup stamps** -- every migrated
+  item carries a hidden `KP2BW_ID` custom field (the KeePass UUID kp2bw matches on for idempotent re-runs). Once a user
+  is satisfied the migration is complete and ready to fully adopt Bitwarden, `kp2bw --strip-ids` removes that stamp from
+  every migrated item and exits -- no KeePass database is read, no migration runs. Scope follows `-o`/`-c` exactly as a
+  migration would; other vault data is untouched. The mutation is gated behind a confirmation (skippable with `-y`) and
+  is safe to repeat (a second pass finds nothing). After stripping, a later migration re-matches by folder + name (and
+  re-stamps) rather than by UUID, so idempotency is not permanently lost -- this is simply the intended last step.
+
 ## [3.5.0] - 2026-06-10
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,11 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Added
 
 - **`--strip-ids` finalize mode (env `KP2BW_STRIP_IDS`) to remove kp2bw's `KP2BW_ID` dedup stamps** -- every migrated
-  item carries a hidden `KP2BW_ID` custom field (the KeePass UUID kp2bw matches on for idempotent re-runs). Once a user
-  is satisfied the migration is complete and ready to fully adopt Bitwarden, `kp2bw --strip-ids` removes that stamp from
-  every migrated item and exits -- no KeePass database is read, no migration runs. Scope follows `-o`/`-c` exactly as a
-  migration would; other vault data is untouched. The strip itself is safe to repeat (a second pass finds nothing), but
-  it is **irreversible** and makes future migration re-runs unreliable: without the stamp a re-run falls back to
+  item carries a plain-text `KP2BW_ID` custom field (the KeePass UUID kp2bw matches on for idempotent re-runs). Once a
+  user is satisfied the migration is complete and ready to fully adopt Bitwarden, `kp2bw --strip-ids` removes that stamp
+  from every migrated item and exits -- no KeePass database is read, no migration runs. Scope follows `-o`/`-c` exactly
+  as a migration would; other vault data is untouched. The strip itself is safe to repeat (a second pass finds nothing),
+  but it is **irreversible** and makes future migration re-runs unreliable: without the stamp a re-run falls back to
   folder + name matching -- the exact collision the stamp disambiguates -- so entries sharing a folder and title can be
   duplicated or mismatched. Because of that it confirms before changing anything (skippable with `-y` for callers who
   know what they want) -- a deliberate final step, not a routine flag.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [Unreleased]
+## [Unreleased] <!-- #28 -->
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,11 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   item carries a hidden `KP2BW_ID` custom field (the KeePass UUID kp2bw matches on for idempotent re-runs). Once a user
   is satisfied the migration is complete and ready to fully adopt Bitwarden, `kp2bw --strip-ids` removes that stamp from
   every migrated item and exits -- no KeePass database is read, no migration runs. Scope follows `-o`/`-c` exactly as a
-  migration would; other vault data is untouched. The mutation is gated behind a confirmation (skippable with `-y`) and
-  is safe to repeat (a second pass finds nothing). After stripping, a later migration re-matches by folder + name (and
-  re-stamps) rather than by UUID, so idempotency is not permanently lost -- this is simply the intended last step.
+  migration would; other vault data is untouched. The strip itself is safe to repeat (a second pass finds nothing), but
+  it is **irreversible** and makes future migration re-runs unreliable: without the stamp a re-run falls back to
+  folder + name matching -- the exact collision the stamp disambiguates -- so entries sharing a folder and title can be
+  duplicated or mismatched. Because of that it confirms before changing anything (skippable with `-y` for callers who
+  know what they want) -- a deliberate final step, not a routine flag.
 
 ## [3.5.0] - 2026-06-10
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ kp2bw [-h] [-V] [-k PASSWORD] [-K FILE] [-b PASSWORD] [-o ID]
        [--path-to-name-skip N] [--skip-expired | --no-skip-expired]
        [--include-recycle-bin | --no-include-recycle-bin]
        [--metadata | --no-metadata] [--update | --no-update]
-       [--include-oversize-secrets] [-y] [-v] [-d]
+       [--include-oversize-secrets] [--strip-ids] [-y] [-v] [-d]
        [FILE]
 ```
 
@@ -105,12 +105,26 @@ kp2bw [-h] [-V] [-k PASSWORD] [-K FILE] [-b PASSWORD] [-o ID]
 | `--metadata` / `--no-metadata`         | Toggle KeePass tags/expiry as a `KP2BW_META` field (default: on)                                          | `KP2BW_MIGRATE_METADATA`              |
 | `--update` / `--no-update`             | Update existing entries changed in KeePass (default: on)                                                  | `KP2BW_UPDATE`                        |
 | `--include-oversize-secrets`           | Offload over-limit secret fields[^offload] to a `.txt` attachment instead of dropping them (default: off) | `KP2BW_INCLUDE_OVERSIZE_SECRETS`      |
+| `--strip-ids`                          | Finalize: remove the `KP2BW_ID` dedup stamp from migrated items, then exit (no migration; no KeePass db)  | `KP2BW_STRIP_IDS`                     |
 | `-y, --yes`                            | Skip the Bitwarden CLI setup confirmation prompt                                                          | `KP2BW_YES`                           |
 | `-v, --verbose`                        | Verbose output                                                                                            | `KP2BW_VERBOSE`                       |
 | `-d, --debug`                          | Debug output — includes third-party library logs                                                          | `KP2BW_DEBUG`                         |
 | `-V, --version`                        | Print the installed `kp2bw` version and exit                                                              | -                                     |
 
 Configuration precedence is always: CLI flag > environment variable > built-in default.
+
+### Finalizing (`--strip-ids`)
+
+Every migrated item carries a hidden `KP2BW_ID` field — the KeePass UUID kp2bw uses to match entries on re-runs so
+nothing duplicates. Once you're satisfied the migration is complete and you're ready to fully adopt Bitwarden, run
+
+```bash
+kp2bw --strip-ids            # personal vault; add -o/-c to scope to an org/collection
+```
+
+to remove that stamp from every migrated item and exit. No KeePass database is read. It asks for confirmation first
+(skip with `-y`) and is safe to repeat. Note that after stripping, a later migration re-matches by folder + name (and
+re-stamps) rather than by UUID.
 
 ### `.env` file
 

--- a/README.md
+++ b/README.md
@@ -122,9 +122,13 @@ nothing duplicates. Once you're satisfied the migration is complete and you're r
 kp2bw --strip-ids            # personal vault; add -o/-c to scope to an org/collection
 ```
 
-to remove that stamp from every migrated item and exit. No KeePass database is read. It asks for confirmation first
-(skip with `-y`) and is safe to repeat. Note that after stripping, a later migration re-matches by folder + name (and
-re-stamps) rather than by UUID.
+to remove that stamp from every migrated item and exit. No KeePass database is read.
+
+> [!WARNING]
+> This is **irreversible** and makes future migration re-runs unreliable. Without the stamp, a re-run can only match by
+> folder + name — the exact collision the stamp exists to prevent — so entries that share a folder and title may be
+> duplicated or mismatched on a later migration. `--strip-ids` confirms before changing anything (skip with `-y`). Only
+> run it once you're truly done migrating.
 
 ### `.env` file
 

--- a/README.md
+++ b/README.md
@@ -115,8 +115,9 @@ Configuration precedence is always: CLI flag > environment variable > built-in d
 
 ### Finalizing (`--strip-ids`)
 
-Every migrated item carries a hidden `KP2BW_ID` field — the KeePass UUID kp2bw uses to match entries on re-runs so
-nothing duplicates. Once you're satisfied the migration is complete and you're ready to fully adopt Bitwarden, run
+Every migrated item carries a plain-text `KP2BW_ID` custom field — the KeePass UUID kp2bw uses to match entries on
+re-runs so nothing duplicates. Once you're satisfied the migration is complete and you're ready to fully adopt
+Bitwarden, run
 
 ```bash
 kp2bw --strip-ids            # personal vault; add -o/-c to scope to an org/collection

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,12 @@ venv             = ".venv"
 typeCheckingMode = "strict"
 pythonVersion    = "3.14"
 
+# Tests legitimately exercise module-internal helpers (e.g. _run_strip_ids);
+# allow accessing private symbols there without weakening strict mode elsewhere.
+[[tool.pyright.executionEnvironments]]
+root               = "tests"
+reportPrivateUsage = "none"
+
 [tool.ruff]
 preview        = true
 target-version = "py314"

--- a/src/kp2bw/AGENTS.md
+++ b/src/kp2bw/AGENTS.md
@@ -78,6 +78,13 @@ src/kp2bw/
   failing that it creates a new item. This stops distinct same-titled entries from collapsing onto one item (data loss)
   and keeps re-runs idempotent across title/folder edits. The legacy adoption is a one-time path for vaults imported
   before stable identity.
+- `--strip-ids` (`KP2BW_STRIP_IDS`, default off) is the finalize-mode inverse of the stamp above: it short-circuits
+  migration entirely (`main()` returns before any KeePass read or password prompt) and only touches Bitwarden, removing
+  the `KP2BW_ID` field from every in-scope item via `_run_strip_ids` (`cli.py`) → `strip_field_from_items`
+  (`bw_serve.py`, one full `update_item` `PUT` per stamped item). Scope mirrors a migration (`-o`/`-c`), so only items
+  kp2bw could have stamped are touched. It is **irreversible** and degrades future re-runs (they fall back to
+  `(folder, name)` matching), so an interactive run confirms first (skippable with `-y`/`KP2BW_YES`); a declined prompt
+  exits `0` (clean abort), Ctrl+C exits `130`. Re-runnable: a second pass finds nothing.
 - `--metadata` (default on) folds the KeePass metadata Bitwarden has no native slot for — **tags and expiry** — into a
   single readable **YAML** `KP2BW_META` text field (`_build_metadata_field`, via PyYAML
   `safe_dump(allow_unicode=

--- a/src/kp2bw/bw_serve.py
+++ b/src/kp2bw/bw_serve.py
@@ -79,7 +79,7 @@ KP2BW_ID_FIELD_NAME: str = "KP2BW_ID"
 def item_kp2bw_id(item: BwItemResponse) -> str | None:
     """Return *item*'s KeePass-UUID stamp, or ``None`` if it is unstamped.
 
-    Reads the hidden ``KP2BW_ID`` custom field written by :mod:`kp2bw.convert`.
+    Reads the plain-text ``KP2BW_ID`` custom field written by :mod:`kp2bw.convert`.
     An unstamped item is a legacy import (pre-stable-identity) eligible for a
     one-time ``(folder, name)`` adoption that backfills the stamp.
     """

--- a/src/kp2bw/bw_serve.py
+++ b/src/kp2bw/bw_serve.py
@@ -881,10 +881,13 @@ class BitwardenServeClient:
         field are skipped; each match is rewritten via a full :meth:`update_item`
         ``PUT``.  Returns the scanned/stripped counts for the caller to report.
 
-        Re-runnable and harmless to repeat: a second pass finds nothing to do.
-        After stripping, a later migration re-stamps via the one-time
-        ``(folder, name)`` legacy adoption, so this does not permanently break
-        idempotency -- it is simply the intended last step.
+        The strip itself is re-runnable (a second pass finds nothing), but it is
+        **irreversible** and degrades future migrations: the stamp is the stable
+        identity key, and without it a re-run falls back to ``(folder, name)``
+        matching -- the very collision the stamp exists to disambiguate -- so
+        entries sharing a folder and title can then be duplicated or mismatched.
+        It is therefore a deliberate final step, gated by a confirmation in the
+        CLI (skippable with ``-y`` for callers who know what they want).
         """
         items = self.list_items(
             organization_id=self._org_id,

--- a/src/kp2bw/bw_serve.py
+++ b/src/kp2bw/bw_serve.py
@@ -13,7 +13,7 @@ import subprocess
 import time
 from collections.abc import Callable, Mapping
 from types import FrameType, TracebackType
-from typing import Any, Self, cast
+from typing import Any, NamedTuple, Self, cast
 
 import httpx
 from rich.markup import escape
@@ -87,6 +87,17 @@ def item_kp2bw_id(item: BwItemResponse) -> str | None:
         if field.get("name") == KP2BW_ID_FIELD_NAME:
             return field.get("value") or None
     return None
+
+
+class StripResult(NamedTuple):
+    """Outcome of a :meth:`BitwardenServeClient.strip_field_from_items` pass.
+
+    *scanned* is every in-scope item inspected; *stripped* is the subset that
+    carried the field and was rewritten.
+    """
+
+    scanned: int
+    stripped: int
 
 
 # Actionable message shown when the Bitwarden CLI cannot be located.
@@ -858,6 +869,41 @@ class BitwardenServeClient:
         }
         self._request("PUT", f"/object/item/{item_id}", json_body=body)
         logger.log(VERBOSE, f"Updated item {item.get('name', '?')!r} ({item_id})")
+
+    def strip_field_from_items(self, field_name: str) -> StripResult:
+        """Remove a custom field from every in-scope item that carries it.
+
+        The finalize step for users adopting Bitwarden: drops kp2bw's
+        ``KP2BW_ID`` dedup stamp once a migration is trusted, leaving clean
+        items behind.  Scope mirrors a migration -- the configured
+        organisation/collection when set, otherwise the personal vault -- so
+        only items kp2bw could have stamped are touched.  Items lacking the
+        field are skipped; each match is rewritten via a full :meth:`update_item`
+        ``PUT``.  Returns the scanned/stripped counts for the caller to report.
+
+        Re-runnable and harmless to repeat: a second pass finds nothing to do.
+        After stripping, a later migration re-stamps via the one-time
+        ``(folder, name)`` legacy adoption, so this does not permanently break
+        idempotency -- it is simply the intended last step.
+        """
+        items = self.list_items(
+            organization_id=self._org_id,
+            collection_id=self._collection_id,
+        )
+        stripped = 0
+        for item in items:
+            fields = item.get("fields") or []
+            if not any(field.get("name") == field_name for field in fields):
+                continue
+            item["fields"] = [
+                field for field in fields if field.get("name") != field_name
+            ]
+            self.update_item(item["id"], item)
+            stripped += 1
+        logger.info(
+            f"Stripped {field_name} from {stripped} of {len(items)} scanned items"
+        )
+        return StripResult(scanned=len(items), stripped=stripped)
 
     def create_items_batch(
         self,

--- a/src/kp2bw/cli.py
+++ b/src/kp2bw/cli.py
@@ -235,9 +235,10 @@ def _argparser() -> MyArgParser:
         help=(
             "Finalize adoption: remove the KP2BW_ID dedup stamp kp2bw adds to "
             "every migrated item, then exit (no migration, no KeePass database "
-            "needed). Run once you're satisfied the migration is complete and "
-            "ready to fully adopt Bitwarden. Honors -o/--bitwarden-org and "
-            "-c/--bitwarden-collection for scope (env: KP2BW_STRIP_IDS)"
+            "needed). Run once you're ready to fully adopt Bitwarden. IRREVERSIBLE "
+            "and makes future migration re-runs unreliable, so it confirms first "
+            "(skip with -y). Honors -o/--bitwarden-org and -c/--bitwarden-collection "
+            "for scope (env: KP2BW_STRIP_IDS)"
         ),
         action="store_true",
         default=None,
@@ -310,19 +311,25 @@ def _run_strip_ids(
 ) -> None:
     """Remove kp2bw's ``KP2BW_ID`` dedup stamp from every migrated item, then stop.
 
-    The finalize step for users who trust their migration and want clean
-    Bitwarden items: no KeePass database is read.  Scope follows ``-o``/``-c``
-    exactly as a migration would.  The mutation is gated behind a confirmation
-    (skippable with ``-y``); answering ``n`` aborts without changes.  Errors
-    surface as an actionable message rather than a traceback.
+    The finalize step for users ready to fully adopt Bitwarden: no KeePass
+    database is read, and scope follows ``-o``/``-c`` exactly as a migration
+    would.  The operation is **irreversible** -- the stamp cannot be recovered --
+    and makes future migration re-runs unreliable: without it, entries that share
+    a folder + name (the very collision the stamp disambiguates) can be
+    duplicated or mismatched.  A loud confirmation states this before any change;
+    ``-y``/``--yes`` skips it for callers who know what they want.  Errors surface
+    as an actionable message rather than a traceback.
     """
     scope = _describe_scope(org_id, collection_id)
     if not skip_confirm:
         console.print(
-            f"This removes the [bold]{KP2BW_ID_FIELD_NAME}[/bold] field from "
-            f"every kp2bw-migrated item in [bold]{escape(scope)}[/bold]. Your "
-            "other vault data is left untouched, but re-runs will no longer be "
-            "matched by stamp (they fall back to folder + name)."
+            f"[bold yellow]Warning:[/bold yellow] this removes the "
+            f"[bold]{KP2BW_ID_FIELD_NAME}[/bold] field from every kp2bw-migrated "
+            f"item in [bold]{escape(scope)}[/bold]. Other vault data is "
+            "untouched, but this [bold]cannot be undone[/bold] and makes future "
+            "migration re-runs unreliable: without the stamp, entries sharing a "
+            "folder + name can be duplicated or mismatched. Only do this once "
+            "you are finished migrating and ready to fully adopt Bitwarden."
         )
         if not _confirm(f"Remove {KP2BW_ID_FIELD_NAME} stamps? [y/n]: "):
             console.print("[yellow]Aborted; nothing changed.[/yellow]")

--- a/src/kp2bw/cli.py
+++ b/src/kp2bw/cli.py
@@ -356,7 +356,7 @@ def _run_strip_ids(
         )
     else:
         console.print(
-            f"No items carried a {KP2BW_ID_FIELD_NAME} stamp in {scope} "
+            f"No items carried a {KP2BW_ID_FIELD_NAME} stamp in {escape(scope)} "
             f"({result.scanned} scanned); nothing to do."
         )
 

--- a/src/kp2bw/cli.py
+++ b/src/kp2bw/cli.py
@@ -13,7 +13,7 @@ from rich.markup import escape
 
 from . import VERBOSE, __title__, __version__
 from ._console import console
-from .bw_serve import ensure_bw_available
+from .bw_serve import KP2BW_ID_FIELD_NAME, BitwardenServeClient, ensure_bw_available
 from .convert import Converter
 from .exceptions import BitwardenClientError, ConversionError
 
@@ -230,6 +230,19 @@ def _argparser() -> MyArgParser:
         default=None,
     )
     parser.add_argument(
+        "--strip-ids",
+        dest="strip_ids",
+        help=(
+            "Finalize adoption: remove the KP2BW_ID dedup stamp kp2bw adds to "
+            "every migrated item, then exit (no migration, no KeePass database "
+            "needed). Run once you're satisfied the migration is complete and "
+            "ready to fully adopt Bitwarden. Honors -o/--bitwarden-org and "
+            "-c/--bitwarden-collection for scope (env: KP2BW_STRIP_IDS)"
+        ),
+        action="store_true",
+        default=None,
+    )
+    parser.add_argument(
         "-y",
         "--yes",
         dest="skip_confirm",
@@ -269,6 +282,76 @@ def _fail(exc: BaseException) -> NoReturn:
     """Print an actionable error and exit non-zero, without a stack trace."""
     console.print(f"[red]ERROR:[/red] {escape(str(exc))}")
     sys.exit(1)
+
+
+def _confirm(prompt: str) -> bool:
+    """Prompt for a y/n answer, looping until valid; True only on explicit yes."""
+    answer: str | None = None
+    while answer not in {"y", "n"}:
+        answer = input(prompt).strip().lower()
+    return answer == "y"
+
+
+def _describe_scope(org_id: str | None, collection_id: str | None) -> str:
+    """Human-readable description of the vault scope a strip run will touch."""
+    if collection_id:
+        return f"collection {collection_id} (organization {org_id})"
+    if org_id:
+        return f"organization {org_id}"
+    return "your personal vault"
+
+
+def _run_strip_ids(
+    *,
+    bitwarden_password_arg: str | None,
+    org_id: str | None,
+    collection_id: str | None,
+    skip_confirm: bool,
+) -> None:
+    """Remove kp2bw's ``KP2BW_ID`` dedup stamp from every migrated item, then stop.
+
+    The finalize step for users who trust their migration and want clean
+    Bitwarden items: no KeePass database is read.  Scope follows ``-o``/``-c``
+    exactly as a migration would.  The mutation is gated behind a confirmation
+    (skippable with ``-y``); answering ``n`` aborts without changes.  Errors
+    surface as an actionable message rather than a traceback.
+    """
+    scope = _describe_scope(org_id, collection_id)
+    if not skip_confirm:
+        console.print(
+            f"This removes the [bold]{KP2BW_ID_FIELD_NAME}[/bold] field from "
+            f"every kp2bw-migrated item in [bold]{escape(scope)}[/bold]. Your "
+            "other vault data is left untouched, but re-runs will no longer be "
+            "matched by stamp (they fall back to folder + name)."
+        )
+        if not _confirm(f"Remove {KP2BW_ID_FIELD_NAME} stamps? [y/n]: "):
+            console.print("[yellow]Aborted; nothing changed.[/yellow]")
+            sys.exit(2)
+
+    bw_pw = _read_password(
+        bitwarden_password_arg, "Please enter your Bitwarden password: "
+    )
+    try:
+        with BitwardenServeClient(
+            bw_pw, org_id=org_id, collection_id=collection_id
+        ) as bw:
+            result = bw.strip_field_from_items(KP2BW_ID_FIELD_NAME)
+    except KeyboardInterrupt:
+        console.print("\n[yellow]Interrupted.[/yellow]")
+        sys.exit(130)
+    except (BitwardenClientError, ConversionError) as exc:
+        _fail(exc)
+
+    if result.stripped:
+        console.print(
+            f"[green]Removed {KP2BW_ID_FIELD_NAME} from {result.stripped} of "
+            f"{result.scanned} item(s).[/green]"
+        )
+    else:
+        console.print(
+            f"No items carried a {KP2BW_ID_FIELD_NAME} stamp in {scope} "
+            f"({result.scanned} scanned); nothing to do."
+        )
 
 
 # Third-party loggers whose DEBUG/INFO chatter is valuable in the always-on file
@@ -434,6 +517,9 @@ def main() -> None:
         skip_confirm = _resolve_bool_option(
             args.skip_confirm, "KP2BW_YES", default=False
         )
+        strip_ids = _resolve_bool_option(
+            args.strip_ids, "KP2BW_STRIP_IDS", default=False
+        )
         verbose = _resolve_bool_option(args.verbose, "KP2BW_VERBOSE", default=False)
         debug = _resolve_bool_option(args.debug, "KP2BW_DEBUG", default=False)
     except ValueError as exc:
@@ -456,7 +542,9 @@ def main() -> None:
                 _argparser().print_help()
                 sys.exit(2)
 
-    if not args.keepass_file:
+    # --strip-ids is a Bitwarden-only finalize step: no KeePass database is read,
+    # so the path requirement (and the KeePass password prompt below) is skipped.
+    if not strip_ids and not args.keepass_file:
         _ = sys.stderr.write(
             "ERROR: KeePass database path is required "
             "(positional FILE or KP2BW_KEEPASS_FILE)\n\n"
@@ -488,6 +576,18 @@ def main() -> None:
         ensure_bw_available()
     except BitwardenClientError as exc:
         _fail(exc)
+
+    # --strip-ids short-circuits migration entirely: it only touches Bitwarden
+    # (remove kp2bw's dedup stamps), so it needs neither the bw-setup spiel nor a
+    # KeePass password. It handles its own confirmation and Bitwarden password.
+    if strip_ids:
+        _run_strip_ids(
+            bitwarden_password_arg=args.bw_pw,
+            org_id=args.bw_org,
+            collection_id=args.bw_coll,
+            skip_confirm=skip_confirm,
+        )
+        return
 
     # bw confirmation
     if not skip_confirm:

--- a/src/kp2bw/cli.py
+++ b/src/kp2bw/cli.py
@@ -321,24 +321,25 @@ def _run_strip_ids(
     as an actionable message rather than a traceback.
     """
     scope = _describe_scope(org_id, collection_id)
-    if not skip_confirm:
-        console.print(
-            f"[bold yellow]Warning:[/bold yellow] this removes the "
-            f"[bold]{KP2BW_ID_FIELD_NAME}[/bold] field from every kp2bw-migrated "
-            f"item in [bold]{escape(scope)}[/bold]. Other vault data is "
-            "untouched, but this [bold]cannot be undone[/bold] and makes future "
-            "migration re-runs unreliable: without the stamp, entries sharing a "
-            "folder + name can be duplicated or mismatched. Only do this once "
-            "you are finished migrating and ready to fully adopt Bitwarden."
-        )
-        if not _confirm(f"Remove {KP2BW_ID_FIELD_NAME} stamps? [y/n]: "):
-            console.print("[yellow]Aborted; nothing changed.[/yellow]")
-            sys.exit(2)
-
-    bw_pw = _read_password(
-        bitwarden_password_arg, "Please enter your Bitwarden password: "
-    )
     try:
+        if not skip_confirm:
+            console.print(
+                f"[bold yellow]Warning:[/bold yellow] this removes the "
+                f"[bold]{KP2BW_ID_FIELD_NAME}[/bold] field from every "
+                f"kp2bw-migrated item in [bold]{escape(scope)}[/bold]. Other "
+                "vault data is untouched, but this [bold]cannot be undone[/bold] "
+                "and makes future migration re-runs unreliable: without the "
+                "stamp, entries sharing a folder + name can be duplicated or "
+                "mismatched. Only do this once you are finished migrating and "
+                "ready to fully adopt Bitwarden."
+            )
+            if not _confirm(f"Remove {KP2BW_ID_FIELD_NAME} stamps? [y/n]: "):
+                console.print("[yellow]Aborted; nothing changed.[/yellow]")
+                sys.exit(0)
+
+        bw_pw = _read_password(
+            bitwarden_password_arg, "Please enter your Bitwarden password: "
+        )
         with BitwardenServeClient(
             bw_pw, org_id=org_id, collection_id=collection_id
         ) as bw:

--- a/tests/strip_ids_test.py
+++ b/tests/strip_ids_test.py
@@ -91,9 +91,84 @@ def assert_second_pass_is_noop() -> None:
         raise AssertionError(f"expected no updates, got {client.updates}")
 
 
+def assert_declined_confirmation_aborts_without_touching_vault() -> None:
+    """Answering 'n' at the prompt aborts before any client is built.
+
+    Stripping is irreversible, so an interactive run (``skip_confirm=False``)
+    must not reach ``bw serve`` unless the user explicitly confirms.
+    """
+    from unittest import mock
+
+    from kp2bw import cli
+
+    def _must_not_build(*_args: object, **_kwargs: object) -> object:
+        raise AssertionError("client built despite a declined confirmation")
+
+    with (
+        mock.patch("builtins.input", return_value="n"),
+        mock.patch.object(cli, "BitwardenServeClient", _must_not_build),
+    ):
+        try:
+            cli._run_strip_ids(
+                bitwarden_password_arg="bw-pw",
+                org_id=None,
+                collection_id=None,
+                skip_confirm=False,
+            )
+        except SystemExit as exc:
+            if exc.code != 2:
+                raise AssertionError(f"expected exit code 2, got {exc.code}")
+        else:
+            raise AssertionError("expected SystemExit on a declined confirmation")
+
+
+def assert_yes_skips_confirmation_prompt() -> None:
+    """``-y`` (``skip_confirm=True``) runs the strip without prompting at all.
+
+    The user is trusted to opt out of the confirmation; reaching ``input`` would
+    mean the override was ignored.
+    """
+    from typing import Self
+    from unittest import mock
+
+    from kp2bw import cli
+    from kp2bw.bw_serve import StripResult
+
+    class _FakeClient:
+        """Minimal context-manager stand-in exposing the one method called."""
+
+        def __enter__(self) -> Self:
+            return self
+
+        def __exit__(self, *_exc: object) -> None:
+            return None
+
+        def strip_field_from_items(self, _field_name: str) -> StripResult:
+            return StripResult(scanned=3, stripped=0)
+
+    def _must_not_prompt(*_args: object, **_kwargs: object) -> str:
+        raise AssertionError("prompted despite -y (skip_confirm=True)")
+
+    def _make_client(*_args: object, **_kwargs: object) -> _FakeClient:
+        return _FakeClient()
+
+    with (
+        mock.patch("builtins.input", _must_not_prompt),
+        mock.patch.object(cli, "BitwardenServeClient", _make_client),
+    ):
+        cli._run_strip_ids(
+            bitwarden_password_arg="bw-pw",
+            org_id=None,
+            collection_id=None,
+            skip_confirm=True,
+        )
+
+
 def main() -> None:
     assert_only_stamped_items_stripped()
     assert_second_pass_is_noop()
+    assert_declined_confirmation_aborts_without_touching_vault()
+    assert_yes_skips_confirmation_prompt()
     print("strip ids test passed")
 
 

--- a/tests/strip_ids_test.py
+++ b/tests/strip_ids_test.py
@@ -116,8 +116,8 @@ def assert_declined_confirmation_aborts_without_touching_vault() -> None:
                 skip_confirm=False,
             )
         except SystemExit as exc:
-            if exc.code != 2:
-                raise AssertionError(f"expected exit code 2, got {exc.code}")
+            if exc.code != 0:
+                raise AssertionError(f"expected exit code 0, got {exc.code}")
         else:
             raise AssertionError("expected SystemExit on a declined confirmation")
 

--- a/tests/strip_ids_test.py
+++ b/tests/strip_ids_test.py
@@ -1,0 +1,101 @@
+"""Checks the KP2BW_ID strip/finalize pass (`--strip-ids`).
+
+Once a migration is trusted, `BitwardenServeClient.strip_field_from_items`
+removes kp2bw's `KP2BW_ID` dedup stamp from every in-scope item, leaving other
+fields and unstamped items untouched, and is safe to repeat (a second pass finds
+nothing). These checks drive the method with a client double, so no live
+`bw serve` process is spawned.
+"""
+
+from typing import cast
+
+from kp2bw.bw_serve import KP2BW_ID_FIELD_NAME, BitwardenServeClient
+from kp2bw.bw_types import BwField, BwItemResponse
+
+
+def _item(item_id: str, field_names: list[str]) -> BwItemResponse:
+    """Build a minimal list-shaped item carrying the named custom fields."""
+    fields = [cast(BwField, {"name": name, "value": "v"}) for name in field_names]
+    return cast(BwItemResponse, {"id": item_id, "name": item_id, "fields": fields})
+
+
+class _StripClient(BitwardenServeClient):
+    """Client double serving a fixed item list and recording every update.
+
+    Bypasses the real ``__init__`` (which would spawn ``bw serve``); only the
+    scope state and the two transport methods the strip touches are provided.
+    The inherited ``strip_field_from_items`` is the code under test.
+    """
+
+    def __init__(self, items: list[BwItemResponse]) -> None:
+        self._org_id = None
+        self._collection_id = None
+        self._items = items
+        # (item_id, remaining field names) for each PUT the method issues.
+        self.updates: list[tuple[str, list[str]]] = []
+
+    def list_items(
+        self,
+        *,
+        folder_id: str | None = None,
+        organization_id: str | None = None,
+        collection_id: str | None = None,
+    ) -> list[BwItemResponse]:
+        return self._items
+
+    def update_item(self, item_id: str, item: BwItemResponse) -> None:
+        names = [field.get("name", "") for field in item.get("fields") or []]
+        self.updates.append((item_id, names))
+
+
+def assert_only_stamped_items_stripped() -> None:
+    """Only items carrying KP2BW_ID are rewritten, and only that field is removed."""
+    items = [
+        _item("stamped-both", [KP2BW_ID_FIELD_NAME, "keep"]),
+        _item("plain", ["keep"]),
+        _item("stamped-only", [KP2BW_ID_FIELD_NAME]),
+        _item("no-fields", []),
+    ]
+    client = _StripClient(items)
+
+    result = client.strip_field_from_items(KP2BW_ID_FIELD_NAME)
+
+    if result.scanned != 4:
+        raise AssertionError(f"expected 4 scanned, got {result.scanned}")
+    if result.stripped != 2:
+        raise AssertionError(f"expected 2 stripped, got {result.stripped}")
+
+    updated_ids = [item_id for item_id, _ in client.updates]
+    if updated_ids != ["stamped-both", "stamped-only"]:
+        raise AssertionError(f"unexpected items updated: {updated_ids}")
+
+    for item_id, remaining in client.updates:
+        if KP2BW_ID_FIELD_NAME in remaining:
+            raise AssertionError(f"{item_id} still carries {KP2BW_ID_FIELD_NAME}")
+    # The unrelated field on the multi-field item must survive.
+    both_remaining = dict(client.updates)["stamped-both"]
+    if both_remaining != ["keep"]:
+        raise AssertionError(f"non-stamp field not preserved: {both_remaining}")
+
+
+def assert_second_pass_is_noop() -> None:
+    """Re-running over already-clean items strips nothing and issues no PUTs."""
+    items = [_item("plain", ["keep"]), _item("no-fields", [])]
+    client = _StripClient(items)
+
+    result = client.strip_field_from_items(KP2BW_ID_FIELD_NAME)
+
+    if result.stripped != 0:
+        raise AssertionError(f"expected 0 stripped, got {result.stripped}")
+    if client.updates:
+        raise AssertionError(f"expected no updates, got {client.updates}")
+
+
+def main() -> None:
+    assert_only_stamped_items_stripped()
+    assert_second_pass_is_noop()
+    print("strip ids test passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_script_adapters.py
+++ b/tests/test_script_adapters.py
@@ -35,6 +35,10 @@ def test_bw_serve_batch_script() -> None:
     _run_script_main("bw_serve_batch_test.py")
 
 
+def test_strip_ids_script() -> None:
+    _run_script_main("strip_ids_test.py")
+
+
 def test_otp_script() -> None:
     _run_script_main("otp_test.py")
 


### PR DESCRIPTION
## What

A new **`--strip-ids`** flag (env `KP2BW_STRIP_IDS`) runs a Bitwarden-only pass that removes the hidden `KP2BW_ID` dedup stamp from every migrated item, then exits. No KeePass database is read; no migration runs.

```bash
kp2bw --strip-ids            # personal vault; add -o/-c to scope to an org/collection
```

## Why

Every migrated item carries a hidden `KP2BW_ID` field — the KeePass UUID kp2bw matches on so re-runs stay idempotent and never duplicate. Once a user trusts the migration and is ready to fully adopt Bitwarden, those internal stamps are just noise. This is the **finalize step** to scrub them.

## Behavior

- **Mode switch**: short-circuits migration — skips the KeePass-path requirement and the KeePass password prompt; still unlocks `bw serve` with the Bitwarden password.
- **Scope** follows `-o`/`-c` exactly as a migration would (personal vault by default).
- **Only `KP2BW_ID`** is removed — `KP2BW_META` (tags/expiry) is real data and left alone.
- **Confirmed first** (skippable with `-y`); answering `n` aborts with no changes.
- **Safe to repeat**: a second pass finds nothing. After stripping, a later migration re-matches by folder + name (and re-stamps), so idempotency isn't permanently lost.

## Implementation

- `bw_serve.py`: `BitwardenServeClient.strip_field_from_items(field_name) -> StripResult` (lists in scope, removes the field, full `PUT` per match, returns scanned/stripped counts).
- `cli.py`: `--strip-ids` dispatch + `_run_strip_ids` / `_confirm` / `_describe_scope` helpers.
- `tests/strip_ids_test.py`: stamped-only stripping, non-stamp field preserved, no-op re-run (client double, no live `bw serve`).

## Gates

ruff · ty · basedpyright (0/0/0) · dprint · pytest 13 passed / 4 skipped. Also verified `--help` lists the flag and the strip branch dispatches without a KeePass file.