### PR TITLE
feat: nested org collections + org-aware personal folders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,25 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- **`--bitwarden-collection nested` -- recreate the full KeePass folder hierarchy as nested collections** (issue #33, PR
+  #34). `auto` only ever used the top-level folder name, so `Work/Servers/ssh` collapsed onto a single `Work` collection
+  and the nesting was lost. `nested` builds collections from the full `/`-joined path (`Work/Servers`), which Bitwarden
+  renders as a nested tree. Collections are matched by org + name and seeded from the existing set on connect, so an
+  unchanged tree is a no-op and entries sharing a path never duplicate a collection.
+
+- **`--folder` / `--no-folder` (env `KP2BW_CREATE_FOLDERS`) -- control whether personal-vault folders are created from
+  KeePass groups.** Defaults on for personal imports, so existing behaviour is unchanged there (issue #33, PR #34).
+
+### Changed
+
+- **An organization import (`--bitwarden-org`) no longer also builds a personal folder tree by default** (issue #33, PR
+  #34). Bitwarden folders are a personal-vault concept; the org-side equivalent is a collection, so creating both
+  double-filed every item -- the collection *and* a redundant personal-folder copy. With an org set, `--no-folder` is
+  now the default and items are filed into collections only. Pass `--folder` (or `KP2BW_CREATE_FOLDERS=1`) to restore
+  the personal folder tree alongside the collections. Personal imports (no `--bitwarden-org`) are unaffected.
+
 ## [3.6.0] - 2026-06-14
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ kp2bw [-h] [-V] [-k PASSWORD] [-K FILE] [-b PASSWORD] [-o ID]
        [--path-to-name-skip N] [--skip-expired | --no-skip-expired]
        [--include-recycle-bin | --no-include-recycle-bin]
        [--metadata | --no-metadata] [--update | --no-update] [--force-update]
-       [--include-oversize-secrets] [--uri-match MODE]
+       [--include-oversize-secrets] [--no-folder] [--uri-match MODE]
        [--interpret-uri-syntax | --no-interpret-uri-syntax]
        [--migrate-uris] [--report-uris SOURCE] [--strip-ids] [-y] [-v] [-d]
        [FILE]
@@ -98,8 +98,9 @@ kp2bw [-h] [-V] [-k PASSWORD] [-K FILE] [-b PASSWORD] [-o ID]
 | `-K, --keepass-keyfile`                | KeePass key file                                                                                                          | `KP2BW_KEEPASS_KEYFILE`               |
 | `-b, --bitwarden-password`             | Bitwarden password (prompted if omitted)                                                                                  | `KP2BW_BITWARDEN_PASSWORD`            |
 | `-o, --bitwarden-org`                  | Bitwarden Organization ID                                                                                                 | `KP2BW_BITWARDEN_ORG`                 |
-| `-c, --bitwarden-collection`           | Collection ID, or `auto` to derive from top-level folder names                                                            | `KP2BW_BITWARDEN_COLLECTION`          |
+| `-c, --bitwarden-collection`           | Collection ID, `auto` for top-level folder names, or `nested` for full folder paths                                       | `KP2BW_BITWARDEN_COLLECTION`          |
 | `-t, --import-tags`                    | Only import entries with these tags                                                                                       | `KP2BW_IMPORT_TAGS` (comma-separated) |
+| `--no-folder`                          | Do not create personal Bitwarden folders; items stay at the vault root unless org collections apply                       | `KP2BW_CREATE_FOLDERS=0`              |
 | `--path-to-name` / `--no-path-to-name` | Prepend folder path to entry names (default: off)                                                                         | `KP2BW_PATH_TO_NAME`                  |
 | `--path-to-name-skip`                  | Skip first N folders in path prefix (default: 1)                                                                          | `KP2BW_PATH_TO_NAME_SKIP`             |
 | `--skip-expired`                       | Skip entries that have expired in KeePass                                                                                 | `KP2BW_SKIP_EXPIRED`                  |
@@ -119,6 +120,13 @@ kp2bw [-h] [-V] [-k PASSWORD] [-K FILE] [-b PASSWORD] [-o ID]
 | `-V, --version`                        | Print the installed `kp2bw` version and exit                                                                              | -                                     |
 
 Configuration precedence is always: CLI flag > environment variable > built-in default.
+
+### Organization collections
+
+Bitwarden folders are personal-vault metadata. When importing into an organization, use `--bitwarden-collection auto` to
+create/use one collection per top-level KeePass folder, or `--bitwarden-collection nested` to create/use collections
+from full KeePass paths such as `Work/Servers`. Add `--no-folder` if you want organization items filed only into
+collections, without creating matching personal folders.
 
 ### URL handling
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ kp2bw [-h] [-V] [-k PASSWORD] [-K FILE] [-b PASSWORD] [-o ID]
        [--path-to-name-skip N] [--skip-expired | --no-skip-expired]
        [--include-recycle-bin | --no-include-recycle-bin]
        [--metadata | --no-metadata] [--update | --no-update] [--force-update]
-       [--include-oversize-secrets] [--no-folder] [--uri-match MODE]
+       [--include-oversize-secrets] [--folder | --no-folder] [--uri-match MODE]
        [--interpret-uri-syntax | --no-interpret-uri-syntax]
        [--migrate-uris] [--report-uris SOURCE] [--strip-ids] [-y] [-v] [-d]
        [FILE]
@@ -100,7 +100,7 @@ kp2bw [-h] [-V] [-k PASSWORD] [-K FILE] [-b PASSWORD] [-o ID]
 | `-o, --bitwarden-org`                  | Bitwarden Organization ID                                                                                                 | `KP2BW_BITWARDEN_ORG`                 |
 | `-c, --bitwarden-collection`           | Collection ID, `auto` for top-level folder names, or `nested` for full folder paths                                       | `KP2BW_BITWARDEN_COLLECTION`          |
 | `-t, --import-tags`                    | Only import entries with these tags                                                                                       | `KP2BW_IMPORT_TAGS` (comma-separated) |
-| `--no-folder`                          | Do not create personal Bitwarden folders; items stay at the vault root unless org collections apply                       | `KP2BW_CREATE_FOLDERS=0`              |
+| `--folder` / `--no-folder`             | Create personal Bitwarden folders from KeePass groups (default: on, but off when `--bitwarden-org` is set)                | `KP2BW_CREATE_FOLDERS`                |
 | `--path-to-name` / `--no-path-to-name` | Prepend folder path to entry names (default: off)                                                                         | `KP2BW_PATH_TO_NAME`                  |
 | `--path-to-name-skip`                  | Skip first N folders in path prefix (default: 1)                                                                          | `KP2BW_PATH_TO_NAME_SKIP`             |
 | `--skip-expired`                       | Skip entries that have expired in KeePass                                                                                 | `KP2BW_SKIP_EXPIRED`                  |
@@ -125,8 +125,11 @@ Configuration precedence is always: CLI flag > environment variable > built-in d
 
 Bitwarden folders are personal-vault metadata. When importing into an organization, use `--bitwarden-collection auto` to
 create/use one collection per top-level KeePass folder, or `--bitwarden-collection nested` to create/use collections
-from full KeePass paths such as `Work/Servers`. Add `--no-folder` if you want organization items filed only into
-collections, without creating matching personal folders.
+from full KeePass paths such as `Work/Servers`.
+
+Because folders only duplicate the collection tree in your personal vault, `--bitwarden-org` defaults to **not**
+creating personal folders — items are filed only into collections. Pass `--folder` (or `KP2BW_CREATE_FOLDERS=1`) to
+restore the personal folder tree alongside the collections.
 
 ### URL handling
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name            = "kp2bw"
-version         = "3.6.0"
+version         = "3.7.0"
 description     = "Imports and existing KeePass db with REF fields into Bitwarden"
 readme          = "README.md"
 requires-python = ">=3.14"

--- a/src/kp2bw/bw_serve.py
+++ b/src/kp2bw/bw_serve.py
@@ -734,7 +734,10 @@ class BitwardenServeClient:
             "--hostname",
             "127.0.0.1",
         ]
-        env = {**os.environ}
+        # Annotated so the type stays dict[str, str] after env.pop() below;
+        # without it the inferred type widens and subprocess.Popen's overload
+        # no longer resolves to Popen[bytes].
+        env: dict[str, str] = {**os.environ}
         if session:
             env["BW_SESSION"] = session
         else:

--- a/src/kp2bw/bw_serve.py
+++ b/src/kp2bw/bw_serve.py
@@ -1095,12 +1095,16 @@ class BitwardenServeClient:
         *,
         on_item_created: Callable[[], None] | None = None,
         on_item_failed: Callable[[str, BitwardenClientError], None] | None = None,
+        create_folders: bool = True,
     ) -> dict[str, str]:
         """Create folders and items via HTTP, returning ``{key: item_id}``.
 
         *entries* maps arbitrary keys to ``(folder_name, bw_item_dict)`` tuples.
         Folders are created/resolved first, then items are created sequentially
-        with the correct ``folderId`` bound.
+        with the correct ``folderId`` bound.  When *create_folders* is ``False``,
+        folder creation and ``folderId`` binding are skipped, leaving items in
+        the personal-vault root while any collection IDs on the items still
+        apply.
 
         A single create that fails (``bw serve`` drops or times out the request,
         surfaced as :class:`BitwardenClientError`) is non-fatal: the item is
@@ -1117,7 +1121,11 @@ class BitwardenServeClient:
         """
         # Ensure all required folders exist. A folder whose creation fails is
         # recorded so its items are skipped, not misplaced into the no-folder root.
-        folder_names = {fname for fname, _ in entries.values() if fname}
+        folder_names: set[str] = (
+            {fname for fname, _ in entries.values() if fname}
+            if create_folders
+            else set()
+        )
         failed_folders: set[str] = set()
         for fname in sorted(folder_names):
             try:
@@ -1143,7 +1151,11 @@ class BitwardenServeClient:
                 continue
             # Bind folder ID — shallow-copy rather than mutating the shared dict.
             item = copy.copy(bw_item)
-            item["folderId"] = self._folders.get(folder_name) if folder_name else None
+            item["folderId"] = (
+                self._folders.get(folder_name)
+                if create_folders and folder_name
+                else None
+            )
             try:
                 item_id = self.create_item(item)
             except BitwardenClientError as exc:

--- a/src/kp2bw/cli.py
+++ b/src/kp2bw/cli.py
@@ -185,7 +185,21 @@ def _argparser() -> MyArgParser:
         "--bitwarden-collection",
         dest="bw_coll",
         metavar="ID",
-        help="Id of Org-Collection, or 'auto' for top-level folder names (env: KP2BW_BITWARDEN_COLLECTION)",
+        help=(
+            "Id of Org-Collection, 'auto' for top-level folder names, or "
+            "'nested' for full folder paths (env: KP2BW_BITWARDEN_COLLECTION)"
+        ),
+        default=None,
+    )
+    parser.add_argument(
+        "--no-folder",
+        dest="create_folders",
+        help=(
+            "Do not create personal Bitwarden folders from KeePass groups; "
+            "items are kept at the vault root unless collections apply "
+            "(env: KP2BW_CREATE_FOLDERS=0)"
+        ),
+        action="store_false",
         default=None,
     )
     parser.add_argument(
@@ -735,6 +749,11 @@ def main() -> None:
             "KP2BW_INCLUDE_OVERSIZE_SECRETS",
             default=False,
         )
+        create_folders = _resolve_bool_option(
+            args.create_folders,
+            "KP2BW_CREATE_FOLDERS",
+            default=True,
+        )
         skip_confirm = _resolve_bool_option(
             args.skip_confirm, "KP2BW_YES", default=False
         )
@@ -913,6 +932,7 @@ def main() -> None:
         update_existing=update_existing,
         force_update=force_update,
         include_oversize_secrets=include_oversize_secrets,
+        create_folders=create_folders,
         uri_match=uri_match,
         interpret_uri_syntax=interpret_uri_syntax,
     )

--- a/src/kp2bw/cli.py
+++ b/src/kp2bw/cli.py
@@ -192,14 +192,14 @@ def _argparser() -> MyArgParser:
         default=None,
     )
     parser.add_argument(
-        "--no-folder",
+        "--folder",
         dest="create_folders",
         help=(
-            "Do not create personal Bitwarden folders from KeePass groups; "
-            "items are kept at the vault root unless collections apply "
-            "(env: KP2BW_CREATE_FOLDERS=0)"
+            "Create personal Bitwarden folders from KeePass groups (default: on, "
+            "but off when --bitwarden-org is set); --no-folder keeps items at the "
+            "vault root unless collections apply (env: KP2BW_CREATE_FOLDERS)"
         ),
-        action="store_false",
+        action=BooleanOptionalAction,
         default=None,
     )
     parser.add_argument(
@@ -749,10 +749,13 @@ def main() -> None:
             "KP2BW_INCLUDE_OVERSIZE_SECRETS",
             default=False,
         )
+        # Personal folders are a personal-vault concept; under --bitwarden-org
+        # they duplicate the collection tree, so default them off there. Explicit
+        # --folder/--no-folder or KP2BW_CREATE_FOLDERS still wins (issue #33).
         create_folders = _resolve_bool_option(
             args.create_folders,
             "KP2BW_CREATE_FOLDERS",
-            default=True,
+            default=not args.bw_org,
         )
         skip_confirm = _resolve_bool_option(
             args.skip_confirm, "KP2BW_YES", default=False

--- a/src/kp2bw/convert.py
+++ b/src/kp2bw/convert.py
@@ -53,6 +53,12 @@ KPEX_PASSKEY_PREFIX: str = "KPEX_PASSKEY_"
 # Bitwarden item type for login entries (1=login, 2=secureNote, 3=card,
 # 4=identity).  kp2bw only ever creates and content-syncs login items.
 BW_ITEM_TYPE_LOGIN: int = 1
+AUTO_COLLECTION_MODE: str = "auto"
+NESTED_COLLECTION_MODE: str = "nested"
+COLLECTION_FOLDER_MODES: frozenset[str] = frozenset({
+    AUTO_COLLECTION_MODE,
+    NESTED_COLLECTION_MODE,
+})
 
 # Single custom field holding KeePass metadata Bitwarden has no native slot for
 # (tags, expiry) as readable YAML. Folds what used to be several rows into one,
@@ -209,6 +215,7 @@ class Converter:
     _migrate_metadata: bool
     _update_existing: bool
     _include_oversize_secrets: bool
+    _create_folders: bool
     _uri_match: UriMatchValue
     _interpret_uri_syntax: bool
     _kp_ref_entries: list[Entry]
@@ -236,6 +243,7 @@ class Converter:
         update_existing: bool = True,
         force_update: bool = False,
         include_oversize_secrets: bool = False,
+        create_folders: bool = True,
         uri_match: UriMatchValue = None,
         interpret_uri_syntax: bool = True,
     ) -> None:
@@ -255,6 +263,7 @@ class Converter:
         self._update_existing = update_existing
         self._force_update_all = force_update
         self._include_oversize_secrets = include_oversize_secrets
+        self._create_folders = create_folders
         self._uri_match = uri_match
         self._interpret_uri_syntax = interpret_uri_syntax
         self._kp_ref_entries = []
@@ -867,14 +876,20 @@ class Converter:
         self,
         bw: BitwardenServeClient,
         bw_item: BwItemCreate,
+        folder: str | None,
         firstlevel: str | None,
     ) -> str | None:
         """Resolve and set collection ID on *bw_item*."""
         collection_id: str | None = None
-        if self._bitwarden_coll_id == "auto":
-            if firstlevel:
-                logger.log(VERBOSE, f"Searching Collection {firstlevel}")
-                collection_id = bw.create_org_collection(firstlevel)
+        if self._bitwarden_coll_id in COLLECTION_FOLDER_MODES:
+            collection_name = (
+                folder
+                if self._bitwarden_coll_id == NESTED_COLLECTION_MODE
+                else firstlevel
+            )
+            if collection_name:
+                logger.log(VERBOSE, f"Searching Collection {collection_name}")
+                collection_id = bw.create_org_collection(collection_name)
         elif self._bitwarden_coll_id:
             collection_id = self._bitwarden_coll_id
 
@@ -889,6 +904,7 @@ class Converter:
         self,
         bw: BitwardenServeClient,
         bw_item: BwItemCreate,
+        folder: str | None,
         firstlevel: str | None,
     ) -> bool:
         """Resolve+set the collection for *bw_item*, reporting failure non-fatally.
@@ -900,7 +916,7 @@ class Converter:
         phases have (issue #24).
         """
         try:
-            self._resolve_collection(bw, bw_item, firstlevel)
+            self._resolve_collection(bw, bw_item, folder, firstlevel)
         except BitwardenClientError as exc:
             logger.warning(
                 f"Could not resolve the collection for {bw_item.get('name', '?')!r}; "
@@ -1292,7 +1308,8 @@ class Converter:
         # new and are imported into the target collection rather than skipped.
         fixed_coll_id = (
             self._bitwarden_coll_id
-            if self._bitwarden_coll_id and self._bitwarden_coll_id != "auto"
+            if self._bitwarden_coll_id
+            and self._bitwarden_coll_id not in COLLECTION_FOLDER_MODES
             else None
         )
 
@@ -1349,7 +1366,7 @@ class Converter:
                 # Resolve collection (mutates bw_item). A dropped collection
                 # POST is non-fatal: skip just this entry rather than abort the
                 # whole loop and strand every entry after it (issue #24).
-                if not self._resolve_collection_safely(bw, bw_item, firstlevel):
+                if not self._resolve_collection_safely(bw, bw_item, folder, firstlevel):
                     n_create_failed += 1
                     progress.advance(task1)
                     continue
@@ -1433,6 +1450,7 @@ class Converter:
                     import_entries,
                     on_item_created=_on_created,
                     on_item_failed=_on_create_failed,
+                    create_folders=self._create_folders,
                 )
             else:
                 key_to_id = {}

--- a/src/kp2bw/convert.py
+++ b/src/kp2bw/convert.py
@@ -1380,6 +1380,12 @@ class Converter:
                 existing = bw.get_item_by_uuid(key)
                 adopted = False
                 if existing is None:
+                    # Fallback for pre-stamp legacy items only. Keyed on the
+                    # KeePass (folder, name); under --no-folder those items were
+                    # created with folderId=None, so this folder-based claim can
+                    # miss them and re-create. Harmless for anything kp2bw wrote
+                    # since: the UUID-stamp match above is folder-independent and
+                    # keeps re-runs idempotent.
                     existing = bw.claim_legacy_item(folder, bw_item["name"])
                     adopted = existing is not None
                 if existing is not None:

--- a/tests/bw_serve_batch_test.py
+++ b/tests/bw_serve_batch_test.py
@@ -9,7 +9,7 @@ have.  These checks drive the per-item (and per-folder) guard in
 """
 
 from collections.abc import Iterable
-from typing import cast
+from typing import Any, cast
 
 from kp2bw.bw_serve import BitwardenServeClient
 from kp2bw.bw_types import BwItemCreate
@@ -39,6 +39,7 @@ class _BatchClient(BitwardenServeClient):
         self._fail_items = set(fail_items or ())
         self._fail_folders = set(fail_folders or ())
         self.created: list[str] = []
+        self.created_payloads: list[dict[str, Any]] = []
         self.folders_created: list[str] = []
 
     def create_folder(self, name: str) -> str:
@@ -54,6 +55,7 @@ class _BatchClient(BitwardenServeClient):
         if name in self._fail_items:
             raise BitwardenClientError(f"simulated create timeout: {name}")
         self.created.append(name)
+        self.created_payloads.append(dict(item))
         return f"id-{name}"
 
 
@@ -123,11 +125,31 @@ def assert_folder_failure_skips_only_its_items() -> None:
         raise AssertionError("an item must not be created without its folder")
 
 
+def assert_no_folder_mode_does_not_create_or_bind_folders() -> None:
+    """Disabling folders leaves items at the root and never calls create_folder."""
+    bw = _BatchClient(fail_folders={"Bad"})
+    entries = {
+        "k1": ("Good", _item("a")),
+        "k2": ("Bad", _item("b")),
+    }
+    key_to_id = bw.create_items_batch(entries, create_folders=False)
+    if set(key_to_id) != {"k1", "k2"}:
+        raise AssertionError(f"all items should be created, got {set(key_to_id)}")
+    if bw.folders_created:
+        raise AssertionError(f"no folders should be created, got {bw.folders_created}")
+    folder_ids = [payload.get("folderId") for payload in bw.created_payloads]
+    if folder_ids != [None, None]:
+        raise AssertionError(
+            f"items should be created without folderId, got {folder_ids}"
+        )
+
+
 def main() -> None:
     """Run the script-style assertions and report success."""
     assert_item_failure_does_not_abort_batch()
     assert_failed_items_are_reported()
     assert_folder_failure_skips_only_its_items()
+    assert_no_folder_mode_does_not_create_or_bind_folders()
     print("bw serve batch test passed")
 
 

--- a/tests/cli_env_test.py
+++ b/tests/cli_env_test.py
@@ -14,6 +14,7 @@ _MANAGED_ENV = (
     "KP2BW_KEEPASS_FILE",
     "KP2BW_KEEPASS_PASSWORD",
     "KP2BW_BITWARDEN_PASSWORD",
+    "KP2BW_CREATE_FOLDERS",
     "KP2BW_YES",
     "KP2BW_LOG_DIR",
 )
@@ -70,6 +71,7 @@ def assert_dotenv_supplies_keepass_file() -> None:
         _ = os.environ.pop("KP2BW_KEEPASS_FILE", None)
         os.environ["KP2BW_KEEPASS_PASSWORD"] = "kp-pw"
         os.environ["KP2BW_BITWARDEN_PASSWORD"] = "bw-pw"
+        os.environ["KP2BW_CREATE_FOLDERS"] = "0"
         os.environ["KP2BW_YES"] = "1"
         os.environ["KP2BW_LOG_DIR"] = tmp  # keep the run's log inside the temp dir
 
@@ -90,6 +92,8 @@ def assert_dotenv_supplies_keepass_file() -> None:
         db_path = _CapturingConverter.captured.get("keepass_file_path")
         if db_path != "from-dotenv.kdbx":
             raise AssertionError(f"expected db path from .env, got {db_path!r}")
+        if _CapturingConverter.captured.get("create_folders") is not False:
+            raise AssertionError("KP2BW_CREATE_FOLDERS=0 should disable folders")
     finally:
         sys.argv = original_argv
         # Release the log file (so rmtree works on Windows) without stripping

--- a/tests/cli_env_test.py
+++ b/tests/cli_env_test.py
@@ -14,6 +14,7 @@ _MANAGED_ENV = (
     "KP2BW_KEEPASS_FILE",
     "KP2BW_KEEPASS_PASSWORD",
     "KP2BW_BITWARDEN_PASSWORD",
+    "KP2BW_BITWARDEN_ORG",
     "KP2BW_CREATE_FOLDERS",
     "KP2BW_YES",
     "KP2BW_LOG_DIR",
@@ -148,9 +149,65 @@ def assert_empty_env_var_defers_to_dotenv() -> None:
         shutil.rmtree(tmp, ignore_errors=True)
 
 
+def assert_org_disables_personal_folders_by_default() -> None:
+    """`--bitwarden-org` flips the personal-folder default off (issue #33).
+
+    Folders only duplicate the collection tree inside the personal vault, so an
+    org import defaults to collections-only. Without an org the default stays on.
+    No explicit ``KP2BW_CREATE_FOLDERS`` is set, so only the org-aware default is
+    under test; an explicit override is covered by the dotenv test above.
+    """
+    original_cwd = Path.cwd()
+    original_argv = sys.argv
+    original_handlers = list(logging.getLogger().handlers)
+    saved_env = {key: os.environ.get(key) for key in _MANAGED_ENV}
+
+    tmp = tempfile.mkdtemp()
+    try:
+        os.environ["KP2BW_KEEPASS_FILE"] = "from-env.kdbx"
+        os.environ["KP2BW_KEEPASS_PASSWORD"] = "kp-pw"
+        os.environ["KP2BW_BITWARDEN_PASSWORD"] = "bw-pw"
+        os.environ["KP2BW_YES"] = "1"
+        os.environ["KP2BW_LOG_DIR"] = tmp
+        _ = os.environ.pop("KP2BW_CREATE_FOLDERS", None)
+        # Run from an empty dir so dotenv autoload can't pull a real project
+        # .env into the env under test.
+        os.chdir(tmp)
+        sys.argv = ["kp2bw"]
+
+        def _run() -> object:
+            with (
+                mock.patch.object(cli, "ensure_bw_available", lambda: None),
+                mock.patch.object(cli, "Converter", _CapturingConverter),
+            ):
+                cli.main()
+            return _CapturingConverter.captured.get("create_folders")
+
+        # Org set -> folders default off.
+        os.environ["KP2BW_BITWARDEN_ORG"] = "org-1"
+        if _run() is not False:
+            raise AssertionError("an org import should default to no personal folders")
+
+        # No org -> folders default on.
+        _ = os.environ.pop("KP2BW_BITWARDEN_ORG", None)
+        if _run() is not True:
+            raise AssertionError("without an org, personal folders should default on")
+    finally:
+        sys.argv = original_argv
+        _reset_root_logging(original_handlers)
+        os.chdir(original_cwd)
+        shutil.rmtree(tmp, ignore_errors=True)
+        for key, value in saved_env.items():
+            if value is None:
+                _ = os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+
+
 def main() -> None:
     assert_dotenv_supplies_keepass_file()
     assert_empty_env_var_defers_to_dotenv()
+    assert_org_disables_personal_folders_by_default()
     print("cli env test passed")
 
 

--- a/tests/convert_resilience_test.py
+++ b/tests/convert_resilience_test.py
@@ -32,10 +32,14 @@ class ResilienceTestConverter(Converter):
         )
 
     def resolve_collection_safely(
-        self, bw: BitwardenServeClient, bw_item: BwItemCreate, firstlevel: str | None
+        self,
+        bw: BitwardenServeClient,
+        bw_item: BwItemCreate,
+        folder: str | None,
+        firstlevel: str | None,
     ) -> bool:
         """Public shim for the guarded collection resolution."""
-        return self._resolve_collection_safely(bw, bw_item, firstlevel)
+        return self._resolve_collection_safely(bw, bw_item, folder, firstlevel)
 
     def sync_safely(self, bw: BitwardenServeClient) -> None:
         """Public shim for the guarded pre-attachment sync."""
@@ -83,7 +87,7 @@ def assert_collection_failure_is_non_fatal() -> None:
     conv = ResilienceTestConverter()
     bw = _FakeBw(fail_collection=True)
     bw_item = _bw_item()
-    ok = conv.resolve_collection_safely(_as_bw(bw), bw_item, "Team")
+    ok = conv.resolve_collection_safely(_as_bw(bw), bw_item, "Team/Servers", "Team")
     if ok:
         raise AssertionError("a failed collection resolution must report False")
     if bw_item.get("collectionIds"):
@@ -94,12 +98,33 @@ def assert_collection_success_assigns_and_reports_true() -> None:
     conv = ResilienceTestConverter()
     bw = _FakeBw(coll_id="coll-9")
     bw_item = _bw_item()
-    ok = conv.resolve_collection_safely(_as_bw(bw), bw_item, "Team")
+    ok = conv.resolve_collection_safely(_as_bw(bw), bw_item, "Team/Servers", "Team")
     if not ok:
         raise AssertionError("a successful resolution must report True")
+    if bw.calls != ["Team"]:
+        raise AssertionError(
+            f"auto collection mode should use top-level folder, got {bw.calls}"
+        )
     if cast(Any, bw_item).get("collectionIds") != ["coll-9"]:
         raise AssertionError(
             f"resolution must assign the collection, got {bw_item.get('collectionIds')}"
+        )
+
+
+def assert_nested_collection_uses_full_folder_path() -> None:
+    conv = ResilienceTestConverter(coll_id="nested")
+    bw = _FakeBw(coll_id="coll-nested")
+    bw_item = _bw_item()
+    ok = conv.resolve_collection_safely(_as_bw(bw), bw_item, "Team/Servers", "Team")
+    if not ok:
+        raise AssertionError("a successful nested resolution must report True")
+    if bw.calls != ["Team/Servers"]:
+        raise AssertionError(
+            f"nested collection mode should use full folder path, got {bw.calls}"
+        )
+    if cast(Any, bw_item).get("collectionIds") != ["coll-nested"]:
+        raise AssertionError(
+            f"nested resolution must assign the collection, got {bw_item.get('collectionIds')}"
         )
 
 
@@ -123,6 +148,7 @@ def main() -> None:
     """Run the script-style assertions and report success."""
     assert_collection_failure_is_non_fatal()
     assert_collection_success_assigns_and_reports_true()
+    assert_nested_collection_uses_full_folder_path()
     assert_pre_attachment_sync_failure_is_non_fatal()
     print("convert resilience test passed")
 

--- a/tests/uri_mapping_test.py
+++ b/tests/uri_mapping_test.py
@@ -29,7 +29,7 @@ def _uris(
     android_packages: list[str] | None = None,
     plain_match: UriMatchValue = None,
     interpret_syntax: bool = True,
-) -> list[tuple[str, object]]:
+) -> list[tuple[str, UriMatchValue]]:
     """Run build_login_uris and return [(uri, match)] for terse assertions."""
     result = build_login_uris(
         primary_url=primary_url,

--- a/tests/uri_mapping_test.py
+++ b/tests/uri_mapping_test.py
@@ -11,6 +11,7 @@ from typing import cast
 
 from kp2bw.bw_types import BwField, BwUri
 from kp2bw.uri_mapping import (
+    UriMatchValue,
     build_login_uris,
     collision_groups,
     is_url_attribute_key,
@@ -21,9 +22,22 @@ from kp2bw.uri_mapping import (
 )
 
 
-def _uris(**kwargs: object) -> list[tuple[str, object]]:
+def _uris(
+    *,
+    primary_url: str,
+    additional_urls: list[str],
+    android_packages: list[str] | None = None,
+    plain_match: UriMatchValue = None,
+    interpret_syntax: bool = True,
+) -> list[tuple[str, object]]:
     """Run build_login_uris and return [(uri, match)] for terse assertions."""
-    result = build_login_uris(**kwargs)  # pyright: ignore[reportArgumentType]
+    result = build_login_uris(
+        primary_url=primary_url,
+        additional_urls=additional_urls,
+        android_packages=android_packages or [],
+        plain_match=plain_match,
+        interpret_syntax=interpret_syntax,
+    )
     return [(u["uri"], u.get("match")) for u in result]
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -384,7 +384,7 @@ wheels = [
 
 [[package]]
 name = "kp2bw"
-version = "3.6.0"
+version = "3.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/uv.lock
+++ b/uv.lock
@@ -19,14 +19,14 @@ wheels = [
 
 [[package]]
 name = "anyio"
-version = "4.13.0"
+version = "4.14.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "idna" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1c/b5/001890774a9552aff22502b8da382593109ce0c95314abaebbb116567545/anyio-4.14.0.tar.gz", hash = "sha256:b47c1f9ccf73e67021df785332508f99379c68fa7d0684e8e3492cb1d4b23f89", size = 253586, upload-time = "2026-06-15T22:00:49.021Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/16/9826f089383c593cdfc4a6e5aca94d9e91ae1692c57af82c3b2aa5e810f7/anyio-4.14.0-py3-none-any.whl", hash = "sha256:dd9b7a2a9799ed6552fde617b2c5df02b7fdd7d88392fc48101e51bae46164d9", size = 123506, upload-time = "2026-06-15T22:00:47.595Z" },
 ]
 
 [[package]]
@@ -83,14 +83,14 @@ wheels = [
 
 [[package]]
 name = "basedpyright"
-version = "1.39.7"
+version = "1.39.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "nodejs-wheel-binaries" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2f/e5/0d685b5808436c628ab8b9edad6810b889d11044a962bc42b128543910ea/basedpyright-1.39.7.tar.gz", hash = "sha256:688d913a19c417870c164c630ed9cdd83a8d8b484b30ab8e99f5dec4ae9604a6", size = 25503256, upload-time = "2026-06-07T11:33:27.266Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d2/62/8550c75850b2185df984d1de437b4805b039ba856cacbee2966236203133/basedpyright-1.39.8.tar.gz", hash = "sha256:bb1a86d4d71425d52d1501b317fe23d45527baed06bd5d5e1a07cd4b60d07b55", size = 25488230, upload-time = "2026-06-14T09:05:30.177Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a1/f4/5b1e8ea279ce8f97a6bb1518c84fa25f5794022053ce10eab22ad3f0b51b/basedpyright-1.39.7-py3-none-any.whl", hash = "sha256:81266deb6044c9be98fb4555e4b7b1a521d8aee06b66e80858d183b0e3991140", size = 13182666, upload-time = "2026-06-07T11:33:24.119Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/94/878454aefe94328ba7ad808ecd63da8311aae1198da46cfb29f5cfe130a8/basedpyright-1.39.8-py3-none-any.whl", hash = "sha256:a79d89928064bd9023d429b50c625d87d023bacc2fe3932ef6c7bd13b5426048", size = 13182726, upload-time = "2026-06-14T09:05:26.368Z" },
 ]
 
 [[package]]
@@ -130,11 +130,11 @@ wheels = [
 
 [[package]]
 name = "certifi"
-version = "2026.5.20"
+version = "2026.6.17"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f3/ce/ee2ecad540810a79593028e88299baeae54d346cc7a0d94b6199988b89b1/certifi-2026.5.20.tar.gz", hash = "sha256:69dea482ab64caa7b9f6aba1c6bf48bb6a5448d1c0f1b17ab42ad8c763a5344d", size = 135422, upload-time = "2026-05-20T11:46:50.073Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/c7/424b75da314c1045981bd9777432fad05a9e0c69daa4ed7e308bbaffe405/certifi-2026.6.17.tar.gz", hash = "sha256:024c88eeec92ca068db80f02b8b07c9cef7b9fe261d1d535abfd5abd6f6af432", size = 134594, upload-time = "2026-06-17T10:31:07.894Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/59/8c/57e832b7af6d7c5abe66eb3fbe3a3a32f4d11ea23a1aa7131371035be991/certifi-2026.5.20-py3-none-any.whl", hash = "sha256:3c52e209ba0a4ad7aebe60436a4ab349c39e1e602e8c134221e546902ad25897", size = 134134, upload-time = "2026-05-20T11:46:48.578Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/2f/c5464532e965badff2f4c4c1a3a83f5697f0d7c407ed0cda44aaa99bb451/certifi-2026.6.17-py3-none-any.whl", hash = "sha256:2227dcbaafe0d2f59279d1762ddddc37783ed4354594f194ffc31d20f41fc3db", size = 133289, upload-time = "2026-06-17T10:31:06.348Z" },
 ]
 
 [[package]]
@@ -202,41 +202,41 @@ wheels = [
 
 [[package]]
 name = "coverage"
-version = "7.14.1"
+version = "7.14.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/54/fd/0ab2772530e946e1be1abd0bc09e647ec9b02e88f0867857601fefca8953/coverage-7.14.1.tar.gz", hash = "sha256:30c08f7d90415aa98b3c990385dea2939b0da55f38515e5b369b83655f8523be", size = 920132, upload-time = "2026-05-26T20:41:36.783Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9c/a3/3834a5564fe8f32154cd7032400d3c2f9c565b2a373fa671f2bbdad6f634/coverage-7.14.2.tar.gz", hash = "sha256:7a2da3d81cfe17c18038c6d98e6592aa9147d596d056119b0ee612c3c8bd5230", size = 923982, upload-time = "2026-06-20T14:49:30.885Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d6/34/fc2f101b151af3799a101f0550b0454aa008afdc0add677394ec4aa8ea10/coverage-7.14.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:d5ed429d0b8edaac649e889b4ffcedb6c80b06629a3f93050e3dddfb99235bee", size = 220091, upload-time = "2026-05-26T20:40:27.249Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/a7/1ebae2ab5b961b5c79bb09fe7b3ac99edb190d8be4a8c510b2cf66f46468/coverage-7.14.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:8011224a62280e50dab346960c03cf47aca1a1e09e608c0fb33fd6e0cc8e9500", size = 220421, upload-time = "2026-05-26T20:40:30.084Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/90/92aca9cf0acc95123c96cd1eb1f08917897a7f5dee01e15738922971ec31/coverage-7.14.1-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:12c42ec1e14f553c4f817e989365982e646e27211f10a0f717855b94a79c8906", size = 251466, upload-time = "2026-05-26T20:40:32.542Z" },
-    { url = "https://files.pythonhosted.org/packages/26/2b/78048cbe3b999f6cbf9cc0d90abba6a88a3e0863a8c1c6cbc762f3f8802f/coverage-7.14.1-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:06144cd511cf2624873a035c5069cf297144f6e77a73ee3d7a55b605ec5efb42", size = 253973, upload-time = "2026-05-26T20:40:34.473Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/21/c2e33b29d1cfde484a19d437afc343c6cd30b08d78cbbf9f5aff14e57b2b/coverage-7.14.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a311d8e1da24be5c1ccf85cbfb06315dbaa1703d5a1eab3f6432c72b837917c8", size = 255318, upload-time = "2026-05-26T20:40:38.154Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/ee/aad2f108d63b769121005302f16bf66db8625c88ceaba466942e09a2607e/coverage-7.14.1-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c79cead5b5bc584d9c71451cb984d0e3a84e0c0937379c8efcbf27c8d661b851", size = 257633, upload-time = "2026-05-26T20:40:40.164Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/f8/11a2c29b4fd76d9849f81d0bb812ec0017a9396df3217214e38934a8c837/coverage-7.14.1-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:dcbf65f1f66a26cdd88c35cf68fb4729c5d1cd2e88added72420541dfb212034", size = 251488, upload-time = "2026-05-26T20:40:42.631Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/b8/9a5820de4b8ac2b71d85e3b5fb49108d7469c665f0e2ad0dd7569023e305/coverage-7.14.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:fd86572566fb40189a8260446158235159bc7a82dfbc87a3b39cf4fb57fcec1c", size = 253329, upload-time = "2026-05-26T20:40:45.208Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/ff/f33e4823667e27548e8fd8df44217515303f9808d0ff29817db56f87d990/coverage-7.14.1-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:7771b601718fdde84832c3a434ca9bbf4ae9adbc49d84198b4110700c3c77c36", size = 251291, upload-time = "2026-05-26T20:40:47.502Z" },
-    { url = "https://files.pythonhosted.org/packages/68/9b/489db0ebb209054766b90a9014a45f6d26eb724c02ec21311c3733b5a644/coverage-7.14.1-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:39b21e212c55af06fa375e3dbf90a8a8e38792f3a910c580066d23563830ddd5", size = 255564, upload-time = "2026-05-26T20:40:49.372Z" },
-    { url = "https://files.pythonhosted.org/packages/27/b5/16bc2d4c2409b23c7737edb68c83bc89e345f378050549fe1d75ac7d34d5/coverage-7.14.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:f2302660e32562a532b442480121aef8aa61a5bdb20b30bf0adab29f10a5a4b4", size = 251107, upload-time = "2026-05-26T20:40:51.677Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/0c/2629997469a00cd069d588a41c9dc887610f2775ae89d250c4791e65272a/coverage-7.14.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:03a6f93c1ec3b7f2e77b5dbcc5573a2c21f12529a5c6bbe0f16f72303cc2fa4d", size = 252764, upload-time = "2026-05-26T20:40:54.267Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/ee/f78d63c8f079e0d7211c7e2401fa17e311514534ba61bae03e4b287ce4ab/coverage-7.14.1-cp314-cp314-win32.whl", hash = "sha256:8a3ce026d73290f42f08dafecbd82c193a74df280461fbf97300fec51fd133ee", size = 222837, upload-time = "2026-05-26T20:40:56.496Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/b9/be539854f93a70dfbeec69117f33ec70dc42ff0b65b5b07ab8d40d04228e/coverage-7.14.1-cp314-cp314-win_amd64.whl", hash = "sha256:114c95ef29302423b87d159075805f4ab973254a2638a5d7d046c94887cc87d7", size = 223650, upload-time = "2026-05-26T20:40:58.351Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/9e/24e2842fef40f35ac82ba3a7719c8023d011bf3bf652d0675316a9d088a1/coverage-7.14.1-cp314-cp314-win_arm64.whl", hash = "sha256:a07891c3f4805442b31b71e84ba3cf29ed1aa9a428284e06deeb4b23e5b46343", size = 222218, upload-time = "2026-05-26T20:41:00.321Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/1d/ac0a9df5fe31c1e8bdd658074905fc12844a05c1a7e3fdb8417e97c31e23/coverage-7.14.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:1101a5ebb083aecb625ebb6209d4105b58f647b093cb2dc8122d7b33f743cfe1", size = 220822, upload-time = "2026-05-26T20:41:02.281Z" },
-    { url = "https://files.pythonhosted.org/packages/32/cf/f964fd9aff20323f9f1a726c97135f8a76bcd87b92dad141a456a43f3c64/coverage-7.14.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:851b9e1e4e8a4608e77c79714b2e77c0970d2ed7202a05e92ae407817481887b", size = 221084, upload-time = "2026-05-26T20:41:04.593Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/5e/7e5ef2aba844de2b80d678619fcf0841b42e3f37f16411226f3fe4c1016f/coverage-7.14.1-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:d5b89cdfb2ee051b71e8c3c70bd81a9eff81100f736a269136fe1a68efe00474", size = 262454, upload-time = "2026-05-26T20:41:06.641Z" },
-    { url = "https://files.pythonhosted.org/packages/64/62/75809bded87015cc4935524218a2a8ed8dd1a8498bfed30a2f4f7a4b4d34/coverage-7.14.1-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0177614a0370f227888b4e436a7c55686d6a9f90eb1ade2b624ba685a1686e86", size = 264578, upload-time = "2026-05-26T20:41:08.556Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/42/d33392dc14633525012d2d504fa1a33b05538bf535f5c1d64675e5754b78/coverage-7.14.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2d69af5dea2de76fc485a83032a630523f985198b7e25be901ec60181587b01e", size = 266981, upload-time = "2026-05-26T20:41:10.824Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/49/0157c4428c2aca7f1e09d5565930586fd5ae36f1655f08b0daa7cf1fcae1/coverage-7.14.1-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:35ab22d91de736e8966b980dc355cbcdd2c6dbbcfe275f9a2991bc8a91b3df65", size = 268112, upload-time = "2026-05-26T20:41:12.966Z" },
-    { url = "https://files.pythonhosted.org/packages/96/26/86b9ce71f4092b1ed325ce1421698081df1286b833400b6836912834d6e0/coverage-7.14.1-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:357d4e32935c36588aaba057d734fa32428c360c9fc2e4442afbf1b646beee6e", size = 261558, upload-time = "2026-05-26T20:41:15Z" },
-    { url = "https://files.pythonhosted.org/packages/20/4c/c311210c5472cf5401d8422b0d7812cdd520f24417673afabda6c323faca/coverage-7.14.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:51bd64741cc6fa065abd300ede1afe5a5291ece9c31da8b24884deda48bcc3f8", size = 264447, upload-time = "2026-05-26T20:41:17.369Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/71/59513f8710ed3e6b0ac0a050a5b7e977bb9c9e880354863b5d00d8809256/coverage-7.14.1-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:9132cd363a68a4c3daa7c8704a654b1e39d3360f6f5b8ddd470608a945236c07", size = 262048, upload-time = "2026-05-26T20:41:19.309Z" },
-    { url = "https://files.pythonhosted.org/packages/84/8d/bceed32dc494f5bbf50f775cd2e78ca814953942b5ea28d3c1c3ac316f14/coverage-7.14.1-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:07c6290b1697b862c0478eab545eec949a0d0e4d6d03497f446d706da3b4f2de", size = 265781, upload-time = "2026-05-26T20:41:21.559Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/c5/9348fe40dbfd4991aaf78df2c6c3098bfb2cc834d1fd362a64b4efef855a/coverage-7.14.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:5ea0c297e27133853b4d8a3eb799bff5a2dbd9f2f41537a240d337ac9b4df890", size = 260896, upload-time = "2026-05-26T20:41:23.428Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/92/1ea0f03929da7cf87206b1fa24f4c8e9c158be0455481af29ec0a1f3503f/coverage-7.14.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:01b7733daad0237daa01ef80fe2dfceffc911e6a17fa7b55d14aa8214eaaaecd", size = 263214, upload-time = "2026-05-26T20:41:25.419Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/a9/b2493c054c0e01a643266742ab45e15744e60743f9260cd930c7142b1124/coverage-7.14.1-cp314-cp314t-win32.whl", hash = "sha256:6adc5a36984624a70bf11d7184e20fa0a49aa7c47ffab43804106a1a695ea22e", size = 223624, upload-time = "2026-05-26T20:41:27.795Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/bd/3e1e6a57fccd2d7c83fcdf338e93ba98eb85c6e877dd34731ac585375490/coverage-7.14.1-cp314-cp314t-win_amd64.whl", hash = "sha256:ddf799247318f34dbcd2efa8c95a8d0642674e926bb1774cf9b63dfd2a389d1c", size = 224728, upload-time = "2026-05-26T20:41:30.098Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/d7/31066cf1d2f0c6c797fce911bcfa01dd35642dc6da992a950256097c5860/coverage-7.14.1-cp314-cp314t-win_arm64.whl", hash = "sha256:145986fe66647eb489f18d9a997567a3fd358584c4b5a808769113abc07466af", size = 222752, upload-time = "2026-05-26T20:41:32.123Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/3c/1a983b9a745d7f83d53f057bcc5bf79ba6a2bbc08266b3f0c7d6fe630c9b/coverage-7.14.1-py3-none-any.whl", hash = "sha256:a252f21c27e38347e60111a3266b03827422a7d5525951aceee313aa68bab1d2", size = 211815, upload-time = "2026-05-26T20:41:34.078Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/bc/120390669817ede714ab141ae0a2a73240fd7354aac992c41dc0bd19570f/coverage-7.14.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:7a0d1f026b72d627fa5c8a57cbc86ad209b64aa2a65833c83b290ace5cbee126", size = 220593, upload-time = "2026-06-20T14:48:35.755Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/a3/7f1cfacd76af91e585f7ad689d7168002b444ed2a8ce59f2daaff10089b5/coverage-7.14.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:4d2b86f81c1c9310a7e774e3cc9e927a3d0bf583ecbfa01498dd626930025428", size = 220925, upload-time = "2026-06-20T14:48:37.35Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/10/6514b2525bb672eb8b43703e46d061d694111db21efe7609db722df2233f/coverage-7.14.2-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:d76bdc1f9396ae70a55d050cf9743d88141c62ce0a22a3f627fab1d11c2f8bc6", size = 251974, upload-time = "2026-06-20T14:48:39.109Z" },
+    { url = "https://files.pythonhosted.org/packages/23/b4/4533091541c6620ecd68115bbfa1c61265b775618adef3a5fd137f4582e9/coverage-7.14.2-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:cda36d8e7bfd63b3e44e75163265429caa5d935b672b00f71bccc8c010518c64", size = 254479, upload-time = "2026-06-20T14:48:40.871Z" },
+    { url = "https://files.pythonhosted.org/packages/06/af/e251a143d5d106385dbca696c553afab6b69f7f6bc376a34e089cc0b8b32/coverage-7.14.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0904f3b79d7b845bef0715afe1900da634d12b97f05b9479cb472880ca07cb9c", size = 255824, upload-time = "2026-06-20T14:48:42.608Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/53/9e5876e60efbaa79d743d1948a5015ddc05b808db1cd62228acf83e87d43/coverage-7.14.2-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b6795ca4198d6cb7fc2c6163214f6555a6bc5f0ae1e268e76139dec4b37c4499", size = 258139, upload-time = "2026-06-20T14:48:44.263Z" },
+    { url = "https://files.pythonhosted.org/packages/85/5a/d35a4f431fb594e46b81cad4a13b470b017e918f347c1c0b260f7494fa1e/coverage-7.14.2-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c41e9b60fc0fa57f5d73306417d2f9d668202cca6944f9435878c55a5e7ae213", size = 252002, upload-time = "2026-06-20T14:48:45.961Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/e2/f5b304c8139c606c4f1b230d3a257d0c88edfbbdf06c58364f07625dc45c/coverage-7.14.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:419d2aadd5746efc2e9df0f33c05570d8192e6f6a6098ab05acce586f44ce8a5", size = 253832, upload-time = "2026-06-20T14:48:47.582Z" },
+    { url = "https://files.pythonhosted.org/packages/86/bc/bbbd283daa6be4f68aad4ad4066fd39ae98e4174db8c03ab26c5803d6234/coverage-7.14.2-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:1c5d273c5f1411c0d26c4f066c398d4a434b1f97bb5fa409189bedce86d4add4", size = 251799, upload-time = "2026-06-20T14:48:49.42Z" },
+    { url = "https://files.pythonhosted.org/packages/69/8d/0745fceb89c9e5f7dd8ed243d97dc8561b7a95545741e2409d2b34654824/coverage-7.14.2-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:5fe465bc691264adce601527a972990c1174075d86bcbe9968fd20c95e0b1948", size = 256075, upload-time = "2026-06-20T14:48:51.065Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/a0/441d9a5255cf021ab41ee00c014a4607d1c72d5e5bef0a4fdaa5be86a907/coverage-7.14.2-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:6fbb61617af1c56f95d53170ae9fa6c9aef6de1abd02fcc50064bfc672efb18d", size = 251612, upload-time = "2026-06-20T14:48:52.653Z" },
+    { url = "https://files.pythonhosted.org/packages/50/37/3d19c5e32d4a529c068eb296abfa3e455bd2c0f9311ecf26280f408ff8e0/coverage-7.14.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:e1eff22b831dfd5694989cc1f0789980f18391f614ac67c851af9a8e6d25e9ba", size = 253270, upload-time = "2026-06-20T14:48:54.3Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/b0/54dd13937297518da6d092cc2c39d9340ec2194bdfa92e0a64694d643e23/coverage-7.14.2-cp314-cp314-win32.whl", hash = "sha256:58e91be0a233adef698d3e6be54f10401bb91fd7854c0d4c4d50e0d3711e72f1", size = 222796, upload-time = "2026-06-20T14:48:56.084Z" },
+    { url = "https://files.pythonhosted.org/packages/51/45/7a10e0909919686e335fdd95869cfb222d55243ebff27dc5cf59ca259a1f/coverage-7.14.2-cp314-cp314-win_amd64.whl", hash = "sha256:d8429bf97906bfe6c61f9dbfb3342e0d88120da61939da8bd04f830cc3eab3b8", size = 223285, upload-time = "2026-06-20T14:48:57.729Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/03/9cb197eb4b3d1a2eccb2537c226a93c80522c5b8afc5dd93e1993d7bb021/coverage-7.14.2-cp314-cp314-win_arm64.whl", hash = "sha256:13609d9d77249447aa73357b14831b0f3b95f275026c9ff20dd105f981f53a0c", size = 222712, upload-time = "2026-06-20T14:48:59.413Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/3c/e59f498511080d20bf866b0af9eeab820feb91547dae2084cb9bb7fb0e58/coverage-7.14.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:9818486c2bac88ae931df7e04905ee29bef49fd218c00f5f02bed4855254a101", size = 221325, upload-time = "2026-06-20T14:49:01.447Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/37/8d7955f7e701e69198bd0a0132ea76518c078a635b930a4924e2ccfa70f0/coverage-7.14.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:58055adffabfa243516a197aa9f85f0dd56d905b0fba1a10193269759c29ccb0", size = 221594, upload-time = "2026-06-20T14:49:03.13Z" },
+    { url = "https://files.pythonhosted.org/packages/34/7a/6738e1e1533ce8ec4e2e472696eefdd4723864d7efaa140e433053bf576a/coverage-7.14.2-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:535747dbc200349d7fb434cffcb28e770f0290f69b225f56dc3803aa7210cdea", size = 262957, upload-time = "2026-06-20T14:49:04.829Z" },
+    { url = "https://files.pythonhosted.org/packages/35/c4/d1be863cd39e0955904315fece67c5c23e046563f5eea0ceac16c547a759/coverage-7.14.2-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:420c66e35d85c0ca5dc6a38147d83ef239762542900e5921ebbdb89333c540ea", size = 265081, upload-time = "2026-06-20T14:49:07.018Z" },
+    { url = "https://files.pythonhosted.org/packages/72/7f/412df3c3c251284a11834287fd6f7e3bb98c528c53e030589e9344a3ef80/coverage-7.14.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f2cf17b33773be446a588551ea6a746b2d70dd0bc90dc31f1dd7648975a63c6b", size = 267500, upload-time = "2026-06-20T14:49:08.709Z" },
+    { url = "https://files.pythonhosted.org/packages/54/68/7d0764e83459455384d5c04179ce2d2a837bef01b9ba463079c6e8b31361/coverage-7.14.2-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:adb4a5fef041f7179bb264203add873c147d169cf2f8d0adae89ff2e51271bac", size = 268619, upload-time = "2026-06-20T14:49:10.405Z" },
+    { url = "https://files.pythonhosted.org/packages/14/68/1292164ac70cbcc86ac3982da31a6fbb42bb4bcebf6e5cf73c99cfcfd50d/coverage-7.14.2-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9c012ec357dec9408a83dad5541172a63c5cfa1421709f2e5811480d31ae1b28", size = 262066, upload-time = "2026-06-20T14:49:12.257Z" },
+    { url = "https://files.pythonhosted.org/packages/20/44/fd6fdf3f63b6e00a1a9230022d072ded5189576001685706aa6524187c65/coverage-7.14.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:dacd0ecd08fda3cb2f85b60cabea7da326dcb2fc15fbb23a88830a80144cc9f2", size = 264953, upload-time = "2026-06-20T14:49:14.13Z" },
+    { url = "https://files.pythonhosted.org/packages/39/29/e803fea3da89eaeb5b6b41b3ccd039fe9f3300a900e3803baac1a998529f/coverage-7.14.2-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:f27e980f2feba5dfe7a32b22b125470de69c0bd113c75e16165de909a777f512", size = 262555, upload-time = "2026-06-20T14:49:15.803Z" },
+    { url = "https://files.pythonhosted.org/packages/32/3c/b360e48ac68e3236c04cb83658382e7f5be7efbbec2e1faae3dcca432783/coverage-7.14.2-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:105c00efb65c863630b2b63cbf7b8267e4da2d44b62284efbb19a03b04c337d4", size = 266289, upload-time = "2026-06-20T14:49:17.962Z" },
+    { url = "https://files.pythonhosted.org/packages/59/12/1ed6d9274d599c586e2d1aa9818765dcdae6bb52aa88afa2fcd868398191/coverage-7.14.2-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:571173fa04c8e8d6235ab32ae67fecca97777e2e1b4a1a30f3022c34e397c1c1", size = 261402, upload-time = "2026-06-20T14:49:19.708Z" },
+    { url = "https://files.pythonhosted.org/packages/44/17/eb6cf12a4538cda937aefbeabb15377a8a30b377b484e63d31c9da790966/coverage-7.14.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:e532f34d42d1a421fa00ed6b7735d14ac2e340256c1bad26a5e1dc1252b0bed7", size = 263715, upload-time = "2026-06-20T14:49:21.427Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/ca/4bafdb9d372ab05d6ed3a63e7f00d3195d169d0afea00f617c026e386c19/coverage-7.14.2-cp314-cp314t-win32.whl", hash = "sha256:243971550fb46c3039257f75e65610002d84304c505f609bbd9779e20a653a0a", size = 223103, upload-time = "2026-06-20T14:49:23.24Z" },
+    { url = "https://files.pythonhosted.org/packages/35/cb/0765dbd9011d2e47315f1da31e62c5fe231f04a6ec8da213e64c4505896d/coverage-7.14.2-cp314-cp314t-win_amd64.whl", hash = "sha256:60fb0ca084a92da96474b8b405a7ea76dfecac3c68db54383e7934b6f3871169", size = 223934, upload-time = "2026-06-20T14:49:25.347Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/ce/373dde027ecd0ae54511430fe7569f838d3a0376b70333ba9fd20c76b836/coverage-7.14.2-cp314-cp314t-win_arm64.whl", hash = "sha256:36a0a3f42ed7dfdbca2a69a541519ffd5064a5692152fc0018109e74370d7345", size = 223249, upload-time = "2026-06-20T14:49:27.241Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/5e/a8ba14ceb014f39bd5e3f7077150718c7de61c01ce326bfe7e8eae9b19b2/coverage-7.14.2-py3-none-any.whl", hash = "sha256:04d92589e481a8b68a005a5a1e0646a91c76f322c397c4635298c57cf63699b5", size = 212325, upload-time = "2026-06-20T14:49:28.991Z" },
 ]
 
 [[package]]
@@ -250,7 +250,7 @@ wheels = [
 
 [[package]]
 name = "datamodel-code-generator"
-version = "0.60.1"
+version = "0.65.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "argcomplete" },
@@ -262,9 +262,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/39/fc/c27ca19607d391b0e15c469748256207dae13ecd0cf2dc61811c523d97eb/datamodel_code_generator-0.60.1.tar.gz", hash = "sha256:320597e2b47b59c2d4d6147f22b9e3bc1a3ac558b38d62388b7ffbe6bd283d83", size = 1139620, upload-time = "2026-06-07T17:38:42.583Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/28/02b8ce032f6cd68d530519e0c3570616c7ba28aad377cb19059001f5ef3b/datamodel_code_generator-0.65.0.tar.gz", hash = "sha256:ccad880007104f5cc462d9f880183fb1ed54f4d8106a3a2ad578861d16548432", size = 1393169, upload-time = "2026-06-21T18:21:06.537Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/f7/1debf05421fc6aa28441f47cd9eec40da3145dc9e5dafc9934207b1dc4c1/datamodel_code_generator-0.60.1-py3-none-any.whl", hash = "sha256:2b2477a6182588076aa44ba7e0202a233c983ff7f62e4f02a2869cefedfd300c", size = 336847, upload-time = "2026-06-07T17:38:40.821Z" },
+    { url = "https://files.pythonhosted.org/packages/99/dd/8e7254f0117a7599622f0509741c1a051946442bf6bc2135df645b6e5d8f/datamodel_code_generator-0.65.0-py3-none-any.whl", hash = "sha256:2fe413a46932dae930be069b951818a228815cd3056a478527ecc9369a831b60", size = 401994, upload-time = "2026-06-21T18:21:04.891Z" },
 ]
 
 [package.optional-dependencies]
@@ -762,16 +762,16 @@ requires-dist = [
 
 [[package]]
 name = "pyotp"
-version = "2.9.0"
+version = "2.10.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f3/b2/1d5994ba2acde054a443bd5e2d384175449c7d2b6d1a0614dbca3a63abfc/pyotp-2.9.0.tar.gz", hash = "sha256:346b6642e0dbdde3b4ff5a930b664ca82abfa116356ed48cc42c7d6590d36f63", size = 17763, upload-time = "2023-07-27T23:41:03.295Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2d/c6/c5d96a86fd0bf6fa1bbb5c5c341ff3208638b692727a683c8289068d9a11/pyotp-2.10.0.tar.gz", hash = "sha256:d01e9703443616b03c57c700b5cbffd56a1f929c1b0f8f03131bc78c1fca9d3f", size = 18625, upload-time = "2026-06-14T03:48:49.221Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c3/c0/c33c8792c3e50193ef55adb95c1c3c2786fe281123291c2dbf0eaab95a6f/pyotp-2.9.0-py3-none-any.whl", hash = "sha256:81c2e5865b8ac55e825b0358e496e1d9387c811e85bb40e71a3b29b288963612", size = 13376, upload-time = "2023-07-27T23:41:01.685Z" },
+    { url = "https://files.pythonhosted.org/packages/65/33/7b83bde70eddaaaaef487751a9c3a5cc0c0be54620ded0e120ebdc401ff9/pyotp-2.10.0-py3-none-any.whl", hash = "sha256:1df2f6a1bcc3bb0716172a5215ddc2f8c7c7fd26a13df9927d52e1746934836c", size = 13768, upload-time = "2026-06-14T03:48:47.831Z" },
 ]
 
 [[package]]
 name = "pytest"
-version = "9.0.3"
+version = "9.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -780,9 +780,9 @@ dependencies = [
     { name = "pluggy" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
 ]
 
 [[package]]
@@ -868,27 +868,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.15.16"
+version = "0.15.18"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a6/bd/5f7ec371001337d8fa61701c186ff8b613ecac1651848c5950f4c4d5f2e9/ruff-0.15.16.tar.gz", hash = "sha256:d05e78d38c78caf020b03789e25106c93017db5a0cb6e2819885018c61343b78", size = 4714267, upload-time = "2026-06-04T16:33:09.974Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/74/98/1295ad5a5aa9bc85bdcdfa5d82fe7b49c61af5657df4f227637ff9de0da6/ruff-0.15.18.tar.gz", hash = "sha256:2698a964c70e8bf402dcb99c8810472d270d141e7aa8c4e13599fd52033a2f33", size = 4761437, upload-time = "2026-06-18T18:25:39.224Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0c/42/53ef1c3953f157956db9bf7861e3bc50b9b887ce93300aa48cdba8336fe6/ruff-0.15.16-py3-none-linux_armv6l.whl", hash = "sha256:6ac3c0b3969cc6cf6b158c4e2f8f682acb58e7d700d8a44b65ecdc72d66ab0b2", size = 10709025, upload-time = "2026-06-04T16:32:51.935Z" },
-    { url = "https://files.pythonhosted.org/packages/93/9a/a79159346f19134a956607754e57d8d128f7a4c00f4ad2f7514d224c172c/ruff-0.15.16-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:197c207ed75ffba54a0dec23db4aa939a27a3053073e085e0042433cbdc58e4a", size = 11063550, upload-time = "2026-06-04T16:32:42.24Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/72/3ce2ac000a5299ec238e01f51397b3b653c93b077d9b1bfe8715bb895f20/ruff-0.15.16-py3-none-macosx_11_0_arm64.whl", hash = "sha256:3a39fec45ab316cc23e7558f23fea4a70403ddb5648ea9a4a3854a16973d0071", size = 10421345, upload-time = "2026-06-04T16:32:37.251Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/c2/cc7fad3ec9169373f5b6a18f1917b91080feec40c3f9658334a1d28e2f03/ruff-0.15.16-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ba93191d79003116b95128c9d306e045200fdbd0bccb782b110f3cd1d4abc5cf", size = 10757217, upload-time = "2026-06-04T16:32:54.722Z" },
-    { url = "https://files.pythonhosted.org/packages/69/d2/3474009eaa0a65b31fa7152a2fad5e2f050c640ceb1e6b02ee6922e94c82/ruff-0.15.16-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c6ee4b90520630120ef032aa5cc10db483852dff950e78b1d717e2993a61ac8d", size = 10507035, upload-time = "2026-06-04T16:33:05.343Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/81/b7ae6ccbd11f0c8dc3d5d67fc4be9b57ff57ca86ba56152021378e1277f2/ruff-0.15.16-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4e4215bc938bc3c8215c1472c1aa437e310fee20cd427335fec9d7e609563628", size = 11255291, upload-time = "2026-06-04T16:32:49.49Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/e1/46e526f1a7cc90857ce6ddf25fbb77eb6568651ac38d71b033af07076dd5/ruff-0.15.16-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7c8d26be963b090f10e29abc8b3e74a2a321f6fa34e02424e30b5af89350ecbb", size = 12124922, upload-time = "2026-06-04T16:33:07.821Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/da/5c791b088b596b24d0deb967fa28ae02ad751a140c0b9ea81c5ab915d6c0/ruff-0.15.16-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f198cf4123602a2280ed46c307bcbafe41758d6fee5b456b6b6058ca1514b3b4", size = 11332186, upload-time = "2026-06-04T16:33:02.971Z" },
-    { url = "https://files.pythonhosted.org/packages/72/11/5da87abe20047c8962361473923ebb2f62b595250126aadfad8c20649c1e/ruff-0.15.16-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bb27515fa6240fb586ae82b901a59e67d24acff86f2190b433dc542fe0435aeb", size = 11373541, upload-time = "2026-06-04T16:32:47.007Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/2a/8554754c23a854ae3fd6b507e36ad61ddb121e298c6d5d617dec94ed0f14/ruff-0.15.16-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:a267c46ba1593fc26b8eecbea050b39d40c0b6bb7781ee11c90a02cd10032951", size = 11353014, upload-time = "2026-06-04T16:32:34.795Z" },
-    { url = "https://files.pythonhosted.org/packages/62/25/62ea41529ec89f742ea3fed9cb1059c72877ec7cf9b9e99ac9cf3294d1d9/ruff-0.15.16-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:528c68f39a91498a8d50e91ff5985df3d105782bab49cc378e73ac26bff083e8", size = 10737467, upload-time = "2026-06-04T16:32:26.348Z" },
-    { url = "https://files.pythonhosted.org/packages/90/17/334d3ad9de4d40f9dd58fdd09e35ce64553bb501e2f19a839e2fb6be14fc/ruff-0.15.16-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:7ed55c58950df60589a9a7a5d2f8fa5f54ebd287163be805adfe6ee95a9de123", size = 10521910, upload-time = "2026-06-04T16:32:32.54Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/bd/3ac7c6ae77a885c1004b3dda2446ea401768d24f851c14b4ad4b24f6639c/ruff-0.15.16-py3-none-musllinux_1_2_i686.whl", hash = "sha256:d482feaf51512b50f9790ceb417a56a61dd1e9d9bf967662b9ed27c01b34f53a", size = 10979190, upload-time = "2026-06-04T16:32:57.492Z" },
-    { url = "https://files.pythonhosted.org/packages/33/d7/609546e6a413c3f216fbf2a50c928f97c80939154f6a0503114094a86191/ruff-0.15.16-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:1e15bc8c94513dae2a40cc9ef07c94fdd4ecc9e29dabebeebe170f952322c9e3", size = 11477014, upload-time = "2026-06-04T16:32:44.687Z" },
-    { url = "https://files.pythonhosted.org/packages/74/0d/f2cd247ad32633a5c36e97141a2c21b11c6279f7957bc2ff360b1e08fddd/ruff-0.15.16-py3-none-win32.whl", hash = "sha256:580378f7bd4aa25f72e74aa54948a9622f142b1e509521dd10902e886681cc1e", size = 10735541, upload-time = "2026-06-04T16:32:30.145Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/9e/02e845ef151b1dee585e55c4739f8e1734ae1d9f1221dff65761c162208b/ruff-0.15.16-py3-none-win_amd64.whl", hash = "sha256:408256017284eddf98fff77b29aa4fb30f586042d535b2d9befc6512f400aaec", size = 11843403, upload-time = "2026-06-04T16:32:39.76Z" },
-    { url = "https://files.pythonhosted.org/packages/15/19/016553f86f207450aebebc2b2b5088d086b901cc8186c02ac4284db3bd88/ruff-0.15.16-py3-none-win_arm64.whl", hash = "sha256:8cd61783afb39638a7133ef0d2dfb1e91277593962f81b5a8423eb0b888a6121", size = 11134555, upload-time = "2026-06-04T16:33:00.136Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/d0/686e984941269621e2be72612d5c1e461f8f7b38415a2a7d7a81c8ae6715/ruff-0.15.18-py3-none-linux_armv6l.whl", hash = "sha256:8b6850172348c8381b8b3084c5915a4393c2373b9b54cd5b5e1ea15812bc10df", size = 10887308, upload-time = "2026-06-18T18:25:03.062Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/21/bc4123e3f5515ee99f8ce1eb93a14a0628fe4d1678663cd08f933ac16931/ruff-0.15.18-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:3fccc153a85417dcd976883160cacce486997b0a0058dd18f54b8aaaac7d1ce2", size = 11281305, upload-time = "2026-06-18T18:25:30.026Z" },
+    { url = "https://files.pythonhosted.org/packages/51/93/4769464c25cf7ab2acb3c7dda9cad3d867eb41c59565b3e2a9d17249c90c/ruff-0.15.18-py3-none-macosx_11_0_arm64.whl", hash = "sha256:08d4c86a68f2c3ec2c9d56380a71fb4a4f65373055cbb8caabd645e9102f38d4", size = 10641215, upload-time = "2026-06-18T18:25:15.802Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/42/56926d17120db2c208d76bf60a1a019644dd9e91dc27f0f95c9caddb1366/ruff-0.15.18-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:37e5108745c2c0705da916d7d4de533ddf547051ef45f62888c31bae73f66318", size = 10957224, upload-time = "2026-06-18T18:25:36.955Z" },
+    { url = "https://files.pythonhosted.org/packages/22/4f/d43fab8d8189afde803103022d000a8ef9f230616d436d52a8b2b8d63b50/ruff-0.15.18-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:56949a6ce8b3abde54c0bcb22cebfe57e8771cadc84b407ae8b8eaf67ebdcd43", size = 10699024, upload-time = "2026-06-18T18:25:05.707Z" },
+    { url = "https://files.pythonhosted.org/packages/63/42/1e3e4c68bd408b9768cf3e439acbe2c78245225faef253f7028a0cdb63e0/ruff-0.15.18-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:01a754cd6a1b630d3f97e33eb452cf7a98040482318e870f8bc52a5a30e62657", size = 11491458, upload-time = "2026-06-18T18:25:20.275Z" },
+    { url = "https://files.pythonhosted.org/packages/20/77/47a3484bea8521e14a203d98c389c5c97846675e4f02734672da4a69b52a/ruff-0.15.18-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6ba7a07e03a44dbf10bb086ee06705b173625014ec99f73a7e6836a5e5590a0c", size = 12383752, upload-time = "2026-06-18T18:25:22.535Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/ca/054159590787023d83b658a1a1819c4c8910114e7015069340b71c0961cb/ruff-0.15.18-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5a2c40a41a4cadbcf5897b548ab29dfe248b20c540961c0247d98a3973c70403", size = 11577923, upload-time = "2026-06-18T18:25:10.702Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/ff/d353d6b7bbd73cc0ec37f4463d7540e45e894338abdd9964eee0de332708/ruff-0.15.18-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5f0480ce690cbb6c4db6e5d08f19fce98e10ba131a8b60c1bcdac42771e3ae2d", size = 11583925, upload-time = "2026-06-18T18:25:32.391Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/4a/891f89b9c296ed3e5f3ece1a5629badc989d9a8fdaa30431aaf4774bc1c2/ruff-0.15.18-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:2330215f1f393fa8733f55edce04fcf94c36a2c460fcde31f78cc84e4951e9b1", size = 11582834, upload-time = "2026-06-18T18:25:27.309Z" },
+    { url = "https://files.pythonhosted.org/packages/32/a3/ed9e370154bf85de360b93c03026157f02d4943b2d01ff4945f4429f8e8a/ruff-0.15.18-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:a6aa6a3d979e48ae617578183674bf264fbe7d0114a796a26bd678d67963c7ff", size = 10927328, upload-time = "2026-06-18T18:25:34.676Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/d1/5cf5909329fedb5d39d555ee818ba5cf4638e1a301b89785d34f2905bfcb/ruff-0.15.18-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:a81beadbbff2c9c245561ae3f77b16709d87f35eec650d0501679239d3449b22", size = 10693187, upload-time = "2026-06-18T18:25:08.245Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/44/ff6c635cf2c4f4e7b618b6640da057376baa36014695487d88aed4794268/ruff-0.15.18-py3-none-musllinux_1_2_i686.whl", hash = "sha256:2186d9e940ae332ab293623a75b5f4fe49565f449954d50a72a046683aa6b809", size = 11208721, upload-time = "2026-06-18T18:25:41.327Z" },
+    { url = "https://files.pythonhosted.org/packages/88/d9/5baa2a30861adfb7022cf33c1e35b2fc18085b08c16f83eff4c7b99a5f48/ruff-0.15.18-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:5c2abf140438032bc77b2284a6c9944ecd8a19e5f1c7b52b1b8e4a0a80d19a7a", size = 11678599, upload-time = "2026-06-18T18:25:13.607Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/1a/0725a7cfdc32ff769efb96ee782bec882e16448c5d9e3be947ec4c04ce27/ruff-0.15.18-py3-none-win32.whl", hash = "sha256:02299e6e9fa5b297a3f6d5d10d7bcd655c925b028bb8b9d4588214549c6b9ec4", size = 10901903, upload-time = "2026-06-18T18:25:24.755Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/51/805d9f6fb7970505c3504794a5ec350f605361b807fef4dcf214ebd35e72/ruff-0.15.18-py3-none-win_amd64.whl", hash = "sha256:dac80dc8d26b2257dbefabed62f5d255c3937b4ccb122da1fc634794fa3578b3", size = 12041189, upload-time = "2026-06-18T18:25:17.915Z" },
+    { url = "https://files.pythonhosted.org/packages/29/4c/67bb45e41609eb4726f1bfeb59e083cf91d14c696d4bd14c234a980be93d/ruff-0.15.18-py3-none-win_arm64.whl", hash = "sha256:b2c9257fcbd4a3e5b977a1904e6facca016bafe2edc17df24db67cfaee03b4e4", size = 11329958, upload-time = "2026-06-18T18:25:43.686Z" },
 ]
 
 [[package]]
@@ -902,49 +902,49 @@ wheels = [
 
 [[package]]
 name = "tombi"
-version = "1.1.2"
+version = "1.1.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/2f/7e/62c451507851adc0d373e6e2e36d15c81c18d70713a73a2317a4e1769315/tombi-1.1.2.tar.gz", hash = "sha256:6893264c71abcf363c837e2e01c1853c5f3afadf2150d71b04572b964954b669", size = 694344, upload-time = "2026-06-07T07:45:40.548Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/27/2d/867f628841b7ed0683d142626bcc183af3854e768456e365a11efd5ad0ed/tombi-1.1.4.tar.gz", hash = "sha256:c943b28b814c9010ebc1e7a052d88caf136f36998f44df9baba84f772b230d43", size = 696139, upload-time = "2026-06-21T01:51:44.692Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/68/38354dbe622abbc36210ea0c10c641e85f96e4ff89a3f21e0101328f7347/tombi-1.1.2-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:14adfc53bf4f46543f81699dd6d527f731a764ac982f747150dddeace3a007c0", size = 10435832, upload-time = "2026-06-07T07:45:28.439Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/f5/76f7a3652f0446af3890a8ffbdcd824e55c0761ef03ab29dfc07bf5ad285/tombi-1.1.2-py3-none-macosx_11_0_arm64.whl", hash = "sha256:19656d9670da5b67b7e0457e30eb6bb08c47120f68007d3ff57ed18e7e94b2f7", size = 10098871, upload-time = "2026-06-07T07:45:25.416Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/8f/83599c18b057cbdf39bf634760133945b820fbf9050ac422313667a0a5e1/tombi-1.1.2-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:286e16e49798fc1eb512d68eb9e136345874e587e27291cea9082303923b93c7", size = 10399583, upload-time = "2026-06-07T07:45:11.701Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/d3/3530da56b3b145c760554d938f7fb5d79b79665447f87a8d9c138631e8b1/tombi-1.1.2-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e6512231ad086645cd589c284c5625a3be74f2e5bedaaf47ca913d80ee3c83ed", size = 11737715, upload-time = "2026-06-07T07:45:19.881Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/05/c672d9574450a0a79b2c2471747407f82e0cbd60bee9740c389845c4661a/tombi-1.1.2-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8edfc5608d35995bde38cef9bb4eb0c2955909e87d788a36c6b09f622684a00d", size = 11809582, upload-time = "2026-06-07T07:45:14.433Z" },
-    { url = "https://files.pythonhosted.org/packages/53/05/d6ab95609e10c925303096e4cb8c1919ee5ed1e9e380da3141783c7f875b/tombi-1.1.2-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8b181fce0409c60174af2e5a1a5e3452148759a733d2060e14f607ad74727bf1", size = 10474227, upload-time = "2026-06-07T07:45:17.083Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/83/8d570f360c65b943332b0b736ec78539ef0e864c021947750d60a2f70c1e/tombi-1.1.2-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f161d44bd7750b312c802619acce8766eafb76d89fb2e058eb1a64eb3757bc2a", size = 10897885, upload-time = "2026-06-07T07:45:22.56Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/7e/e497b8730f4b28a07622fc8987b2eb25b41aadae0ae1e84e0151dbda9f26/tombi-1.1.2-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:056606b06b5d5286d234e35c906e731302a56541bcace1d04902cc7a0681b015", size = 10640536, upload-time = "2026-06-07T07:45:08.806Z" },
-    { url = "https://files.pythonhosted.org/packages/99/db/9be1f77a0ed13a4bf36d0b1b42dfc9b00d05f50aa82a1410015a220ef480/tombi-1.1.2-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:b17cf134174ddb7506b3d4ed92e28c0290882b0ecdc58a7e158bb65a0d15c71d", size = 10683187, upload-time = "2026-06-07T07:45:30.955Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/ca/f9f60c213fa426461c64acf27f526575f5e9dc016e8d4f0b5357a1a46629/tombi-1.1.2-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:13019a351104060850f7a83217eed26ae6a4758b1cb770cdbc5fbb5abf8b406c", size = 10476272, upload-time = "2026-06-07T07:45:33.483Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/45/fa718ed3ed1b0ed305299f69ce6a13b3489cdb50cbadfeb30343282c7bf0/tombi-1.1.2-py3-none-musllinux_1_2_i686.whl", hash = "sha256:19804becd04b748f69ab9c492f5535878e98720ec5680336f6f6506581884d55", size = 11138545, upload-time = "2026-06-07T07:45:36.001Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/3a/c4d3ade656e3ebcef7420fa4fea4935ee805d7860c1e08686d927622d111/tombi-1.1.2-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:826b53bff2bd5030bd177047186f073aece12f2e061f26de6801ed65f6281e55", size = 11114407, upload-time = "2026-06-07T07:45:38.467Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/11/e3cfcf3c81429ce819c49dc3d7c5e7858bc07bf6c11db300e19baeba267f/tombi-1.1.2-py3-none-win32.whl", hash = "sha256:601db67fafe072c3468494390a419d28c13bc99dda1f22417bfb6e2d8b89acaa", size = 8499778, upload-time = "2026-06-07T07:45:44.719Z" },
-    { url = "https://files.pythonhosted.org/packages/21/3c/65a36d487248cf9791c5f10999cd167fa2e1af6a348a50fb2ecb581db4d7/tombi-1.1.2-py3-none-win_amd64.whl", hash = "sha256:6ad7f4c2eb230cee1a28c1579de7e6d81ed860819b6617da38c9d1a82a1f913a", size = 9929697, upload-time = "2026-06-07T07:45:42.423Z" },
+    { url = "https://files.pythonhosted.org/packages/38/a5/db78a10aa63f10a96799c28b8a1c092793496e4c6ded0b49e315ff0df47e/tombi-1.1.4-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:9c01f03d0cc984bd23326092058d1a517f47bd3efa4d219f725567936de61d3e", size = 10433359, upload-time = "2026-06-21T01:51:06.639Z" },
+    { url = "https://files.pythonhosted.org/packages/da/58/61506c12bce77b5b08f55824d5ce700ba06ac919654b1a2ef07c7530cc38/tombi-1.1.4-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e5344ff205040c25fc840894c421f3c3df9b92865c308c809879dfe98dbf3185", size = 10082920, upload-time = "2026-06-21T01:51:09.353Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/72/1dca4b314888787abd9b65e7c7f0823351fbf72af974817f60a0a84ec085/tombi-1.1.4-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:24c2715210ad903e2c2654267f931ceacd0ba80bc09c68e014daeff8e71daa6f", size = 10405605, upload-time = "2026-06-21T01:51:12.206Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/de/a41bb986080b9e4644c153cbb7995aab362886d8066ebaf7d2f7400247a7/tombi-1.1.4-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b27999ee02134d4174c6cdf1e49773fd12645065ac02eb3f52bc56535e60d4ba", size = 11731276, upload-time = "2026-06-21T01:51:14.883Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/db/3fd20ee543e69d438b3792818e1795f7014b10527b11fd77f6e207136cd9/tombi-1.1.4-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:04380541b6fe25e6ec6314bc174f44e50c321c3281cbac3cda07533f0ab27963", size = 11805337, upload-time = "2026-06-21T01:51:17.603Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/38/3816472eae56f2207d5b68347d8b3049c2e3f7dd9c31d1f22885c377f9f0/tombi-1.1.4-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d3ccd5925dd76884c107dee68a7e92f41fafb12618463d950ec1456e828300cb", size = 10480050, upload-time = "2026-06-21T01:51:19.919Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/08/c5d5b195fc8d69f579c976b6f691efb6426dd26b254e76f4625804c8cf13/tombi-1.1.4-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5c0cf580190ded5e4547de37625727a016dc897eb59ab5f145e0ce3884201a62", size = 10907963, upload-time = "2026-06-21T01:51:22.621Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/3c/853bcdd47330c3f791878a5777f1c4ac736ad16a40fc0f7320a328e9dc17/tombi-1.1.4-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:d05f732ffb8f6e1ef3a93d16611c60df1934d786794fc3d50912fb3329725f55", size = 10627761, upload-time = "2026-06-21T01:51:26.507Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/c8/d87d0e7ab502babd139da21e5ee8ebac176fc397c5be0bb9dac775c1791c/tombi-1.1.4-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:2832f2984738e29b48e37be59b096b4585019247b5313b0f1f387235e4853542", size = 10662649, upload-time = "2026-06-21T01:51:29.003Z" },
+    { url = "https://files.pythonhosted.org/packages/32/66/eec7457f7119a19ff9283e8bb379569bd0fc27d482f60798c3c3d9b74623/tombi-1.1.4-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:70bfd4290a7577a90eedbcae55f14bf8a765abf5529aae3c5334e930d740dfe0", size = 10457636, upload-time = "2026-06-21T01:51:31.959Z" },
+    { url = "https://files.pythonhosted.org/packages/64/14/0a66de2806ca7df1ebd93fce0f5b08a6a90907279c27f12529b61c4ca10d/tombi-1.1.4-py3-none-musllinux_1_2_i686.whl", hash = "sha256:4e581d0310561396776fe225f2d79906cfbb57b4ad6be49dc35403cb2bab667f", size = 11145842, upload-time = "2026-06-21T01:51:34.455Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/e5/9696b9be457f5fb79d5dd063290a8042e61b5ea02c8b668884cd82553fb1/tombi-1.1.4-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:7b3d9f70721f23aecae7823ea14ae0bd04c23c9a3c73fc21b30587e8768c6b75", size = 11135065, upload-time = "2026-06-21T01:51:37.293Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/c4/1c87e15e6bf996cbee46ef109366f58d51095fe2281e6b6a1b06c178fcdd/tombi-1.1.4-py3-none-win32.whl", hash = "sha256:9a204b8990c3c9ff47f1db7d4640d7d9f77468ad74edfcb394ebdbc5ea9ab430", size = 8535266, upload-time = "2026-06-21T01:51:39.897Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/de/6a32b67e84990c2a524932bc8fd6f29ed4cbeac66a34d7de83cc5374cf7a/tombi-1.1.4-py3-none-win_amd64.whl", hash = "sha256:1e79de3810a264547ebba77ee741f810c1cd4e7e5723dee502ad0b288d078b83", size = 9910930, upload-time = "2026-06-21T01:51:42.427Z" },
 ]
 
 [[package]]
 name = "ty"
-version = "0.0.44"
+version = "0.0.51"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/13/f4/fbb120226e4f239652525a664bad976a23fea58c646d1323f2296fee8a61/ty-0.0.44.tar.gz", hash = "sha256:5886229830ab77022842a1c55d2ef57405621a91fc465969fa6d538661898173", size = 5803665, upload-time = "2026-06-05T03:33:48.612Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/ce/352fcdba5c72ea20e5d2e46e28809cdb617575b71209d971eff2ace8e6c4/ty-0.0.51.tar.gz", hash = "sha256:b90172d46365bb9d51a7011cbb5c60cc4f514f42c86635df6c092b717f85e1ac", size = 5953151, upload-time = "2026-06-19T01:48:58.015Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e8/c6/b5b8c4762efb4d85401652658786506867553ecfc2beac3bcf361a15937f/ty-0.0.44-py3-none-linux_armv6l.whl", hash = "sha256:272d31e7ad49b1dc5e8465a9fe700354e14c755b40d9c75f08f031d786903df3", size = 11607267, upload-time = "2026-06-05T03:33:27.154Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/5c/f4b405570737f44ab0fc4214117fe43353f8f0825a1823d9e99e9c8e57be/ty-0.0.44-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:b92c4ddd7a3daf2049715edec9dc70cf6fd31a5a318ee647258f90dd75495eed", size = 11382826, upload-time = "2026-06-05T03:33:54.374Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/aa/fb9835aa492b148d7754cb4c3db07f31a7e2e09f0d8e0e8e297f01125dd2/ty-0.0.44-py3-none-macosx_11_0_arm64.whl", hash = "sha256:4d42cfd84a690f6654b2a4f0515027c21b692cf2512d32e6433f754893a95609", size = 10809741, upload-time = "2026-06-05T03:33:33.22Z" },
-    { url = "https://files.pythonhosted.org/packages/47/f5/0b20ba6b66837a5a37bab7f74ac0732c66e766b5f0b2d55b30816b15f348/ty-0.0.44-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5dc47ae87e4cb7db2a9166bb23b78a905c3626e523296ec5bccf36b5e89bda6b", size = 11318153, upload-time = "2026-06-05T03:34:09.403Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/bb/b82ea730774a4f950f06d355fbc120d51eac7da23b57fc79ef6ff7c79cbb/ty-0.0.44-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:46d867e80f16f421ac72c9a85240dbf050d62d9b3fbd10a8b5b082fb21679e0b", size = 11403108, upload-time = "2026-06-05T03:33:57.745Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/41/e2c83856165291049c702eda4e2ef3d3ebd875e8a0a77b8cc4ef3156aa1c/ty-0.0.44-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:411f5de0f96a4e4e5cccc3e0d55954c41f6a99ee6ca1fe5a7226cbc68406e053", size = 11944815, upload-time = "2026-06-05T03:34:15.793Z" },
-    { url = "https://files.pythonhosted.org/packages/66/95/1fa6a101eb9d5bec042b87e5ca9c8fc349b75961beca6306f95af5cd5539/ty-0.0.44-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4b15f01ecb4e2b46c05a1769293f9d32c3d4a1e4e7dfccf37c604d705dc3e3f4", size = 12476121, upload-time = "2026-06-05T03:33:51.529Z" },
-    { url = "https://files.pythonhosted.org/packages/72/6a/da4b45b1229d39207c6140681c2aaf4f5691bcb1dc830b84450ca25c8f57/ty-0.0.44-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:edd32b7467af509c99c0244c2226a4e4c03400699003ec33373282ab931654d9", size = 12091340, upload-time = "2026-06-05T03:33:36.289Z" },
-    { url = "https://files.pythonhosted.org/packages/16/c7/e1c9260ea5188195962ff1214ace418b5d69187e8fa7c0a1ec4994b8071b/ty-0.0.44-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:503a585f4007387c3afc58bae23a7ca1b9f236cbdb1a881dc36110655ceb1937", size = 11986201, upload-time = "2026-06-05T03:34:00.624Z" },
-    { url = "https://files.pythonhosted.org/packages/92/f9/312bb112da9b1a7da295bb0426be85e72ad48da4e4266c36d77256b4058d/ty-0.0.44-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:2d28bcfa83243d77c2316944e8cf197f73597bf17d1ddc047d0b10a762531252", size = 12168475, upload-time = "2026-06-05T03:33:30.386Z" },
-    { url = "https://files.pythonhosted.org/packages/02/de/64978d603f6c3e5dd7cb97eca2214567d8ad0c85fa4a7435b7852ae4b779/ty-0.0.44-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:56fd2dd0192def189715b25f5338f6222fb827884dc34111e50aa1c4e061cee5", size = 11292937, upload-time = "2026-06-05T03:34:06.448Z" },
-    { url = "https://files.pythonhosted.org/packages/64/63/a625d8a3c71dcaa01988d330f849c465fe72ead4b0bbab44fe4bd6e672b5/ty-0.0.44-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:7f8d990489032de1984e73c159f3e760d754cf83a602b874827d943821f63595", size = 11421560, upload-time = "2026-06-05T03:33:23.995Z" },
-    { url = "https://files.pythonhosted.org/packages/99/96/61aeba0e629b0c91bd316ff94d00e38817ec493ae4316f39508988daa287/ty-0.0.44-py3-none-musllinux_1_2_i686.whl", hash = "sha256:f61ffe72996a755432922fe90b28db593f572eb5cbf48e3ef4e67b282533d1b0", size = 11580282, upload-time = "2026-06-05T03:34:03.308Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/f7/256e1538ce21cab67b381201444c42454de69d310059c4929d92a0ee9c48/ty-0.0.44-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:2b237a143bac4f30cec9257d45f01e72da97030a80a09a2b69cfef065f09c37f", size = 12085723, upload-time = "2026-06-05T03:33:45.953Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/76/ec3957c10872643a98db7a7895101ad89c5b7cba4bc6c4aebbbfc91756cc/ty-0.0.44-py3-none-win32.whl", hash = "sha256:6a24586c65419223ac5bab4822d49ab493a5d19ea2a897514284c232b9d6166a", size = 10892978, upload-time = "2026-06-05T03:34:12.603Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/7d/ba24050432196e7d7f03945e5c379951593c48e04e5c5d5275cfc4624791/ty-0.0.44-py3-none-win_amd64.whl", hash = "sha256:8cccb27e348c89a9733fbad1b2efadfbad79b107c7e52adb52dfd8a70156a38d", size = 11987058, upload-time = "2026-06-05T03:33:42.692Z" },
-    { url = "https://files.pythonhosted.org/packages/71/34/16ec3f1fec75292d9c56a8b5fef037ceaba85a5c30562206c1a245a00a67/ty-0.0.44-py3-none-win_arm64.whl", hash = "sha256:58049504e7a12bf1957f24a5384a332c94d5590127083a80db5e5a1bed34190b", size = 11329961, upload-time = "2026-06-05T03:33:39.427Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/8f/8fe7cab79a45320b2cdcd602f16d44c8108d2f418ff7ec316c6212f1f0cc/ty-0.0.51-py3-none-linux_armv6l.whl", hash = "sha256:947986bd82d324b3a5c58ce03f1dad160cdf36443d3e8f64b3484b861ba9bc64", size = 11884805, upload-time = "2026-06-19T01:48:20.184Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/b4/56fdc39a3f44c0564fd157e1e59e1f9c3fc5ba57ae4472ded85c67c63d74/ty-0.0.51-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:25a5b31e6f23fd5dc63ad29087ded09932409e4154e2fe07bbaed015035990bb", size = 11633593, upload-time = "2026-06-19T01:48:22.998Z" },
+    { url = "https://files.pythonhosted.org/packages/33/57/136e83f24fc04f5afdcabff42f40fa27eae5ac3f0e3f12627d072a55f679/ty-0.0.51-py3-none-macosx_11_0_arm64.whl", hash = "sha256:2faed19a8f1505370de071c008df52a994fc03a204f3267c3a33a32ca26f854f", size = 11063076, upload-time = "2026-06-19T01:48:25.223Z" },
+    { url = "https://files.pythonhosted.org/packages/32/f8/5d32f0df5692446440ab781b9b119aa3e0c0dbfa78c583fe9be8417d54fa/ty-0.0.51-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:08adbe53fb8bc9e7f00e89bf1d3c875a02cda76d83f109d2e6ab1ff35a7bfa8c", size = 11579542, upload-time = "2026-06-19T01:48:27.302Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/0c/4f54ef338e9623886809ecd508931b0cd5b3aba1e591586a2f6aeaa8bd11/ty-0.0.51-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:dc5e93695ab5dcbf1eef663aee60ec23a413547cc9cb06adcb0d842e9166bd0f", size = 11676189, upload-time = "2026-06-19T01:48:29.518Z" },
+    { url = "https://files.pythonhosted.org/packages/56/27/31729066f9b9d3596941edaf267894eefc0b30df4518f003dba5f7276258/ty-0.0.51-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:abd92913bc90d1705ef9391ff8c6822b61e2e827fa295eb30bf0dfabcf815645", size = 12188154, upload-time = "2026-06-19T01:48:31.68Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/38/d4301aa12d2283c7130908baf1417a37dfe3e10f5669cb4ce2853c2540b4/ty-0.0.51-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:429a997394dac73870d71b87cc90efc54da3efaf319e72ca18aeef35a78aef90", size = 12780597, upload-time = "2026-06-19T01:48:33.839Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/52/4b2e67e53f126d39abe201bd2299e467e27463a284e965ad195cbc217fa0/ty-0.0.51-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:62d94f06e8c317e89b6884f2bde443040e596b88c7c79bd944c84c105b06257a", size = 12491115, upload-time = "2026-06-19T01:48:36.169Z" },
+    { url = "https://files.pythonhosted.org/packages/74/50/aabfe55c132ebe72b4d639cbf772d931e11b0990d29c1f691922b6ccabc1/ty-0.0.51-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f8f52952cff665bc52a36147e610c10f5699d30007d7a14ab7f345cff93476ff", size = 12230135, upload-time = "2026-06-19T01:48:38.445Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/1b/9aa428052dbed91c50919cd080426a313cf20ce14c6bfe2b71345e548671/ty-0.0.51-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:c1bd1355aee86af01e4e21b0bc16fc460fb05905761f0d8b8d70841de0feade8", size = 12468123, upload-time = "2026-06-19T01:48:40.47Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/5a/f6ce69f2575259386c950c40e02578d0902760cb61f95045e9971182c24e/ty-0.0.51-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:79d1877e93460f936bc10ed1a31525702b7ce51075763ccba993be17f0b9e905", size = 11541672, upload-time = "2026-06-19T01:48:42.635Z" },
+    { url = "https://files.pythonhosted.org/packages/35/3a/2af48924a683e959e95e5cc4dc88e5a8595206a0812b869032b95196f2b0/ty-0.0.51-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:cc233a6235fb23e2a44b14731a10043e37ba2f30f2c361cf49ad3633c5b9da9c", size = 11694015, upload-time = "2026-06-19T01:48:44.819Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/12/899875d8a60b198c8121cb92ce18e18cc072d23ca2130fcdaa176383ef72/ty-0.0.51-py3-none-musllinux_1_2_i686.whl", hash = "sha256:bc7459348a253247bbfb2669a021e614281b86bbea24c36112b8a6e1a2499a16", size = 11832856, upload-time = "2026-06-19T01:48:47.028Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/a2/88f681d826d97cc96ef9f6cadd4935f775758944cee07340aa46113bce28/ty-0.0.51-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:49a21237f6fd1de56beaff0a3e85fe022a09a3401e67e3abec41ce838a5d4d2e", size = 12333449, upload-time = "2026-06-19T01:48:49.091Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/61/535a4163b4452c6978c31fedfd7b5803cf3a2253e9455cde350f86638d6a/ty-0.0.51-py3-none-win32.whl", hash = "sha256:61b4b6a003c3ebe53a63a1125c9b6542aa01bc1b6c9a235d01ee328d000d61a9", size = 11177338, upload-time = "2026-06-19T01:48:51.433Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/4d/2334fbb74291a20129fa7aaa8f789619ec9b6883b27f997b8baa27e4674f/ty-0.0.51-py3-none-win_amd64.whl", hash = "sha256:608d417cd1eaf79bcbd713d9830d5e3db9d57ec225c3af3e4ac9a9ff66b45d70", size = 12325675, upload-time = "2026-06-19T01:48:53.774Z" },
+    { url = "https://files.pythonhosted.org/packages/50/b5/d49096cd5f3694becb86a5a6ccd0f229ead695fc7430d6bc4dd0a104c6fe/ty-0.0.51-py3-none-win_arm64.whl", hash = "sha256:62ced5e380284f12b2dc4802a3e4ed3dac39913fc6719afde7978814a4c7f169", size = 11657350, upload-time = "2026-06-19T01:48:55.904Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #33.

Bitwarden has no "org folder" — the org-side equivalent of a folder is a collection, and nesting is just a `/`-naming convention. So an org import today double-files: items land in the org collection *and* a redundant personal-folder tree gets built on top.

## What this does

- **`--bitwarden-collection nested`** — derive collections from the full KeePass path (`Work/Servers`) instead of `auto`'s top-level-only segment (`Work`). Bitwarden renders the `/` as nested collections.
- **`--folder` / `--no-folder`** (`KP2BW_CREATE_FOLDERS`) — toggle personal-folder creation. **Default is on, but off when `--bitwarden-org` is set**, so org imports are collections-only unless `--folder` opts back in.

Both are opt-in and non-breaking for personal-vault imports. The only behavior change is org imports no longer also build a personal folder tree (the exact complaint in #33).

## Idempotency

- Items: unchanged — matched by the stable `KP2BW_ID` stamp (folder-independent).
- Collections: matched by org + name, seeded from existing collections on connect, so an unchanged tree is a no-op and nested collections aren't duplicated across entries or re-runs.

## Notes

- Free Bitwarden cloud orgs cap at 2 collections; a large tree migrated as collections needs a paid plan. Vaultwarden self-hosted has no cap.
- Nesting is name-based, so a KeePass group name containing `/` creates accidental nesting (pre-existing in folder mode too).

## Tests

- `nested` mode uses the full path; `auto` stays top-level only
- `--no-folder` batch creates items with `folderId=None` and never calls `create_folder`
- `--bitwarden-org` flips the personal-folder default off; no org keeps it on
- `KP2BW_CREATE_FOLDERS=0` env override

All script tests + `ruff` + `ty` + `dprint` clean.
