### PR TITLE
feat(docs): add migration planner site

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,18 @@
+name: Pages
+on: { push: { branches: [master], paths: [docs/**, .github/workflows/pages.yml, bun.lock, package.json] }, workflow_dispatch: {} }
+permissions: { contents: read, pages: write, id-token: write }
+concurrency: { group: pages, cancel-in-progress: false }
+jobs:
+  pages:
+    environment: { name: github-pages, url: "${{ steps.deploy.outputs.page_url }}" }
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: kjanat/runner@master
+      - uses: oven-sh/setup-bun@v2
+      - run: runner --dir=docs install build
+        env: { BASE_PATH: "/${{ github.event.repository.name }}", RUNNER_PM: bun }
+      - uses: actions/upload-pages-artifact@v5
+        with: { path: docs/build }
+      - id: deploy
+        uses: actions/deploy-pages@v5

--- a/.gitignore
+++ b/.gitignore
@@ -18,8 +18,8 @@ dist/
 downloads/
 eggs/
 .eggs/
-lib/
-lib64/
+/lib/
+/lib64/
 parts/
 sdist/
 var/

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+	"mcpServers": {
+		"svelte": {
+			"type": "http",
+			"url": "https://mcp.svelte.dev/mcp"
+		}
+	}
+}

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/.opencode/opencode.json
+++ b/.opencode/opencode.json
@@ -1,0 +1,6 @@
+{
+	"$schema": "https://opencode.ai/config.json",
+	"plugin": [
+		"@sveltejs/opencode"
+	]
+}

--- a/.opencode/svelte.json
+++ b/.opencode/svelte.json
@@ -1,0 +1,3 @@
+{
+	"$schema": "https://svelte.dev/opencode/schema.json"
+}

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ See [TROUBLESHOOTING].
     to a `.txt` file attachment instead of dropping it, so you don't lose data. This applies to long notes as well as
     custom fields.
 
-["🧪 Test this PR"]: https://github.com/kjanat/kp2bw/pull/25#issuecomment-4661427123 "Example"
+["🧪 Test this PR"]: https://github.com/kjanat/kp2bw/pull/34#issuecomment-4763225590 "Example"
 [Bitwarden CLI]: https://bitwarden.com/help/cli/
 [TROUBLESHOOTING]: ./TROUBLESHOOTING.md
 [`.env.example`]: ./.env.example

--- a/bun.lock
+++ b/bun.lock
@@ -14,6 +14,29 @@
         "typescript": "^6.0.3",
       },
     },
+    "docs": {
+      "name": "docs",
+      "version": "0.0.1",
+      "devDependencies": {
+        "@eslint/js": "^10.0.1",
+        "@sveltejs/adapter-auto": "^7.0.1",
+        "@sveltejs/kit": "^2.63.0",
+        "@sveltejs/vite-plugin-svelte": "^7.1.2",
+        "@types/node": "^24",
+        "@vitest/browser-playwright": "^4.1.8",
+        "eslint": "^10.4.1",
+        "eslint-plugin-svelte": "^3.19.0",
+        "globals": "^17.6.0",
+        "playwright": "^1.60.0",
+        "svelte": "^5.56.1",
+        "svelte-check": "^4.6.0",
+        "typescript": "^6.0.3",
+        "typescript-eslint": "^8.60.1",
+        "vite": "^8.0.16",
+        "vitest": "^4.1.8",
+        "vitest-browser-svelte": "^2.1.1",
+      },
+    },
   },
   "packages": {
     "@actions/core": ["@actions/core@1.11.1", "", { "dependencies": { "@actions/exec": "^1.1.1", "@actions/http-client": "^2.0.1" } }, "sha512-hXJCSrkwfA46Vd9Z3q4cpEpHB1rL5NG04+/rbqW9d3+CSvtB1tYe8UTpAlixa1vj0m/ULglfEK2UKxMGxCxv5A=="],
@@ -33,6 +56,8 @@
     "@asamuzakjp/css-color": ["@asamuzakjp/css-color@3.2.0", "", { "dependencies": { "@csstools/css-calc": "^2.1.3", "@csstools/css-color-parser": "^3.0.9", "@csstools/css-parser-algorithms": "^3.0.4", "@csstools/css-tokenizer": "^3.0.3", "lru-cache": "^10.4.3" } }, "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw=="],
 
     "@bitwarden/cli": ["@bitwarden/cli@2026.5.0", "", { "dependencies": { "@koa/multer": "4.0.0", "@koa/router": "15.4.0", "big-integer": "1.6.52", "browser-hrtime": "1.1.8", "chalk": "4.1.2", "commander": "14.0.0", "core-js": "3.49.0", "form-data": "4.0.4", "https-proxy-agent": "7.0.6", "inquirer": "8.2.6", "jsdom": "26.1.0", "jszip": "3.10.1", "koa": "3.1.2", "koa-bodyparser": "4.4.1", "koa-json": "2.0.2", "lowdb": "1.0.0", "lunr": "2.3.9", "multer": "2.1.1", "node-fetch": "2.7.0", "node-forge": "1.4.0", "open": "8.4.2", "papaparse": "5.5.3", "proper-lockfile": "4.1.2", "rxjs": "7.8.1", "semver": "7.7.3", "tldts": "7.0.28", "zxcvbn": "4.4.2" }, "bin": { "bw": "build/bw.js" } }, "sha512-lp4P3PJ9/8KGW6SrBGPRof5XHLXYKg+gW9hHJf3WxzuF/uI0HLrvaqPnXixmfazRBuQQhNXJS4bhHPUS998kQg=="],
+
+    "@blazediff/core": ["@blazediff/core@1.9.1", "", {}, "sha512-ehg3jIkYKulZh+8om/O25vkvSsXXwC+skXmyA87FFx6A/45eqOkZsBltMw/TVteb0mloiGT8oGRTcjRAz66zaA=="],
 
     "@csstools/color-helpers": ["@csstools/color-helpers@5.1.0", "", {}, "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA=="],
 
@@ -66,13 +91,57 @@
 
     "@dprint/win32-x64": ["@dprint/win32-x64@0.54.0", "", { "os": "win32", "cpu": "x64" }, "sha512-AAr2ye/DtgYXDplRoPS+5U++x7T6W4a3I9FvTFWFxziFmUptvAg5G2c4FcXoAduSruhYZJvjDZrLseR2c3IwXg=="],
 
+    "@emnapi/core": ["@emnapi/core@1.10.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" } }, "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw=="],
+
+    "@emnapi/runtime": ["@emnapi/runtime@1.10.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA=="],
+
+    "@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w=="],
+
+    "@eslint-community/eslint-utils": ["@eslint-community/eslint-utils@4.9.1", "", { "dependencies": { "eslint-visitor-keys": "^3.4.3" }, "peerDependencies": { "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0" } }, "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ=="],
+
+    "@eslint-community/regexpp": ["@eslint-community/regexpp@4.12.2", "", {}, "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew=="],
+
+    "@eslint/config-array": ["@eslint/config-array@0.23.5", "", { "dependencies": { "@eslint/object-schema": "^3.0.5", "debug": "^4.3.1", "minimatch": "^10.2.4" } }, "sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA=="],
+
+    "@eslint/config-helpers": ["@eslint/config-helpers@0.6.0", "", { "dependencies": { "@eslint/core": "^1.2.1" } }, "sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA=="],
+
+    "@eslint/core": ["@eslint/core@1.2.1", "", { "dependencies": { "@types/json-schema": "^7.0.15" } }, "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ=="],
+
+    "@eslint/js": ["@eslint/js@10.0.1", "", { "peerDependencies": { "eslint": "^10.0.0" }, "optionalPeers": ["eslint"] }, "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA=="],
+
+    "@eslint/object-schema": ["@eslint/object-schema@3.0.5", "", {}, "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw=="],
+
+    "@eslint/plugin-kit": ["@eslint/plugin-kit@0.7.2", "", { "dependencies": { "@eslint/core": "^1.2.1", "levn": "^0.4.1" } }, "sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A=="],
+
     "@fastify/busboy": ["@fastify/busboy@2.1.1", "", {}, "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA=="],
 
     "@hapi/bourne": ["@hapi/bourne@3.0.0", "", {}, "sha512-Waj1cwPXJDucOib4a3bAISsKJVb15MKi9IvmTI/7ssVEm6sywXGjVJDhl6/umt1pK1ZS7PacXU3A1PmFKHEZ2w=="],
 
+    "@humanfs/core": ["@humanfs/core@0.19.2", "", { "dependencies": { "@humanfs/types": "^0.15.0" } }, "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA=="],
+
+    "@humanfs/node": ["@humanfs/node@0.16.8", "", { "dependencies": { "@humanfs/core": "^0.19.2", "@humanfs/types": "^0.15.0", "@humanwhocodes/retry": "^0.4.0" } }, "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ=="],
+
+    "@humanfs/types": ["@humanfs/types@0.15.0", "", {}, "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q=="],
+
+    "@humanwhocodes/module-importer": ["@humanwhocodes/module-importer@1.0.1", "", {}, "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA=="],
+
+    "@humanwhocodes/retry": ["@humanwhocodes/retry@0.4.3", "", {}, "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ=="],
+
+    "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
+
+    "@jridgewell/remapping": ["@jridgewell/remapping@2.3.5", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ=="],
+
+    "@jridgewell/resolve-uri": ["@jridgewell/resolve-uri@3.1.2", "", {}, "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw=="],
+
+    "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
+
+    "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+
     "@koa/multer": ["@koa/multer@4.0.0", "", { "peerDependencies": { "koa": ">=2", "multer": "*" } }, "sha512-BY6hys3WVX1yL/gcfKWu94z1fJ6ayG1DEEw/s82DnulkaTbumwjF6XqSfNLKFcs8lnJb2QfMJ4DyK4bmF1NDZw=="],
 
     "@koa/router": ["@koa/router@15.4.0", "", { "dependencies": { "debug": "^4.4.3", "http-errors": "^2.0.1", "koa-compose": "^4.1.0", "path-to-regexp": "^8.3.0" }, "peerDependencies": { "koa": "^2.0.0 || ^3.0.0" } }, "sha512-vKYlXtoCfcAN8z4dHiveYX55rTYOgHEYJNumK1WM9ZAwaArhreGVkyC1LTMGfUQUJyIO/SbwRFBOHeOCY8/MaQ=="],
+
+    "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.5", "", { "dependencies": { "@tybys/wasm-util": "^0.10.2" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q=="],
 
     "@octokit/auth-token": ["@octokit/auth-token@6.0.0", "", {}, "sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w=="],
 
@@ -97,6 +166,42 @@
     "@octokit/request-error": ["@octokit/request-error@7.1.0", "", { "dependencies": { "@octokit/types": "^16.0.0" } }, "sha512-KMQIfq5sOPpkQYajXHwnhjCC0slzCNScLHs9JafXc4RAJI+9f+jNDlBNaIMTvazOPLgb4BnlhGJOTbnN0wIjPw=="],
 
     "@octokit/types": ["@octokit/types@16.0.0", "", { "dependencies": { "@octokit/openapi-types": "^27.0.0" } }, "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg=="],
+
+    "@oxc-project/types": ["@oxc-project/types@0.133.0", "", {}, "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA=="],
+
+    "@polka/url": ["@polka/url@1.0.0-next.29", "", {}, "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww=="],
+
+    "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.0.3", "", { "os": "android", "cpu": "arm64" }, "sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw=="],
+
+    "@rolldown/binding-darwin-arm64": ["@rolldown/binding-darwin-arm64@1.0.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA=="],
+
+    "@rolldown/binding-darwin-x64": ["@rolldown/binding-darwin-x64@1.0.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg=="],
+
+    "@rolldown/binding-freebsd-x64": ["@rolldown/binding-freebsd-x64@1.0.3", "", { "os": "freebsd", "cpu": "x64" }, "sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g=="],
+
+    "@rolldown/binding-linux-arm-gnueabihf": ["@rolldown/binding-linux-arm-gnueabihf@1.0.3", "", { "os": "linux", "cpu": "arm" }, "sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw=="],
+
+    "@rolldown/binding-linux-arm64-gnu": ["@rolldown/binding-linux-arm64-gnu@1.0.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw=="],
+
+    "@rolldown/binding-linux-arm64-musl": ["@rolldown/binding-linux-arm64-musl@1.0.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q=="],
+
+    "@rolldown/binding-linux-ppc64-gnu": ["@rolldown/binding-linux-ppc64-gnu@1.0.3", "", { "os": "linux", "cpu": "ppc64" }, "sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg=="],
+
+    "@rolldown/binding-linux-s390x-gnu": ["@rolldown/binding-linux-s390x-gnu@1.0.3", "", { "os": "linux", "cpu": "s390x" }, "sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg=="],
+
+    "@rolldown/binding-linux-x64-gnu": ["@rolldown/binding-linux-x64-gnu@1.0.3", "", { "os": "linux", "cpu": "x64" }, "sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg=="],
+
+    "@rolldown/binding-linux-x64-musl": ["@rolldown/binding-linux-x64-musl@1.0.3", "", { "os": "linux", "cpu": "x64" }, "sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow=="],
+
+    "@rolldown/binding-openharmony-arm64": ["@rolldown/binding-openharmony-arm64@1.0.3", "", { "os": "none", "cpu": "arm64" }, "sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg=="],
+
+    "@rolldown/binding-wasm32-wasi": ["@rolldown/binding-wasm32-wasi@1.0.3", "", { "dependencies": { "@emnapi/core": "1.10.0", "@emnapi/runtime": "1.10.0", "@napi-rs/wasm-runtime": "^1.1.4" }, "cpu": "none" }, "sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg=="],
+
+    "@rolldown/binding-win32-arm64-msvc": ["@rolldown/binding-win32-arm64-msvc@1.0.3", "", { "os": "win32", "cpu": "arm64" }, "sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g=="],
+
+    "@rolldown/binding-win32-x64-msvc": ["@rolldown/binding-win32-x64-msvc@1.0.3", "", { "os": "win32", "cpu": "x64" }, "sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA=="],
+
+    "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.1", "", {}, "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw=="],
 
     "@runner-run/darwin-arm64": ["@runner-run/darwin-arm64@0.12.1", "", { "os": "darwin", "cpu": "arm64", "bin": { "runner": "bin/runner", "run": "bin/run" } }, "sha512-hZUwn1M42ZQTzCaoi9m0qGOP/ejrrd+yIe1CkR6y2VTIU9OMOG1O5hIluLpPyjS8FWg9nVhFlYgaV+YZacBz+w=="],
 
@@ -124,6 +229,20 @@
 
     "@runner-run/win32-x64-msvc": ["@runner-run/win32-x64-msvc@0.12.1", "", { "os": "win32", "cpu": "x64", "bin": { "runner.exe": "bin/runner.exe", "run.exe": "bin/run.exe" } }, "sha512-4nqg6W4CTLyA1Huf7g1WNRxiLOus8F67uLcu28C5HTWmBuS1n8LkgoNbzWJnidHQSTIrAlmOuU4uGuH5sWumdQ=="],
 
+    "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
+
+    "@sveltejs/acorn-typescript": ["@sveltejs/acorn-typescript@1.0.10", "", { "peerDependencies": { "acorn": "^8.9.0" } }, "sha512-4WfKk68eTih+MiJD4fSbxN7E8kVBmTMPWHUPYjvl2N0rMs53YLTT8/YjKU5Dtnz5LqDjl7LEw4U7lXR2W3J5WA=="],
+
+    "@sveltejs/adapter-auto": ["@sveltejs/adapter-auto@7.0.1", "", { "peerDependencies": { "@sveltejs/kit": "^2.0.0" } }, "sha512-dvuPm1E7M9NI/+canIQ6KKQDU2AkEefEZ2Dp7cY6uKoPq9Z/PhOXABe526UdW2mN986gjVkuSLkOYIBnS/M2LQ=="],
+
+    "@sveltejs/kit": ["@sveltejs/kit@2.65.2", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "@sveltejs/acorn-typescript": "^1.0.9", "@types/cookie": "^0.6.0", "acorn": "^8.16.0", "cookie": "^0.6.0", "devalue": "^5.8.1", "esm-env": "^1.2.2", "kleur": "^4.1.5", "magic-string": "^0.30.5", "mrmime": "^2.0.0", "set-cookie-parser": "^3.0.0", "sirv": "^3.0.0" }, "peerDependencies": { "@opentelemetry/api": "^1.0.0", "@sveltejs/vite-plugin-svelte": "^3.0.0 || ^4.0.0-next.1 || ^5.0.0 || ^6.0.0-next.0 || ^7.0.0", "svelte": "^4.0.0 || ^5.0.0-next.0", "typescript": "^5.3.3 || ^6.0.0", "vite": "^5.0.3 || ^6.0.0 || ^7.0.0-beta.0 || ^8.0.0" }, "optionalPeers": ["@opentelemetry/api", "typescript"], "bin": { "svelte-kit": "svelte-kit.js" } }, "sha512-ZIkyEmxT1gcq50Opn1ZIIx6vc/yt2zNN0rF5hS6op95gqHtNw8QMKDhjJI+RyjMcbvECRw+FzEeAoBe/MOz9AA=="],
+
+    "@sveltejs/load-config": ["@sveltejs/load-config@0.1.1", "", {}, "sha512-BXXm+VOH/9X4N7Dd1iZ2MqA1h7M+9i2noI8QYuLDY8QcN2WHYn7D/VK/+IJNfcAmRw7ACNJ538UT9GXIhnBTiA=="],
+
+    "@sveltejs/vite-plugin-svelte": ["@sveltejs/vite-plugin-svelte@7.1.2", "", { "dependencies": { "deepmerge": "^4.3.1", "magic-string": "^0.30.21", "obug": "^2.1.0", "vitefu": "^1.1.2" }, "peerDependencies": { "svelte": "^5.46.4", "vite": "^8.0.0-beta.7 || ^8.0.0" } }, "sha512-DrUBA2UXRfDmUX/ZTiEopd3X40yavsJF1FX2RygcuIScHL7o5YX1fMvoYnDhjeJQC4weCOklirpNWlcb2NiSeA=="],
+
+    "@testing-library/svelte-core": ["@testing-library/svelte-core@1.0.0", "", { "peerDependencies": { "svelte": "^3 || ^4 || ^5 || ^5.0.0-next.0" } }, "sha512-VkUePoLV6oOYwSUvX6ShA8KLnJqZiYMIbP2JW2t0GLWLkJxKGvuH5qrrZBV/X7cXFnLGuFQEC7RheYiZOW68KQ=="],
+
     "@tombi-toml/cli-darwin-arm64": ["@tombi-toml/cli-darwin-arm64@1.1.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-aaN9jQUxVvmoRelp4+6ECLMgGh74jaUS5ODfuR0lPT9ES9qEN7LzI4IhSN3Y+mqPV6Dog+5GJnq24zBbCImDCg=="],
 
     "@tombi-toml/cli-darwin-x64": ["@tombi-toml/cli-darwin-x64@1.1.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-W8O8hR+ZhyFX25mYR8jbehaDgqt0BJ7+B2TOQ8aV9+wPa1QwPHEsFd+Qdvz/4uY1GgJO77xBBinRyuHUtey3Xw=="],
@@ -140,9 +259,45 @@
 
     "@tombi-toml/cli-win32-x64": ["@tombi-toml/cli-win32-x64@1.1.2", "", { "os": "win32", "cpu": "x64" }, "sha512-j04JhyGcjI4ncMxv6yqp/735eNqWCFzm/BJo5+0E/QVza0EGqdtAvMyGGtbci9GBtxkEp8k+slNMAwYhH/ZPXA=="],
 
+    "@tybys/wasm-util": ["@tybys/wasm-util@0.10.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg=="],
+
     "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
+    "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
+
+    "@types/cookie": ["@types/cookie@0.6.0", "", {}, "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA=="],
+
+    "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
+
+    "@types/esrecurse": ["@types/esrecurse@4.3.1", "", {}, "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw=="],
+
+    "@types/estree": ["@types/estree@1.0.9", "", {}, "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg=="],
+
+    "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
+
     "@types/node": ["@types/node@24.13.1", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-RSpUJGmvsJ1ZeBehQZFhIdpsz+bIpES0nIQXko4Ybq+N+kX6XvOq3Jo+iJ82FWLdblFq85AsMikd3m35jgezYg=="],
+
+    "@types/trusted-types": ["@types/trusted-types@2.0.7", "", {}, "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="],
+
+    "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.61.1", "", { "dependencies": { "@eslint-community/regexpp": "^4.12.2", "@typescript-eslint/scope-manager": "8.61.1", "@typescript-eslint/type-utils": "8.61.1", "@typescript-eslint/utils": "8.61.1", "@typescript-eslint/visitor-keys": "8.61.1", "ignore": "^7.0.5", "natural-compare": "^1.4.0", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.61.1", "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-ZPlVl3PB3et/59Ne0fv/sci6ZXz4T4Hp4nTJ56i/Y0gR89ARb+KphojTq6j+56E5PIezmOIOOWyY+aWQFd+IkQ=="],
+
+    "@typescript-eslint/parser": ["@typescript-eslint/parser@8.61.1", "", { "dependencies": { "@typescript-eslint/scope-manager": "8.61.1", "@typescript-eslint/types": "8.61.1", "@typescript-eslint/typescript-estree": "8.61.1", "@typescript-eslint/visitor-keys": "8.61.1", "debug": "^4.4.3" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-PJ5vePq5/ognBbrIcoC5+SHO5dfpeLPzP9FpLkzWrguoYQEeeSjlJpVwOpo1JRSTEi7dRcwNy4h4dzV70PqHcg=="],
+
+    "@typescript-eslint/project-service": ["@typescript-eslint/project-service@8.61.1", "", { "dependencies": { "@typescript-eslint/tsconfig-utils": "^8.61.1", "@typescript-eslint/types": "^8.61.1", "debug": "^4.4.3" }, "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-PrC4JYGmR241lYnfhmKGTXkFqv8+ymbTFgSAY0fVXpY82/QkMw5TZPl+vGzuDDU2QYJk9fIDOBTntF+yDv9LEA=="],
+
+    "@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.61.1", "", { "dependencies": { "@typescript-eslint/types": "8.61.1", "@typescript-eslint/visitor-keys": "8.61.1" } }, "sha512-L2bdIeoQS8FlKAvONAr20w6OcLXeB+qiDKbAooS9A0Ben+iSIkBef0FxqwKWYqt5sa0i4KJtxVyVmhMylKzF5w=="],
+
+    "@typescript-eslint/tsconfig-utils": ["@typescript-eslint/tsconfig-utils@8.61.1", "", { "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-UN/H4di+OO7EWx2ovME+8t31YO+KVnK0RRKEHR3kOt21/Ay8BOq3M1OMvWs5vNiqcFCYGYoxK3MXPZzmMUE+yg=="],
+
+    "@typescript-eslint/type-utils": ["@typescript-eslint/type-utils@8.61.1", "", { "dependencies": { "@typescript-eslint/types": "8.61.1", "@typescript-eslint/typescript-estree": "8.61.1", "@typescript-eslint/utils": "8.61.1", "debug": "^4.4.3", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-GYRicKmVK0C4fsKgaACaknOUAq9Oa2kwsjnpFhFcS/5p4Ht5IP9OVLbgIgcK4SRk92nVHFluurg1lumD9dBcLw=="],
+
+    "@typescript-eslint/types": ["@typescript-eslint/types@8.61.1", "", {}, "sha512-G+CRlPqLv7Bz1IZVs03x5K59F1veqL0EJUROAdGhKsEq8qOiRiZbI+HUojPq5l0fEGOKModD9br6lObhB8zkoA=="],
+
+    "@typescript-eslint/typescript-estree": ["@typescript-eslint/typescript-estree@8.61.1", "", { "dependencies": { "@typescript-eslint/project-service": "8.61.1", "@typescript-eslint/tsconfig-utils": "8.61.1", "@typescript-eslint/types": "8.61.1", "@typescript-eslint/visitor-keys": "8.61.1", "debug": "^4.4.3", "minimatch": "^10.2.2", "semver": "^7.7.3", "tinyglobby": "^0.2.15", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-u+oQD3BqYWPc8YV9Zab4vaJElJuwOLPRc10Jm1o/qS+6Qwen14HCWwx0Seo4LnSn2wxea2Ik8DxPt2/FHmuhrg=="],
+
+    "@typescript-eslint/utils": ["@typescript-eslint/utils@8.61.1", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.9.1", "@typescript-eslint/scope-manager": "8.61.1", "@typescript-eslint/types": "8.61.1", "@typescript-eslint/typescript-estree": "8.61.1" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-1+P/3Dj6jvtybE1q0HQ6yBt/gq+oKJyLdEv4HdnqasaEXRSYCAsD59mXEVQnM/ULNdQxbX77tdG4jPRjIS6knA=="],
+
+    "@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.61.1", "", { "dependencies": { "@typescript-eslint/types": "8.61.1", "eslint-visitor-keys": "^5.0.0" } }, "sha512-6fJ9MHWtK14C1DSkiMlHUSOmrVebL7150xZJBlJiL62jjhIA4JmOq6flwBgDxIdBKKdoiZRel+dfPD5MLfny3w=="],
 
     "@typescript/native-preview": ["@typescript/native-preview@7.0.0-dev.20260607.1", "", { "optionalDependencies": { "@typescript/native-preview-darwin-arm64": "7.0.0-dev.20260607.1", "@typescript/native-preview-darwin-x64": "7.0.0-dev.20260607.1", "@typescript/native-preview-linux-arm": "7.0.0-dev.20260607.1", "@typescript/native-preview-linux-arm64": "7.0.0-dev.20260607.1", "@typescript/native-preview-linux-x64": "7.0.0-dev.20260607.1", "@typescript/native-preview-win32-arm64": "7.0.0-dev.20260607.1", "@typescript/native-preview-win32-x64": "7.0.0-dev.20260607.1" }, "bin": { "tsgo": "bin/tsgo.js" } }, "sha512-+DBR9iyRZiUNhJI2CqFluJLxKl3xkBGFFCADiy63pCpLVCCNuffunRhcxQ2vhnLnM3dBDoqOHE4ekKg0GfaS/Q=="],
 
@@ -160,9 +315,33 @@
 
     "@typescript/native-preview-win32-x64": ["@typescript/native-preview-win32-x64@7.0.0-dev.20260607.1", "", { "os": "win32", "cpu": "x64" }, "sha512-SBWFFs+MglgDrx8lh37uFHVQcljN09Z/D8Z+YwykMVKtYEIGM/i5WzS8Xpiegm9Vcqu3HTkuAfjQfy6X5MsqnA=="],
 
+    "@vitest/browser": ["@vitest/browser@4.1.9", "", { "dependencies": { "@blazediff/core": "1.9.1", "@vitest/mocker": "4.1.9", "@vitest/utils": "4.1.9", "magic-string": "^0.30.21", "pngjs": "^7.0.0", "sirv": "^3.0.2", "tinyrainbow": "^3.1.0", "ws": "^8.19.0" }, "peerDependencies": { "vitest": "4.1.9" } }, "sha512-j1BKtWmPcqpMhmx/L9EPLgAJpCb0zKfwoWLmqBbxaogCXHjOwHFSEoHCBfnGtx93xKQwilZ26m+UOsHqHMkRNg=="],
+
+    "@vitest/browser-playwright": ["@vitest/browser-playwright@4.1.9", "", { "dependencies": { "@vitest/browser": "4.1.9", "@vitest/mocker": "4.1.9", "tinyrainbow": "^3.1.0" }, "peerDependencies": { "playwright": "*", "vitest": "4.1.9" } }, "sha512-Bq1rOGf9waevzG3EOkO/dene6bvKTUsZMVg8S1i+WH3JcMjuXEjiahP9rAqZRELUqjBySOJsvvSWqK/B3wjKQw=="],
+
+    "@vitest/expect": ["@vitest/expect@4.1.9", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.1.9", "@vitest/utils": "4.1.9", "chai": "^6.2.2", "tinyrainbow": "^3.1.0" } }, "sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA=="],
+
+    "@vitest/mocker": ["@vitest/mocker@4.1.9", "", { "dependencies": { "@vitest/spy": "4.1.9", "estree-walker": "^3.0.3", "magic-string": "^0.30.21" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["msw", "vite"] }, "sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw=="],
+
+    "@vitest/pretty-format": ["@vitest/pretty-format@4.1.9", "", { "dependencies": { "tinyrainbow": "^3.1.0" } }, "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A=="],
+
+    "@vitest/runner": ["@vitest/runner@4.1.9", "", { "dependencies": { "@vitest/utils": "4.1.9", "pathe": "^2.0.3" } }, "sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg=="],
+
+    "@vitest/snapshot": ["@vitest/snapshot@4.1.9", "", { "dependencies": { "@vitest/pretty-format": "4.1.9", "@vitest/utils": "4.1.9", "magic-string": "^0.30.21", "pathe": "^2.0.3" } }, "sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA=="],
+
+    "@vitest/spy": ["@vitest/spy@4.1.9", "", {}, "sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA=="],
+
+    "@vitest/utils": ["@vitest/utils@4.1.9", "", { "dependencies": { "@vitest/pretty-format": "4.1.9", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA=="],
+
     "accepts": ["accepts@1.3.8", "", { "dependencies": { "mime-types": "~2.1.34", "negotiator": "0.6.3" } }, "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw=="],
 
+    "acorn": ["acorn@8.17.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg=="],
+
+    "acorn-jsx": ["acorn-jsx@5.3.2", "", { "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="],
+
     "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
+
+    "ajv": ["ajv@6.15.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw=="],
 
     "ansi-escapes": ["ansi-escapes@4.3.2", "", { "dependencies": { "type-fest": "^0.21.3" } }, "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ=="],
 
@@ -172,9 +351,15 @@
 
     "append-field": ["append-field@1.0.0", "", {}, "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw=="],
 
+    "aria-query": ["aria-query@5.3.1", "", {}, "sha512-Z/ZeOgVl7bcSYZ/u/rh0fOpvEpq//LZmdbkXyc7syVzjPAhfOa9ebsdTSjEBDU4vs5nC98Kfduj1uFo0qyET3g=="],
+
+    "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
+
     "asynckit": ["asynckit@0.4.0", "", {}, "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="],
 
-    "balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
+    "axobject-query": ["axobject-query@4.1.0", "", {}, "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ=="],
+
+    "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
     "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
 
@@ -186,7 +371,7 @@
 
     "bottleneck": ["bottleneck@2.19.5", "", {}, "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw=="],
 
-    "brace-expansion": ["brace-expansion@1.1.15", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg=="],
+    "brace-expansion": ["brace-expansion@5.0.6", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g=="],
 
     "browser-hrtime": ["browser-hrtime@1.1.8", "", {}, "sha512-kzXheikaJsBtzUBlyVtPIY5r0soQePzjwVwT4IlDpU2RvfB5Py52gpU98M77rgqMCheoSSZvrcrdj3t6cZ3suA=="],
 
@@ -204,9 +389,13 @@
 
     "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
 
+    "chai": ["chai@6.2.2", "", {}, "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg=="],
+
     "chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
     "chardet": ["chardet@0.7.0", "", {}, "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA=="],
+
+    "chokidar": ["chokidar@4.0.3", "", { "dependencies": { "readdirp": "^4.0.1" } }, "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA=="],
 
     "cli-cursor": ["cli-cursor@3.1.0", "", { "dependencies": { "restore-cursor": "^3.1.0" } }, "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw=="],
 
@@ -215,6 +404,8 @@
     "cli-width": ["cli-width@3.0.0", "", {}, "sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw=="],
 
     "clone": ["clone@1.0.4", "", {}, "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg=="],
+
+    "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
 
     "co-body": ["co-body@6.2.0", "", { "dependencies": { "@hapi/bourne": "^3.0.0", "inflation": "^2.0.0", "qs": "^6.5.2", "raw-body": "^2.3.3", "type-is": "^1.6.16" } }, "sha512-Kbpv2Yd1NdL1V/V4cwLVxraHDV6K8ayohr2rmH0J87Er8+zJjcTa6dAn9QMPC9CRgU8+aNajKbSf1TzDB1yKPA=="],
 
@@ -234,6 +425,10 @@
 
     "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
 
+    "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
+
+    "cookie": ["cookie@0.6.0", "", {}, "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw=="],
+
     "cookies": ["cookies@0.9.1", "", { "dependencies": { "depd": "~2.0.0", "keygrip": "~1.1.0" } }, "sha512-TG2hpqe4ELx54QER/S3HQ9SRVnQnGBtKUz5bLQWtYAQ+o6GpgMs6sYUvaiJjVxb+UXwhRhAEP3m7LbsIZ77Hmw=="],
 
     "copy-to": ["copy-to@2.0.1", "", {}, "sha512-3DdaFaU/Zf1AnpLiFDeNCD4TOWe3Zl2RZaTzUvWiIk5ERzcCodOE20Vqq4fzCbNoHURFHT4/us/Lfq+S2zyY4w=="],
@@ -241,6 +436,10 @@
     "core-js": ["core-js@3.49.0", "", {}, "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg=="],
 
     "core-util-is": ["core-util-is@1.0.3", "", {}, "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="],
+
+    "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
+
+    "cssesc": ["cssesc@3.0.0", "", { "bin": { "cssesc": "bin/cssesc" } }, "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg=="],
 
     "cssstyle": ["cssstyle@4.6.0", "", { "dependencies": { "@asamuzakjp/css-color": "^3.2.0", "rrweb-cssom": "^0.8.0" } }, "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg=="],
 
@@ -251,6 +450,10 @@
     "decimal.js": ["decimal.js@10.6.0", "", {}, "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg=="],
 
     "deep-equal": ["deep-equal@1.0.1", "", {}, "sha512-bHtC0iYvWhyaTzvV3CZgPeZQqCOBGyGsVV7v4eevpdkLHfiSrXUdBG+qAuSz4RI70sszvjQ1QSZ98An1yNwpSw=="],
+
+    "deep-is": ["deep-is@0.1.4", "", {}, "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="],
+
+    "deepmerge": ["deepmerge@4.3.1", "", {}, "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A=="],
 
     "defaults": ["defaults@1.0.4", "", { "dependencies": { "clone": "^1.0.2" } }, "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A=="],
 
@@ -263,6 +466,12 @@
     "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
 
     "destroy": ["destroy@1.2.0", "", {}, "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg=="],
+
+    "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
+
+    "devalue": ["devalue@5.8.1", "", {}, "sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw=="],
+
+    "docs": ["docs@workspace:docs"],
 
     "dprint": ["dprint@0.54.0", "", { "optionalDependencies": { "@dprint/darwin-arm64": "0.54.0", "@dprint/darwin-x64": "0.54.0", "@dprint/linux-arm64-glibc": "0.54.0", "@dprint/linux-arm64-musl": "0.54.0", "@dprint/linux-loong64-glibc": "0.54.0", "@dprint/linux-loong64-musl": "0.54.0", "@dprint/linux-riscv64-glibc": "0.54.0", "@dprint/linux-x64-glibc": "0.54.0", "@dprint/linux-x64-musl": "0.54.0", "@dprint/win32-arm64": "0.54.0", "@dprint/win32-x64": "0.54.0" }, "bin": { "dprint": "bin.cjs" } }, "sha512-sIy25poR2gRP/tWPTgP0MPeJoJcpv0xzYDcsboapvthbEt1Qw3Al252CA0xFyIh2cYEGGKyBJtKokryv4ERlJw=="],
 
@@ -280,27 +489,77 @@
 
     "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
 
+    "es-module-lexer": ["es-module-lexer@2.1.0", "", {}, "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ=="],
+
     "es-object-atoms": ["es-object-atoms@1.1.2", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw=="],
 
     "es-set-tostringtag": ["es-set-tostringtag@2.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "get-intrinsic": "^1.2.6", "has-tostringtag": "^1.0.2", "hasown": "^2.0.2" } }, "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA=="],
 
     "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
 
-    "escape-string-regexp": ["escape-string-regexp@1.0.5", "", {}, "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="],
+    "escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
+
+    "eslint": ["eslint@10.5.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.8.0", "@eslint-community/regexpp": "^4.12.2", "@eslint/config-array": "^0.23.5", "@eslint/config-helpers": "^0.6.0", "@eslint/core": "^1.2.1", "@eslint/plugin-kit": "^0.7.2", "@humanfs/node": "^0.16.6", "@humanwhocodes/module-importer": "^1.0.1", "@humanwhocodes/retry": "^0.4.2", "@types/estree": "^1.0.6", "ajv": "^6.14.0", "cross-spawn": "^7.0.6", "debug": "^4.3.2", "escape-string-regexp": "^4.0.0", "eslint-scope": "^9.1.2", "eslint-visitor-keys": "^5.0.1", "espree": "^11.2.0", "esquery": "^1.7.0", "esutils": "^2.0.2", "fast-deep-equal": "^3.1.3", "file-entry-cache": "^8.0.0", "find-up": "^5.0.0", "glob-parent": "^6.0.2", "ignore": "^5.2.0", "imurmurhash": "^0.1.4", "is-glob": "^4.0.0", "json-stable-stringify-without-jsonify": "^1.0.1", "minimatch": "^10.2.4", "natural-compare": "^1.4.0", "optionator": "^0.9.3" }, "peerDependencies": { "jiti": "*" }, "optionalPeers": ["jiti"], "bin": { "eslint": "bin/eslint.js" } }, "sha512-1y+7C+vi12bUK1IpZeaV3gsH9fHLBmPvYmPx42pvT/E9yG0IC8g3PUZZgp0+JLJl7ZDK0flc2gc+Aw9dpCvIsQ=="],
+
+    "eslint-plugin-svelte": ["eslint-plugin-svelte@3.19.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.6.1", "@jridgewell/sourcemap-codec": "^1.5.0", "esutils": "^2.0.3", "globals": "^16.0.0", "known-css-properties": "^0.37.0", "postcss": "^8.4.49", "postcss-load-config": "^3.1.4", "postcss-safe-parser": "^7.0.0", "semver": "^7.6.3", "svelte-eslint-parser": "^1.7.0" }, "peerDependencies": { "eslint": "^8.57.1 || ^9.0.0 || ^10.0.0", "svelte": "^3.37.0 || ^4.0.0 || ^5.0.0" }, "optionalPeers": ["svelte"] }, "sha512-t3rNaZeXz4d2gG4uJyMEYfJCFKf22+SWbSizIIXIWKu4wM+XPLiMWuSSr/C5821JmFeN9ogK+eExbG+z+twyxw=="],
+
+    "eslint-scope": ["eslint-scope@9.1.2", "", { "dependencies": { "@types/esrecurse": "^4.3.1", "@types/estree": "^1.0.8", "esrecurse": "^4.3.0", "estraverse": "^5.2.0" } }, "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ=="],
+
+    "eslint-visitor-keys": ["eslint-visitor-keys@5.0.1", "", {}, "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA=="],
+
+    "esm-env": ["esm-env@1.2.2", "", {}, "sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA=="],
+
+    "espree": ["espree@11.2.0", "", { "dependencies": { "acorn": "^8.16.0", "acorn-jsx": "^5.3.2", "eslint-visitor-keys": "^5.0.1" } }, "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw=="],
+
+    "esquery": ["esquery@1.7.0", "", { "dependencies": { "estraverse": "^5.1.0" } }, "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g=="],
+
+    "esrap": ["esrap@2.2.11", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.4.15" }, "peerDependencies": { "@typescript-eslint/types": "^8.2.0" }, "optionalPeers": ["@typescript-eslint/types"] }, "sha512-gPdx+I+BjYEinNMQaBXFjbaJVyoPMU4ZODg5mE+M4DqVG9VusAVHHjcBX+zqyITlI0DIARwDMMzZwAWj36dRoQ=="],
+
+    "esrecurse": ["esrecurse@4.3.0", "", { "dependencies": { "estraverse": "^5.2.0" } }, "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag=="],
+
+    "estraverse": ["estraverse@5.3.0", "", {}, "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="],
+
+    "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
+
+    "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
+
+    "expect-type": ["expect-type@1.3.0", "", {}, "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA=="],
 
     "external-editor": ["external-editor@3.1.0", "", { "dependencies": { "chardet": "^0.7.0", "iconv-lite": "^0.4.24", "tmp": "^0.0.33" } }, "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew=="],
 
+    "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
+
+    "fast-json-stable-stringify": ["fast-json-stable-stringify@2.1.0", "", {}, "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="],
+
+    "fast-levenshtein": ["fast-levenshtein@2.0.6", "", {}, "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="],
+
+    "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
+
     "figures": ["figures@3.2.0", "", { "dependencies": { "escape-string-regexp": "^1.0.5" } }, "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg=="],
+
+    "file-entry-cache": ["file-entry-cache@8.0.0", "", { "dependencies": { "flat-cache": "^4.0.0" } }, "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ=="],
+
+    "find-up": ["find-up@5.0.0", "", { "dependencies": { "locate-path": "^6.0.0", "path-exists": "^4.0.0" } }, "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng=="],
+
+    "flat-cache": ["flat-cache@4.0.1", "", { "dependencies": { "flatted": "^3.2.9", "keyv": "^4.5.4" } }, "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw=="],
+
+    "flatted": ["flatted@3.4.2", "", {}, "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA=="],
 
     "form-data": ["form-data@4.0.4", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.2", "mime-types": "^2.1.12" } }, "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow=="],
 
     "fresh": ["fresh@0.5.2", "", {}, "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q=="],
+
+    "fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
     "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
 
     "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
 
     "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
+
+    "glob-parent": ["glob-parent@6.0.2", "", { "dependencies": { "is-glob": "^4.0.3" } }, "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A=="],
+
+    "globals": ["globals@17.6.0", "", {}, "sha512-sepffkT8stwnIYbsMBpoCHJuJM5l98FUF2AnE07hfvE0m/qp3R586hw4jF4uadbhvg1ooIdzuu7CsfD2jzCaNA=="],
 
     "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
 
@@ -328,7 +587,11 @@
 
     "ieee754": ["ieee754@1.2.1", "", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
 
+    "ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
+
     "immediate": ["immediate@3.0.6", "", {}, "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ=="],
+
+    "imurmurhash": ["imurmurhash@0.1.4", "", {}, "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="],
 
     "inflation": ["inflation@2.1.0", "", {}, "sha512-t54PPJHG1Pp7VQvxyVCJ9mBbjG3Hqryges9bXoOO6GExCPa+//i/d5GSuFtpx3ALLd7lgIAur6zrIlBQyJuMlQ=="],
 
@@ -338,7 +601,11 @@
 
     "is-docker": ["is-docker@2.2.1", "", { "bin": { "is-docker": "cli.js" } }, "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ=="],
 
+    "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
+
     "is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
+
+    "is-glob": ["is-glob@4.0.3", "", { "dependencies": { "is-extglob": "^2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
 
     "is-interactive": ["is-interactive@1.0.0", "", {}, "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w=="],
 
@@ -346,13 +613,25 @@
 
     "is-promise": ["is-promise@2.2.2", "", {}, "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ=="],
 
+    "is-reference": ["is-reference@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.6" } }, "sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw=="],
+
     "is-unicode-supported": ["is-unicode-supported@0.1.0", "", {}, "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw=="],
 
     "is-wsl": ["is-wsl@2.2.0", "", { "dependencies": { "is-docker": "^2.0.0" } }, "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww=="],
 
     "isarray": ["isarray@1.0.0", "", {}, "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="],
 
+    "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
+    "jiti": ["jiti@2.7.0", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ=="],
+
     "jsdom": ["jsdom@26.1.0", "", { "dependencies": { "cssstyle": "^4.2.1", "data-urls": "^5.0.0", "decimal.js": "^10.5.0", "html-encoding-sniffer": "^4.0.0", "http-proxy-agent": "^7.0.2", "https-proxy-agent": "^7.0.6", "is-potential-custom-element-name": "^1.0.1", "nwsapi": "^2.2.16", "parse5": "^7.2.1", "rrweb-cssom": "^0.8.0", "saxes": "^6.0.0", "symbol-tree": "^3.2.4", "tough-cookie": "^5.1.1", "w3c-xmlserializer": "^5.0.0", "webidl-conversions": "^7.0.0", "whatwg-encoding": "^3.1.1", "whatwg-mimetype": "^4.0.0", "whatwg-url": "^14.1.1", "ws": "^8.18.0", "xml-name-validator": "^5.0.0" }, "peerDependencies": { "canvas": "^3.0.0" }, "optionalPeers": ["canvas"] }, "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg=="],
+
+    "json-buffer": ["json-buffer@3.0.1", "", {}, "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="],
+
+    "json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
+
+    "json-stable-stringify-without-jsonify": ["json-stable-stringify-without-jsonify@1.0.1", "", {}, "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="],
 
     "json-stringify-safe": ["json-stringify-safe@5.0.1", "", {}, "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="],
 
@@ -361,6 +640,12 @@
     "jszip": ["jszip@3.10.1", "", { "dependencies": { "lie": "~3.3.0", "pako": "~1.0.2", "readable-stream": "~2.3.6", "setimmediate": "^1.0.5" } }, "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g=="],
 
     "keygrip": ["keygrip@1.1.0", "", { "dependencies": { "tsscmp": "1.0.6" } }, "sha512-iYSchDJ+liQ8iwbSI2QqsQOvqv58eJCEanyJPJi+Khyu8smkcKSFUCbPwzFcL7YVtZ6eONjqRX/38caJ7QjRAQ=="],
+
+    "keyv": ["keyv@4.5.4", "", { "dependencies": { "json-buffer": "3.0.1" } }, "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw=="],
+
+    "kleur": ["kleur@4.1.5", "", {}, "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ=="],
+
+    "known-css-properties": ["known-css-properties@0.37.0", "", {}, "sha512-JCDrsP4Z1Sb9JwG0aJ8Eo2r7k4Ou5MwmThS/6lcIe1ICyb7UBJKGRIUUdqc2ASdE/42lgz6zFUnzAIhtXnBVrQ=="],
 
     "koa": ["koa@3.1.2", "", { "dependencies": { "accepts": "^1.3.8", "content-disposition": "~1.0.1", "content-type": "^1.0.5", "cookies": "~0.9.1", "delegates": "^1.0.0", "destroy": "^1.2.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "fresh": "~0.5.2", "http-assert": "^1.5.0", "http-errors": "^2.0.0", "koa-compose": "^4.1.0", "mime-types": "^3.0.1", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-2LOQnFKu3m0VxpE+5sb5+BRTSKrXmNxGgxVRiKwD9s5KQB1zID/FRXhtzeV7RT1L2GVpdEEAfVuclFOMGl1ikA=="],
 
@@ -372,7 +657,39 @@
 
     "koa-json": ["koa-json@2.0.2", "", { "dependencies": { "koa-is-json": "1", "streaming-json-stringify": "3" } }, "sha512-8+dz0T2ekDuNN1svYoKPCV2txotQ3Ufg8Fn5bft1T48MPJWiC/HKmkk+3xj9EC/iNZuFYeLRazN2h2o3RSUXuQ=="],
 
+    "levn": ["levn@0.4.1", "", { "dependencies": { "prelude-ls": "^1.2.1", "type-check": "~0.4.0" } }, "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ=="],
+
     "lie": ["lie@3.3.0", "", { "dependencies": { "immediate": "~3.0.5" } }, "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ=="],
+
+    "lightningcss": ["lightningcss@1.32.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.32.0", "lightningcss-darwin-arm64": "1.32.0", "lightningcss-darwin-x64": "1.32.0", "lightningcss-freebsd-x64": "1.32.0", "lightningcss-linux-arm-gnueabihf": "1.32.0", "lightningcss-linux-arm64-gnu": "1.32.0", "lightningcss-linux-arm64-musl": "1.32.0", "lightningcss-linux-x64-gnu": "1.32.0", "lightningcss-linux-x64-musl": "1.32.0", "lightningcss-win32-arm64-msvc": "1.32.0", "lightningcss-win32-x64-msvc": "1.32.0" } }, "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ=="],
+
+    "lightningcss-android-arm64": ["lightningcss-android-arm64@1.32.0", "", { "os": "android", "cpu": "arm64" }, "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg=="],
+
+    "lightningcss-darwin-arm64": ["lightningcss-darwin-arm64@1.32.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ=="],
+
+    "lightningcss-darwin-x64": ["lightningcss-darwin-x64@1.32.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w=="],
+
+    "lightningcss-freebsd-x64": ["lightningcss-freebsd-x64@1.32.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig=="],
+
+    "lightningcss-linux-arm-gnueabihf": ["lightningcss-linux-arm-gnueabihf@1.32.0", "", { "os": "linux", "cpu": "arm" }, "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw=="],
+
+    "lightningcss-linux-arm64-gnu": ["lightningcss-linux-arm64-gnu@1.32.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ=="],
+
+    "lightningcss-linux-arm64-musl": ["lightningcss-linux-arm64-musl@1.32.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg=="],
+
+    "lightningcss-linux-x64-gnu": ["lightningcss-linux-x64-gnu@1.32.0", "", { "os": "linux", "cpu": "x64" }, "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA=="],
+
+    "lightningcss-linux-x64-musl": ["lightningcss-linux-x64-musl@1.32.0", "", { "os": "linux", "cpu": "x64" }, "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg=="],
+
+    "lightningcss-win32-arm64-msvc": ["lightningcss-win32-arm64-msvc@1.32.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw=="],
+
+    "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.32.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q=="],
+
+    "lilconfig": ["lilconfig@2.1.0", "", {}, "sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ=="],
+
+    "locate-character": ["locate-character@3.0.0", "", {}, "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA=="],
+
+    "locate-path": ["locate-path@6.0.0", "", { "dependencies": { "p-locate": "^5.0.0" } }, "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw=="],
 
     "lodash": ["lodash@4.18.1", "", {}, "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q=="],
 
@@ -384,6 +701,8 @@
 
     "lunr": ["lunr@2.3.9", "", {}, "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow=="],
 
+    "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
+
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
 
     "media-typer": ["media-typer@1.1.0", "", {}, "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="],
@@ -394,13 +713,21 @@
 
     "mimic-fn": ["mimic-fn@2.1.0", "", {}, "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="],
 
-    "minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
+    "minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
+
+    "mri": ["mri@1.2.0", "", {}, "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA=="],
+
+    "mrmime": ["mrmime@2.0.1", "", {}, "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ=="],
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
     "multer": ["multer@2.1.1", "", { "dependencies": { "append-field": "^1.0.0", "busboy": "^1.6.0", "concat-stream": "^2.0.0", "type-is": "^1.6.18" } }, "sha512-mo+QTzKlx8R7E5ylSXxWzGoXoZbOsRMpyitcht8By2KHvMbf3tjwosZ/Mu/XYU6UuJ3VZnODIrak5ZrPiPyB6A=="],
 
     "mute-stream": ["mute-stream@0.0.8", "", {}, "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA=="],
+
+    "nanoid": ["nanoid@3.3.12", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ=="],
+
+    "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
 
     "negotiator": ["negotiator@0.6.3", "", {}, "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="],
 
@@ -412,15 +739,23 @@
 
     "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
 
+    "obug": ["obug@2.1.3", "", {}, "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg=="],
+
     "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
 
     "onetime": ["onetime@5.1.2", "", { "dependencies": { "mimic-fn": "^2.1.0" } }, "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg=="],
 
     "open": ["open@8.4.2", "", { "dependencies": { "define-lazy-prop": "^2.0.0", "is-docker": "^2.1.1", "is-wsl": "^2.2.0" } }, "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ=="],
 
+    "optionator": ["optionator@0.9.4", "", { "dependencies": { "deep-is": "^0.1.3", "fast-levenshtein": "^2.0.6", "levn": "^0.4.1", "prelude-ls": "^1.2.1", "type-check": "^0.4.0", "word-wrap": "^1.2.5" } }, "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g=="],
+
     "ora": ["ora@5.4.1", "", { "dependencies": { "bl": "^4.1.0", "chalk": "^4.1.0", "cli-cursor": "^3.1.0", "cli-spinners": "^2.5.0", "is-interactive": "^1.0.0", "is-unicode-supported": "^0.1.0", "log-symbols": "^4.1.0", "strip-ansi": "^6.0.0", "wcwidth": "^1.0.1" } }, "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ=="],
 
     "os-tmpdir": ["os-tmpdir@1.0.2", "", {}, "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g=="],
+
+    "p-limit": ["p-limit@3.1.0", "", { "dependencies": { "yocto-queue": "^0.1.0" } }, "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ=="],
+
+    "p-locate": ["p-locate@5.0.0", "", { "dependencies": { "p-limit": "^3.0.2" } }, "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw=="],
 
     "pako": ["pako@1.0.11", "", {}, "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="],
 
@@ -430,9 +765,37 @@
 
     "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
 
+    "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
+
+    "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
+
     "path-to-regexp": ["path-to-regexp@8.4.2", "", {}, "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="],
 
+    "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
+
+    "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
+
+    "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
+
     "pify": ["pify@3.0.0", "", {}, "sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg=="],
+
+    "playwright": ["playwright@1.61.0", "", { "dependencies": { "playwright-core": "1.61.0" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ=="],
+
+    "playwright-core": ["playwright-core@1.61.0", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA=="],
+
+    "pngjs": ["pngjs@7.0.0", "", {}, "sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow=="],
+
+    "postcss": ["postcss@8.5.15", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A=="],
+
+    "postcss-load-config": ["postcss-load-config@3.1.4", "", { "dependencies": { "lilconfig": "^2.0.5", "yaml": "^1.10.2" }, "peerDependencies": { "postcss": ">=8.0.9", "ts-node": ">=9.0.0" }, "optionalPeers": ["postcss", "ts-node"] }, "sha512-6DiM4E7v4coTE4uzA8U//WhtPwyhiim3eyjEMFCnUpzbrkK9wJHgKDT2mR+HbtSrd/NubVaYTOpSpjUl8NQeRg=="],
+
+    "postcss-safe-parser": ["postcss-safe-parser@7.0.1", "", { "peerDependencies": { "postcss": "^8.4.31" } }, "sha512-0AioNCJZ2DPYz5ABT6bddIqlhgwhpHZ/l65YAYo0BCIn0xiDpsnTHz0gnoTGk0OXZW0JRs+cDwL8u/teRdz+8A=="],
+
+    "postcss-scss": ["postcss-scss@4.0.9", "", { "peerDependencies": { "postcss": "^8.4.29" } }, "sha512-AjKOeiwAitL/MXxQW2DliT28EKukvvbEWx3LBmJIRN8KfBGZbRTxNYW0kSqi1COiTZ57nZ9NW06S6ux//N1c9A=="],
+
+    "postcss-selector-parser": ["postcss-selector-parser@7.1.4", "", { "dependencies": { "cssesc": "^3.0.0", "util-deprecate": "^1.0.2" } }, "sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg=="],
+
+    "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
 
     "process-nextick-args": ["process-nextick-args@2.0.1", "", {}, "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="],
 
@@ -446,9 +809,13 @@
 
     "readable-stream": ["readable-stream@2.3.8", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.3", "isarray": "~1.0.0", "process-nextick-args": "~2.0.0", "safe-buffer": "~5.1.1", "string_decoder": "~1.1.1", "util-deprecate": "~1.0.1" } }, "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA=="],
 
+    "readdirp": ["readdirp@4.1.2", "", {}, "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="],
+
     "restore-cursor": ["restore-cursor@3.1.0", "", { "dependencies": { "onetime": "^5.1.0", "signal-exit": "^3.0.2" } }, "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA=="],
 
     "retry": ["retry@0.12.0", "", {}, "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow=="],
+
+    "rolldown": ["rolldown@1.0.3", "", { "dependencies": { "@oxc-project/types": "=0.133.0", "@rolldown/pluginutils": "^1.0.0" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.3", "@rolldown/binding-darwin-arm64": "1.0.3", "@rolldown/binding-darwin-x64": "1.0.3", "@rolldown/binding-freebsd-x64": "1.0.3", "@rolldown/binding-linux-arm-gnueabihf": "1.0.3", "@rolldown/binding-linux-arm64-gnu": "1.0.3", "@rolldown/binding-linux-arm64-musl": "1.0.3", "@rolldown/binding-linux-ppc64-gnu": "1.0.3", "@rolldown/binding-linux-s390x-gnu": "1.0.3", "@rolldown/binding-linux-x64-gnu": "1.0.3", "@rolldown/binding-linux-x64-musl": "1.0.3", "@rolldown/binding-openharmony-arm64": "1.0.3", "@rolldown/binding-wasm32-wasi": "1.0.3", "@rolldown/binding-win32-arm64-msvc": "1.0.3", "@rolldown/binding-win32-x64-msvc": "1.0.3" }, "bin": { "rolldown": "./bin/cli.mjs" } }, "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g=="],
 
     "rrweb-cssom": ["rrweb-cssom@0.8.0", "", {}, "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw=="],
 
@@ -458,6 +825,8 @@
 
     "rxjs": ["rxjs@7.8.1", "", { "dependencies": { "tslib": "^2.1.0" } }, "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg=="],
 
+    "sade": ["sade@1.8.1", "", { "dependencies": { "mri": "^1.1.0" } }, "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A=="],
+
     "safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
 
     "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
@@ -466,9 +835,15 @@
 
     "semver": ["semver@7.7.3", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
 
+    "set-cookie-parser": ["set-cookie-parser@3.1.0", "", {}, "sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw=="],
+
     "setimmediate": ["setimmediate@1.0.5", "", {}, "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="],
 
     "setprototypeof": ["setprototypeof@1.2.0", "", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
+
+    "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
+
+    "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
 
     "side-channel": ["side-channel@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3", "side-channel-list": "^1.0.0", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw=="],
 
@@ -478,9 +853,19 @@
 
     "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
 
+    "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
+
     "signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
 
+    "sirv": ["sirv@3.0.2", "", { "dependencies": { "@polka/url": "^1.0.0-next.24", "mrmime": "^2.0.0", "totalist": "^3.0.0" } }, "sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g=="],
+
+    "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
+
+    "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
+
     "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
+
+    "std-env": ["std-env@4.1.0", "", {}, "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ=="],
 
     "steno": ["steno@0.4.4", "", { "dependencies": { "graceful-fs": "^4.1.3" } }, "sha512-EEHMVYHNXFHfGtgjNITnka0aHhiAlo93F7z2/Pwd+g0teG9CnM3JIINM7hVVB5/rhw9voufD7Wukwgtw2uqh6w=="],
 
@@ -496,9 +881,23 @@
 
     "supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
+    "svelte": ["svelte@5.56.3", "", { "dependencies": { "@jridgewell/remapping": "^2.3.4", "@jridgewell/sourcemap-codec": "^1.5.0", "@sveltejs/acorn-typescript": "^1.0.10", "@types/estree": "^1.0.5", "@types/trusted-types": "^2.0.7", "acorn": "^8.12.1", "aria-query": "5.3.1", "axobject-query": "^4.1.0", "clsx": "^2.1.1", "devalue": "^5.8.1", "esm-env": "^1.2.1", "esrap": "^2.2.11", "is-reference": "^3.0.3", "locate-character": "^3.0.0", "magic-string": "^0.30.11", "zimmerframe": "^1.1.2" } }, "sha512-w7JvrM5IFl5cmfbY0TLik9o7mjRUJmRMhOR51tBPu708Gr/MjbGs7VnJnr/B0CaXeI4vtnOh7RKxDr0cwhMdDA=="],
+
+    "svelte-check": ["svelte-check@4.6.0", "", { "dependencies": { "@jridgewell/trace-mapping": "^0.3.25", "@sveltejs/load-config": "0.1.1", "chokidar": "^4.0.1", "fdir": "^6.2.0", "picocolors": "^1.0.0", "sade": "^1.7.4" }, "peerDependencies": { "svelte": "^4.0.0 || ^5.0.0-next.0", "typescript": ">=5.0.0" }, "bin": { "svelte-check": "bin/svelte-check" } }, "sha512-KhVnDFDSid57mmZtHz8gfW8AAGylOZ0vPnOIzVmAL+urzwK8sBYXRss953gD8T0OdgAQ11mdWhE6uadmtOz8TQ=="],
+
+    "svelte-eslint-parser": ["svelte-eslint-parser@1.8.0", "", { "dependencies": { "eslint-scope": "^8.2.0", "eslint-visitor-keys": "^4.0.0", "espree": "^10.0.0", "postcss": "^8.4.49", "postcss-scss": "^4.0.9", "postcss-selector-parser": "^7.0.0", "semver": "^7.7.2" }, "peerDependencies": { "svelte": "^3.37.0 || ^4.0.0 || ^5.0.0" }, "optionalPeers": ["svelte"] }, "sha512-mikR1qwIVy3t5WthUoAXkMwxkXvabZP9FJgdx35Ei7EbGWmctva1Pih16Koeor/bdNNq8NXHlwKGS6NkYTawLg=="],
+
     "symbol-tree": ["symbol-tree@3.2.4", "", {}, "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="],
 
     "through": ["through@2.3.8", "", {}, "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg=="],
+
+    "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
+
+    "tinyexec": ["tinyexec@1.2.4", "", {}, "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg=="],
+
+    "tinyglobby": ["tinyglobby@0.2.17", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g=="],
+
+    "tinyrainbow": ["tinyrainbow@3.1.0", "", {}, "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw=="],
 
     "tldts": ["tldts@7.0.28", "", { "dependencies": { "tldts-core": "^7.0.28" }, "bin": { "tldts": "bin/cli.js" } }, "sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw=="],
 
@@ -510,15 +909,21 @@
 
     "tombi": ["tombi@1.1.2", "", { "optionalDependencies": { "@tombi-toml/cli-darwin-arm64": "1.1.2", "@tombi-toml/cli-darwin-x64": "1.1.2", "@tombi-toml/cli-linux-arm64": "1.1.2", "@tombi-toml/cli-linux-arm64-musl": "1.1.2", "@tombi-toml/cli-linux-x64": "1.1.2", "@tombi-toml/cli-linux-x64-musl": "1.1.2", "@tombi-toml/cli-win32-arm64": "1.1.2", "@tombi-toml/cli-win32-x64": "1.1.2" }, "bin": { "tombi": "bin/tombi" } }, "sha512-2f9wXy6vbyuJ++ForbHkgHMvOeli8UgrD0Da/gTBKbiKruDB4prgAVuAjwqvWdinXzn/3QVk2CJjmDq03lZCkA=="],
 
+    "totalist": ["totalist@3.0.1", "", {}, "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ=="],
+
     "tough-cookie": ["tough-cookie@5.1.2", "", { "dependencies": { "tldts": "^6.1.32" } }, "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A=="],
 
     "tr46": ["tr46@5.1.1", "", { "dependencies": { "punycode": "^2.3.1" } }, "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw=="],
+
+    "ts-api-utils": ["ts-api-utils@2.5.0", "", { "peerDependencies": { "typescript": ">=4.8.4" } }, "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA=="],
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "tsscmp": ["tsscmp@1.0.6", "", {}, "sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA=="],
 
     "tunnel": ["tunnel@0.0.6", "", {}, "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg=="],
+
+    "type-check": ["type-check@0.4.0", "", { "dependencies": { "prelude-ls": "^1.2.1" } }, "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew=="],
 
     "type-fest": ["type-fest@0.21.3", "", {}, "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w=="],
 
@@ -528,6 +933,8 @@
 
     "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
 
+    "typescript-eslint": ["typescript-eslint@8.61.1", "", { "dependencies": { "@typescript-eslint/eslint-plugin": "8.61.1", "@typescript-eslint/parser": "8.61.1", "@typescript-eslint/typescript-estree": "8.61.1", "@typescript-eslint/utils": "8.61.1" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-V7PayAfJokV3pEHgN7/v03D1SpujhRfQtYLbLIiBfDDncdg4PAiRBfoS4cnCANK4jmAPncczi59QO3afiXUlNw=="],
+
     "undici": ["undici@6.26.0", "", {}, "sha512-4yqz8a3n5HmGTlsbADNtr/dJlhkh/55Rq798G6ibiULcXbDtaLpTl1pvdqcbFfeoj3iSi52lePFM7h9H21cw/A=="],
 
     "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
@@ -536,9 +943,19 @@
 
     "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
 
+    "uri-js": ["uri-js@4.4.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="],
+
     "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
 
     "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
+
+    "vite": ["vite@8.0.16", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.15", "rolldown": "1.0.3", "tinyglobby": "^0.2.17" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.18", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw=="],
+
+    "vitefu": ["vitefu@1.1.3", "", { "peerDependencies": { "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["vite"] }, "sha512-ub4okH7Z5KLjb6hDyjqrGXqWtWvoYdU3IGm/NorpgHncKoLTCfRIbvlhBm7r0YstIaQRYlp4yEbFqDcKSzXSSg=="],
+
+    "vitest": ["vitest@4.1.9", "", { "dependencies": { "@vitest/expect": "4.1.9", "@vitest/mocker": "4.1.9", "@vitest/pretty-format": "4.1.9", "@vitest/runner": "4.1.9", "@vitest/snapshot": "4.1.9", "@vitest/spy": "4.1.9", "@vitest/utils": "4.1.9", "es-module-lexer": "^2.0.0", "expect-type": "^1.3.0", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^4.0.0-rc.1", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.1.0", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.1.9", "@vitest/browser-preview": "4.1.9", "@vitest/browser-webdriverio": "4.1.9", "@vitest/coverage-istanbul": "4.1.9", "@vitest/coverage-v8": "4.1.9", "@vitest/ui": "4.1.9", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "./vitest.mjs" } }, "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ=="],
+
+    "vitest-browser-svelte": ["vitest-browser-svelte@2.1.1", "", { "dependencies": { "@testing-library/svelte-core": "^1.0.0" }, "peerDependencies": { "svelte": "^3 || ^4 || ^5 || ^5.0.0-next.0", "vitest": "^4.0.0" } }, "sha512-qbunYRSm+N92r9bfTkdDTpBZESLmp4QFz2SluV3n/x8U7ysosfeXYJZ4vXbJ0Y0LzoqqDnV5LHprmFgn4Eo+Ug=="],
 
     "w3c-xmlserializer": ["w3c-xmlserializer@5.0.0", "", { "dependencies": { "xml-name-validator": "^5.0.0" } }, "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA=="],
 
@@ -552,6 +969,12 @@
 
     "whatwg-url": ["whatwg-url@14.2.0", "", { "dependencies": { "tr46": "^5.1.0", "webidl-conversions": "^7.0.0" } }, "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw=="],
 
+    "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
+    "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
+
+    "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
+
     "wrap-ansi": ["wrap-ansi@6.2.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA=="],
 
     "ws": ["ws@8.21.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
@@ -560,13 +983,25 @@
 
     "xmlchars": ["xmlchars@2.2.0", "", {}, "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="],
 
+    "yaml": ["yaml@1.10.3", "", {}, "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA=="],
+
+    "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
+
+    "zimmerframe": ["zimmerframe@1.1.4", "", {}, "sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ=="],
+
     "zxcvbn": ["zxcvbn@4.4.2", "", {}, "sha512-Bq0B+ixT/DMyG8kgX2xWcI5jUvCwqrMxSFam7m0lAf78nf04hv6lNCsyLYdyYTrCVMqNDY/206K7eExYCeSyUQ=="],
 
     "@actions/github/@actions/http-client": ["@actions/http-client@3.0.2", "", { "dependencies": { "tunnel": "^0.0.6", "undici": "^6.23.0" } }, "sha512-JP38FYYpyqvUsz+Igqlc/JG6YO9PaKuvqjM3iGvaLqFnJ7TFmcLyy2IDrY0bI0qCQug8E9K+elv5ZNfw62ZJzA=="],
 
+    "@actions/glob/minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
+
     "@actions/http-client/undici": ["undici@5.29.0", "", { "dependencies": { "@fastify/busboy": "^2.0.0" } }, "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg=="],
 
+    "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
+
     "@octokit/request/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
+
+    "@typescript-eslint/eslint-plugin/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
 
     "bl/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
 
@@ -575,6 +1010,10 @@
     "co-body/type-is": ["type-is@1.6.18", "", { "dependencies": { "media-typer": "0.3.0", "mime-types": "~2.1.24" } }, "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g=="],
 
     "concat-stream/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
+
+    "eslint-plugin-svelte/globals": ["globals@16.5.0", "", {}, "sha512-c/c15i26VrJ4IRt5Z89DnIzCGDn9EcebibhAOjw5ibqEHsE1wLUgkPn9RDmNcUKyU87GeaL633nyJ+pplFR2ZQ=="],
+
+    "figures/escape-string-regexp": ["escape-string-regexp@1.0.5", "", {}, "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="],
 
     "http-assert/http-errors": ["http-errors@1.8.1", "", { "dependencies": { "depd": "~1.1.2", "inherits": "2.0.4", "setprototypeof": "1.2.0", "statuses": ">= 1.5.0 < 2", "toidentifier": "1.0.1" } }, "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g=="],
 
@@ -586,13 +1025,23 @@
 
     "node-fetch/whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
 
+    "svelte-eslint-parser/eslint-scope": ["eslint-scope@8.4.0", "", { "dependencies": { "esrecurse": "^4.3.0", "estraverse": "^5.2.0" } }, "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg=="],
+
+    "svelte-eslint-parser/eslint-visitor-keys": ["eslint-visitor-keys@4.2.1", "", {}, "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ=="],
+
+    "svelte-eslint-parser/espree": ["espree@10.4.0", "", { "dependencies": { "acorn": "^8.15.0", "acorn-jsx": "^5.3.2", "eslint-visitor-keys": "^4.2.1" } }, "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ=="],
+
     "tough-cookie/tldts": ["tldts@6.1.86", "", { "dependencies": { "tldts-core": "^6.1.86" }, "bin": { "tldts": "bin/cli.js" } }, "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ=="],
 
     "type-is/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
 
     "type-is/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
 
+    "vite/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
     "whatwg-encoding/iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
+
+    "@actions/glob/minimatch/brace-expansion": ["brace-expansion@1.1.15", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg=="],
 
     "bun-types/@types/node/undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
 
@@ -615,5 +1064,7 @@
     "tough-cookie/tldts/tldts-core": ["tldts-core@6.1.86", "", {}, "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA=="],
 
     "type-is/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
+
+    "@actions/glob/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
   }
 }

--- a/bun.lock
+++ b/bun.lock
@@ -7,10 +7,10 @@
         "@actions/github-script": "github:actions/github-script",
         "@bitwarden/cli": "^2026.5.0",
         "@types/bun": "^1.3.14",
-        "@typescript/native-preview": "^7.0.0-dev.20260607.1",
+        "@typescript/native-preview": "^7.0.0-dev",
         "dprint": "^0.54.0",
-        "runner-run": "^0.12.1",
-        "tombi": "^1.1.2",
+        "runner-run": "catalog:",
+        "tombi": "^1.1.4",
         "typescript": "^6.0.3",
       },
     },
@@ -28,6 +28,7 @@
         "eslint-plugin-svelte": "^3.19.0",
         "globals": "^17.6.0",
         "playwright": "^1.60.0",
+        "runner-run": "catalog:",
         "svelte": "^5.56.1",
         "svelte-check": "^4.6.0",
         "typescript": "^6.0.3",
@@ -37,6 +38,9 @@
         "vitest-browser-svelte": "^2.1.1",
       },
     },
+  },
+  "catalog": {
+    "runner-run": "^0.13.1",
   },
   "packages": {
     "@actions/core": ["@actions/core@1.11.1", "", { "dependencies": { "@actions/exec": "^1.1.1", "@actions/http-client": "^2.0.1" } }, "sha512-hXJCSrkwfA46Vd9Z3q4cpEpHB1rL5NG04+/rbqW9d3+CSvtB1tYe8UTpAlixa1vj0m/ULglfEK2UKxMGxCxv5A=="],
@@ -203,31 +207,31 @@
 
     "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.1", "", {}, "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw=="],
 
-    "@runner-run/darwin-arm64": ["@runner-run/darwin-arm64@0.12.1", "", { "os": "darwin", "cpu": "arm64", "bin": { "runner": "bin/runner", "run": "bin/run" } }, "sha512-hZUwn1M42ZQTzCaoi9m0qGOP/ejrrd+yIe1CkR6y2VTIU9OMOG1O5hIluLpPyjS8FWg9nVhFlYgaV+YZacBz+w=="],
+    "@runner-run/darwin-arm64": ["@runner-run/darwin-arm64@0.13.1", "", { "os": "darwin", "cpu": "arm64", "bin": { "runner": "bin/runner", "run": "bin/run" } }, "sha512-TS9j74y/qVqyg7esJD948JKbBAtwO8EnbeKIfZYr4M2mRZWVUblPm04HwDKAgBax9J9KfMZEICBZ5FLAsx6SIA=="],
 
-    "@runner-run/darwin-x64": ["@runner-run/darwin-x64@0.12.1", "", { "os": "darwin", "cpu": "x64", "bin": { "runner": "bin/runner", "run": "bin/run" } }, "sha512-u0LtJvZpmn3WN6cAxCWwQNTT2HRYseR1WePVTsvKfWaiaPyddgXuoLIU9SWnR3fEybzY9eQvxxKM5psDPxOrLA=="],
+    "@runner-run/darwin-x64": ["@runner-run/darwin-x64@0.13.1", "", { "os": "darwin", "cpu": "x64", "bin": { "runner": "bin/runner", "run": "bin/run" } }, "sha512-ov0wCAKlqMmEMdbg1AstonAwxEns0URPuE77T0vWjdG/WMeQ0bsRmStg2vuMDuo065tGPmGtruGE8xN8C7qVew=="],
 
-    "@runner-run/freebsd-arm64": ["@runner-run/freebsd-arm64@0.12.1", "", { "os": "freebsd", "cpu": "arm64", "bin": { "runner": "bin/runner", "run": "bin/run" } }, "sha512-E3YQ7F0CCmfWy+zCNsBCBWA/Z0Dko1OU1UMnkLtLxP2vfKUGAQpzqf89XNFNxtcNmeLBEGtUvdc6CENYwmYybw=="],
+    "@runner-run/freebsd-arm64": ["@runner-run/freebsd-arm64@0.13.1", "", { "os": "freebsd", "cpu": "arm64", "bin": { "runner": "bin/runner", "run": "bin/run" } }, "sha512-AKN27BaJa0aWwPbDjPQUIx333jsRBl1deiy8Kvnfc9hLXbTZshtTJ5rufzSPRytsK2RwscM18oEwYjfBBRTNSg=="],
 
-    "@runner-run/freebsd-x64": ["@runner-run/freebsd-x64@0.12.1", "", { "os": "freebsd", "cpu": "x64", "bin": { "runner": "bin/runner", "run": "bin/run" } }, "sha512-EPT793vd5C3pc/1CwnDl62/c9iu5mhN4UbDVn7MEQxNAilRTxpqdyadPkdl+L+zvrTACpIoVpPqJ6pq+BXNSOQ=="],
+    "@runner-run/freebsd-x64": ["@runner-run/freebsd-x64@0.13.1", "", { "os": "freebsd", "cpu": "x64", "bin": { "runner": "bin/runner", "run": "bin/run" } }, "sha512-qbjzBah6Qv6ZMxRMd16w+Pkt/uREN5T6pz0r0BN0xnLDgRHCLMTm44pi1odnSRn4RIrv1i9QC3FJtcDbT3ty0Q=="],
 
-    "@runner-run/linux-arm64-gnu": ["@runner-run/linux-arm64-gnu@0.12.1", "", { "os": "linux", "cpu": "arm64", "bin": { "runner": "bin/runner", "run": "bin/run" } }, "sha512-60kcJq8hIsW886/mq3b8teJPJ2xBIFn+3YRMORZScvzPe3hmQOwGMtJADNVkYenYDRJcFqa0IwM+Tr1C5iCH6A=="],
+    "@runner-run/linux-arm64-gnu": ["@runner-run/linux-arm64-gnu@0.13.1", "", { "os": "linux", "cpu": "arm64", "bin": { "runner": "bin/runner", "run": "bin/run" } }, "sha512-/FC77Br0XRwdA6DIIaCGvYAVlW2DE+2I5jXnQXJ3QOnwm7T4x34BZ5DqIhd2Iwsx6qeG2Xv5LXoIGRZJwYOsOw=="],
 
-    "@runner-run/linux-arm64-musl": ["@runner-run/linux-arm64-musl@0.12.1", "", { "os": "linux", "cpu": "arm64", "bin": { "runner": "bin/runner", "run": "bin/run" } }, "sha512-TkSIovz32Tgn5SPT30ttawR+8xBIcwTKp/mHlW1yRR/wNIc95mYOw1/4fEZdxl5YejjSAKrdMHRg4UvOTfatGg=="],
+    "@runner-run/linux-arm64-musl": ["@runner-run/linux-arm64-musl@0.13.1", "", { "os": "linux", "cpu": "arm64", "bin": { "runner": "bin/runner", "run": "bin/run" } }, "sha512-1t7ZlFqw6WZFqV/QAblYUb1vCnGRPba9+ZvOasjMeVX8vS8D0YMhe+mUvwtqBiq9wZI9ZB0ACALgp2G5Bznjyg=="],
 
-    "@runner-run/linux-armv7-gnueabihf": ["@runner-run/linux-armv7-gnueabihf@0.12.1", "", { "os": "linux", "cpu": "arm", "bin": { "runner": "bin/runner", "run": "bin/run" } }, "sha512-WdMdO9SgBv+t0TAf/Em5ffIuVK5Y7pEf2Ct5tp2ZcbqFXcqJQt0zHJV0vtLtC3SA0SRe3W51RybK3SDtJVgQZQ=="],
+    "@runner-run/linux-armv7-gnueabihf": ["@runner-run/linux-armv7-gnueabihf@0.13.1", "", { "os": "linux", "cpu": "arm", "bin": { "runner": "bin/runner", "run": "bin/run" } }, "sha512-FaPAGSSBLidn56MDGL7LVcmJ77pFFvKTa49cvY5/toGxe+ZdjHW9Uoms8dqpxGiv/STqQZyukgQIYNL96dps8Q=="],
 
-    "@runner-run/linux-x64-gnu": ["@runner-run/linux-x64-gnu@0.12.1", "", { "os": "linux", "cpu": "x64", "bin": { "runner": "bin/runner", "run": "bin/run" } }, "sha512-xm0BciC2iy2Q9yYgV4qYCR8PZl9hBJHv1ZDAV2akp/BVbULJpdwoGp1ppoUrPdODWzTWRjuaqx3u8GRQCWhagw=="],
+    "@runner-run/linux-x64-gnu": ["@runner-run/linux-x64-gnu@0.13.1", "", { "os": "linux", "cpu": "x64", "bin": { "runner": "bin/runner", "run": "bin/run" } }, "sha512-FcfWKpN0R8m7ZznHeAkd8d7L2ev4/bBQZi30d2NdyTZ4SzhVC6fO45zerJmMmLI7Ti3kRx3noWro+8ErbiTUXg=="],
 
-    "@runner-run/linux-x64-musl": ["@runner-run/linux-x64-musl@0.12.1", "", { "os": "linux", "cpu": "x64", "bin": { "runner": "bin/runner", "run": "bin/run" } }, "sha512-zx2fcYp7bSSfkDxCF9t8TLdH4mwquE96grzM+KwoUXVv900KYMl9BNr8n9LjJuBYp1saHFYD3KncJ9zFNUUyDg=="],
+    "@runner-run/linux-x64-musl": ["@runner-run/linux-x64-musl@0.13.1", "", { "os": "linux", "cpu": "x64", "bin": { "runner": "bin/runner", "run": "bin/run" } }, "sha512-SKhxAkK78pzTdOLAtO1a67DqybuKU7wFqWiSjFyzgNvJbdWhzuiGPI3/ZhoEcjnWKlNkGVgMUdmwjtvW32dTKQ=="],
 
-    "@runner-run/netbsd-x64": ["@runner-run/netbsd-x64@0.12.1", "", { "os": "none", "cpu": "x64", "bin": { "runner": "bin/runner", "run": "bin/run" } }, "sha512-fM98K1ft5Zc7Gt+9I4gL4OWF7AaCbcdLbVsOWLiExvGCPrCpmryqjrBZUq1PnHs0I7N1S42g4BR5tW4agKavMg=="],
+    "@runner-run/netbsd-x64": ["@runner-run/netbsd-x64@0.13.1", "", { "os": "none", "cpu": "x64", "bin": { "runner": "bin/runner", "run": "bin/run" } }, "sha512-G34CIuvI8bwIM1PRGJcmsIpvvvscPtebnyvehWvMM7sc0tbu4Y9H33UKxOE/DamNRlsLbx7CFS+JfItT3W3uFQ=="],
 
-    "@runner-run/win32-arm64-msvc": ["@runner-run/win32-arm64-msvc@0.12.1", "", { "os": "win32", "cpu": "arm64", "bin": { "runner.exe": "bin/runner.exe", "run.exe": "bin/run.exe" } }, "sha512-vnBHdjT5XruQnSNOn104Dvvf0/boFZAu0DcAgooNY6NPjh3wMp0Cz/GBGvRR9sitCDXaw1g+rbqJ8vTSDsoRiA=="],
+    "@runner-run/win32-arm64-msvc": ["@runner-run/win32-arm64-msvc@0.13.1", "", { "os": "win32", "cpu": "arm64", "bin": { "runner.exe": "bin/runner.exe", "run.exe": "bin/run.exe" } }, "sha512-gpAguwdjDZ/35IoCFyUbBsPF1MXEH4yL7bE8DjvcclFxjXJ/VmSuI3AgGLWv68KJEQHjFvpz59wXfHxAoaykuQ=="],
 
-    "@runner-run/win32-ia32-msvc": ["@runner-run/win32-ia32-msvc@0.12.1", "", { "os": "win32", "cpu": "ia32", "bin": { "runner.exe": "bin/runner.exe", "run.exe": "bin/run.exe" } }, "sha512-rVaUMab8FkXAKejKV6ak+Soepm3hd+LUfmrDBtivptY1iXyoogVoPvJzBwOnu6zCx6/ptdUqnyzEkpAeS9AivQ=="],
+    "@runner-run/win32-ia32-msvc": ["@runner-run/win32-ia32-msvc@0.13.1", "", { "os": "win32", "cpu": "ia32", "bin": { "runner.exe": "bin/runner.exe", "run.exe": "bin/run.exe" } }, "sha512-biS6FMYtDeD/bntBzNC0Db+WeoI7++xCY/vBjsaWlEDbc6TcQCVUZVyeWcXEgl5ObcD6gc20Qw0tAJDc0X1CnA=="],
 
-    "@runner-run/win32-x64-msvc": ["@runner-run/win32-x64-msvc@0.12.1", "", { "os": "win32", "cpu": "x64", "bin": { "runner.exe": "bin/runner.exe", "run.exe": "bin/run.exe" } }, "sha512-4nqg6W4CTLyA1Huf7g1WNRxiLOus8F67uLcu28C5HTWmBuS1n8LkgoNbzWJnidHQSTIrAlmOuU4uGuH5sWumdQ=="],
+    "@runner-run/win32-x64-msvc": ["@runner-run/win32-x64-msvc@0.13.1", "", { "os": "win32", "cpu": "x64", "bin": { "runner.exe": "bin/runner.exe", "run.exe": "bin/run.exe" } }, "sha512-HJxbv/JGj4aNlpewq48miep6wk6uuVKEAVVEL0gUta8iD/H/hI2ASefHwywpXkyBW6v+7QHaeOP7z0iOYNfQSw=="],
 
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
@@ -243,21 +247,21 @@
 
     "@testing-library/svelte-core": ["@testing-library/svelte-core@1.0.0", "", { "peerDependencies": { "svelte": "^3 || ^4 || ^5 || ^5.0.0-next.0" } }, "sha512-VkUePoLV6oOYwSUvX6ShA8KLnJqZiYMIbP2JW2t0GLWLkJxKGvuH5qrrZBV/X7cXFnLGuFQEC7RheYiZOW68KQ=="],
 
-    "@tombi-toml/cli-darwin-arm64": ["@tombi-toml/cli-darwin-arm64@1.1.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-aaN9jQUxVvmoRelp4+6ECLMgGh74jaUS5ODfuR0lPT9ES9qEN7LzI4IhSN3Y+mqPV6Dog+5GJnq24zBbCImDCg=="],
+    "@tombi-toml/cli-darwin-arm64": ["@tombi-toml/cli-darwin-arm64@1.1.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-0Ub0tIX/XvDdJuZyAsXJn2MvE/hkkQDqL+CrjvxHyX0mqaRqgzyMZbeQyHaBcF9FRGlMRyE51Uybbm42+R2tNA=="],
 
-    "@tombi-toml/cli-darwin-x64": ["@tombi-toml/cli-darwin-x64@1.1.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-W8O8hR+ZhyFX25mYR8jbehaDgqt0BJ7+B2TOQ8aV9+wPa1QwPHEsFd+Qdvz/4uY1GgJO77xBBinRyuHUtey3Xw=="],
+    "@tombi-toml/cli-darwin-x64": ["@tombi-toml/cli-darwin-x64@1.1.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-yzlC9DyuMlBU0wgLlY7SmDYFubZKA5EF/bBQ26YPMKqGohDpNE2U2jc8aK8tAbUhcpJsqIIF9r35eDep1iKkHw=="],
 
-    "@tombi-toml/cli-linux-arm64": ["@tombi-toml/cli-linux-arm64@1.1.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-wM0hLGPYs1f3XY7CUfuAGvd+DH/q1FmZXIhpQu3sFYiJ6xHvc9OdDfje4MQ+bnOMGYKNT9vyjpphRnseWoi6lg=="],
+    "@tombi-toml/cli-linux-arm64": ["@tombi-toml/cli-linux-arm64@1.1.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-XUl7FH/BGoaKr5CaFCImEGr/HMuJgukHQiP8jmtrnrstlioAh6Kk6aeHF315bFQobga5RorSK4QbTF/Txy3mQg=="],
 
-    "@tombi-toml/cli-linux-arm64-musl": ["@tombi-toml/cli-linux-arm64-musl@1.1.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-FZvzTl9WcTk1XuJpTvaGRl9GKqDNTPfpajiSBeX6OoQVr0n/KeyeGu9KQfiZbW6umMUfDq5Lx40rGkamDlvBVQ=="],
+    "@tombi-toml/cli-linux-arm64-musl": ["@tombi-toml/cli-linux-arm64-musl@1.1.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-YLE1fkGdaJ71CII4q+RHSuuXJaT0uWQqcUMRYKfquRyfamqL48S5l0De9fDlIn775tg8YVXql5H9gp1EGXGgjA=="],
 
-    "@tombi-toml/cli-linux-x64": ["@tombi-toml/cli-linux-x64@1.1.2", "", { "os": "linux", "cpu": "x64" }, "sha512-UgkDUXdcj92/Rs2zSYe0mSbpT9pKTbi5LHzYhwrikA+7W4FRR7TJRJqtAj4feEU3Yo5R3NdnwTk9yGRv4hX6Ew=="],
+    "@tombi-toml/cli-linux-x64": ["@tombi-toml/cli-linux-x64@1.1.4", "", { "os": "linux", "cpu": "x64" }, "sha512-2te2faLLvqJOVXZj8yvjUjmeyFHFeNQfXAL82eqlaYGAHA8IespVjFRHaRNQqNPdEI54o7Qg4dADYuqNyhOQEw=="],
 
-    "@tombi-toml/cli-linux-x64-musl": ["@tombi-toml/cli-linux-x64-musl@1.1.2", "", { "os": "linux", "cpu": "x64" }, "sha512-jKCzUx8zpgTZX5yjQzvv5gA40EKYTJixNy3rnicZSgvQzYB1mxIuKRpjEFe+vjjguEuM9VFKK5VIRiJWFAvVGw=="],
+    "@tombi-toml/cli-linux-x64-musl": ["@tombi-toml/cli-linux-x64-musl@1.1.4", "", { "os": "linux", "cpu": "x64" }, "sha512-RXDcBiy24faBhOwsuFoXb9aujcsmA0lFBlQgNQqurV/PXDfgfLAdYz3hgEv79dvmP5LZY+gJ+iY+/9+Lsw60Uw=="],
 
-    "@tombi-toml/cli-win32-arm64": ["@tombi-toml/cli-win32-arm64@1.1.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-WftKCDXoRM8iuaNQTkwDytNPVPPvES0MZOTRn24eKGGy6QwIENAAl9GBuCayzHHH5Umq+e3MCStA0g0uWo5Rfg=="],
+    "@tombi-toml/cli-win32-arm64": ["@tombi-toml/cli-win32-arm64@1.1.4", "", { "os": "win32", "cpu": "arm64" }, "sha512-eVI1HC0Q4TUXrWS8SqYk0tRDCVqFbatUJ989cItUNn/drL1H53Js7MITuChKYgtdJ52nmJ8EsDOFPyA2HAI1Xg=="],
 
-    "@tombi-toml/cli-win32-x64": ["@tombi-toml/cli-win32-x64@1.1.2", "", { "os": "win32", "cpu": "x64" }, "sha512-j04JhyGcjI4ncMxv6yqp/735eNqWCFzm/BJo5+0E/QVza0EGqdtAvMyGGtbci9GBtxkEp8k+slNMAwYhH/ZPXA=="],
+    "@tombi-toml/cli-win32-x64": ["@tombi-toml/cli-win32-x64@1.1.4", "", { "os": "win32", "cpu": "x64" }, "sha512-buT+AHrjWBrlzOFlnFYXx+nDJ02H/CwwC+a3Zgip7qTgFDjjuoc+TekhLSiUNL/1oLzbnnOQnUEyNNbyBVEqVQ=="],
 
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg=="],
 
@@ -299,21 +303,21 @@
 
     "@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.61.1", "", { "dependencies": { "@typescript-eslint/types": "8.61.1", "eslint-visitor-keys": "^5.0.0" } }, "sha512-6fJ9MHWtK14C1DSkiMlHUSOmrVebL7150xZJBlJiL62jjhIA4JmOq6flwBgDxIdBKKdoiZRel+dfPD5MLfny3w=="],
 
-    "@typescript/native-preview": ["@typescript/native-preview@7.0.0-dev.20260607.1", "", { "optionalDependencies": { "@typescript/native-preview-darwin-arm64": "7.0.0-dev.20260607.1", "@typescript/native-preview-darwin-x64": "7.0.0-dev.20260607.1", "@typescript/native-preview-linux-arm": "7.0.0-dev.20260607.1", "@typescript/native-preview-linux-arm64": "7.0.0-dev.20260607.1", "@typescript/native-preview-linux-x64": "7.0.0-dev.20260607.1", "@typescript/native-preview-win32-arm64": "7.0.0-dev.20260607.1", "@typescript/native-preview-win32-x64": "7.0.0-dev.20260607.1" }, "bin": { "tsgo": "bin/tsgo.js" } }, "sha512-+DBR9iyRZiUNhJI2CqFluJLxKl3xkBGFFCADiy63pCpLVCCNuffunRhcxQ2vhnLnM3dBDoqOHE4ekKg0GfaS/Q=="],
+    "@typescript/native-preview": ["@typescript/native-preview@7.0.0-dev.20260621.1", "", { "optionalDependencies": { "@typescript/native-preview-darwin-arm64": "7.0.0-dev.20260621.1", "@typescript/native-preview-darwin-x64": "7.0.0-dev.20260621.1", "@typescript/native-preview-linux-arm": "7.0.0-dev.20260621.1", "@typescript/native-preview-linux-arm64": "7.0.0-dev.20260621.1", "@typescript/native-preview-linux-x64": "7.0.0-dev.20260621.1", "@typescript/native-preview-win32-arm64": "7.0.0-dev.20260621.1", "@typescript/native-preview-win32-x64": "7.0.0-dev.20260621.1" }, "bin": { "tsgo": "bin/tsgo.js" } }, "sha512-2epYxi5NDRPOvAG8TPEFd43qDVGHhD4IbIHF0uhsy72OSUbVY2rjEAv1DkW1Q2p/YbszXd7ZL/Ulch8VuDDS1g=="],
 
-    "@typescript/native-preview-darwin-arm64": ["@typescript/native-preview-darwin-arm64@7.0.0-dev.20260607.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-7t6tPrvxiHTCL8Ye8H/XZDceUB/UTXerghIEBiVjoEvPK6AYxxqOB0vEhKGRhlCkUd3kQAcKQuda/SK63hBkTQ=="],
+    "@typescript/native-preview-darwin-arm64": ["@typescript/native-preview-darwin-arm64@7.0.0-dev.20260621.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-E81mNlY2JqZlDqflCvRpt6WhU6ha1SOkRC85o+EmKZJCjBxaaJpBGdwGjIisv2jiEMcHy2OW4ZHcE9GTM1BL2A=="],
 
-    "@typescript/native-preview-darwin-x64": ["@typescript/native-preview-darwin-x64@7.0.0-dev.20260607.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-pCzBIEDQTDaXdGdv6tQkPdnvnyLdIhSApeTjP86rvm3bfNpMbSi0DkDSQoJvEeZWYDw0ewe7TTDhbgtTSmqegQ=="],
+    "@typescript/native-preview-darwin-x64": ["@typescript/native-preview-darwin-x64@7.0.0-dev.20260621.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-VS4VF8L0So56tC1jaJ57pMQOGd0Hc1wU0RIMkJi41/dKvcmc/WTRa7hiWJwzZLxXhZoVkdjesT36D9GahoAulg=="],
 
-    "@typescript/native-preview-linux-arm": ["@typescript/native-preview-linux-arm@7.0.0-dev.20260607.1", "", { "os": "linux", "cpu": "arm" }, "sha512-8cFWEOlCcVh8pPiqkXkjgNqPJgOk3VLtYKijMh9KAPaDFu3EBfV9pp68uteTajljPmZdX5zYkfcMzQly2RjMzg=="],
+    "@typescript/native-preview-linux-arm": ["@typescript/native-preview-linux-arm@7.0.0-dev.20260621.1", "", { "os": "linux", "cpu": "arm" }, "sha512-2Xp+pu7Xu9EMKxYFiZuyIzd6KUkMn7SvElzgBRwbrhfsk54Jieg2sxyL3aAw9xfzRsEN4m1VrU3Z/iq2gL5OUw=="],
 
-    "@typescript/native-preview-linux-arm64": ["@typescript/native-preview-linux-arm64@7.0.0-dev.20260607.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-OAJi5GpueqRVGrtDn/N8uNRriD1OX1jvJf3GyYNMKdWw4ZAArYKAmLU0ZY4rEDj4oIV2RAHf1IGVQesCBcWqIw=="],
+    "@typescript/native-preview-linux-arm64": ["@typescript/native-preview-linux-arm64@7.0.0-dev.20260621.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-Ek1uLWN6VzqwwTQNu1vcnRW4F3ipqvediLEwJP6uR5P6vrXYE7XvcGLEJcXiw31SR40NhxZW/RhLcJrHQcehrA=="],
 
-    "@typescript/native-preview-linux-x64": ["@typescript/native-preview-linux-x64@7.0.0-dev.20260607.1", "", { "os": "linux", "cpu": "x64" }, "sha512-TGdfapfCFj4hl9M1/5oG6wjjhfoFviiMLru3a7ib63ozQwMDraJNqPrJuQ0tvVAoSMJb1wtVbvg7yYMml/KPLg=="],
+    "@typescript/native-preview-linux-x64": ["@typescript/native-preview-linux-x64@7.0.0-dev.20260621.1", "", { "os": "linux", "cpu": "x64" }, "sha512-VUhea6+Drw+PHRpsjsY7lNOZtXAlRXLHrpYynJU3jfnSflYgoqkrvlSzWVhcvhkjxGOZsqlIV+5ryy8ANZ6peg=="],
 
-    "@typescript/native-preview-win32-arm64": ["@typescript/native-preview-win32-arm64@7.0.0-dev.20260607.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-tOEn/EC0nRnz7JHfDWwXmmBkU4dt8wdU/jYyJTOlkEhxfJtAJTjVmo4AUHwzLyV9KGIzvfymTKrQPTnD0p9ACA=="],
+    "@typescript/native-preview-win32-arm64": ["@typescript/native-preview-win32-arm64@7.0.0-dev.20260621.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-JyxxNWWs2X7WzK90zN8hgGKqP4zo2/y7Z2tlLLaHhSFtEh1AC+tsQun3NBlW9JvF1vHhGI/hPpnoZOxLO0CEWw=="],
 
-    "@typescript/native-preview-win32-x64": ["@typescript/native-preview-win32-x64@7.0.0-dev.20260607.1", "", { "os": "win32", "cpu": "x64" }, "sha512-SBWFFs+MglgDrx8lh37uFHVQcljN09Z/D8Z+YwykMVKtYEIGM/i5WzS8Xpiegm9Vcqu3HTkuAfjQfy6X5MsqnA=="],
+    "@typescript/native-preview-win32-x64": ["@typescript/native-preview-win32-x64@7.0.0-dev.20260621.1", "", { "os": "win32", "cpu": "x64" }, "sha512-2ijIynqyxK1LkWUpLlmsBKuH7XHk6K4TAwdnfZ7x7BQHF9Z3okIXtKMzOik8fajB3oooVrEvbfOe2Mf+uZ7maQ=="],
 
     "@vitest/browser": ["@vitest/browser@4.1.9", "", { "dependencies": { "@blazediff/core": "1.9.1", "@vitest/mocker": "4.1.9", "@vitest/utils": "4.1.9", "magic-string": "^0.30.21", "pngjs": "^7.0.0", "sirv": "^3.0.2", "tinyrainbow": "^3.1.0", "ws": "^8.19.0" }, "peerDependencies": { "vitest": "4.1.9" } }, "sha512-j1BKtWmPcqpMhmx/L9EPLgAJpCb0zKfwoWLmqBbxaogCXHjOwHFSEoHCBfnGtx93xKQwilZ26m+UOsHqHMkRNg=="],
 
@@ -821,7 +825,7 @@
 
     "run-async": ["run-async@2.4.1", "", {}, "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ=="],
 
-    "runner-run": ["runner-run@0.12.1", "", { "optionalDependencies": { "@runner-run/darwin-arm64": "0.12.1", "@runner-run/darwin-x64": "0.12.1", "@runner-run/freebsd-arm64": "0.12.1", "@runner-run/freebsd-x64": "0.12.1", "@runner-run/linux-arm64-gnu": "0.12.1", "@runner-run/linux-arm64-musl": "0.12.1", "@runner-run/linux-armv7-gnueabihf": "0.12.1", "@runner-run/linux-x64-gnu": "0.12.1", "@runner-run/linux-x64-musl": "0.12.1", "@runner-run/netbsd-x64": "0.12.1", "@runner-run/win32-arm64-msvc": "0.12.1", "@runner-run/win32-ia32-msvc": "0.12.1", "@runner-run/win32-x64-msvc": "0.12.1" }, "bin": { "run": "bin/run.cjs", "runner": "bin/runner.cjs" } }, "sha512-HmzVfgpVdLaebFXX7Gm3p34FvTkp/ArXp/JFj4xqH+yjE0ysZJCCEczzbwyG3SlIrAknW/OfmVpATgIc+NG2fA=="],
+    "runner-run": ["runner-run@0.13.1", "", { "optionalDependencies": { "@runner-run/darwin-arm64": "0.13.1", "@runner-run/darwin-x64": "0.13.1", "@runner-run/freebsd-arm64": "0.13.1", "@runner-run/freebsd-x64": "0.13.1", "@runner-run/linux-arm64-gnu": "0.13.1", "@runner-run/linux-arm64-musl": "0.13.1", "@runner-run/linux-armv7-gnueabihf": "0.13.1", "@runner-run/linux-x64-gnu": "0.13.1", "@runner-run/linux-x64-musl": "0.13.1", "@runner-run/netbsd-x64": "0.13.1", "@runner-run/win32-arm64-msvc": "0.13.1", "@runner-run/win32-ia32-msvc": "0.13.1", "@runner-run/win32-x64-msvc": "0.13.1" }, "bin": { "run": "bin/run.cjs", "runner": "bin/runner.cjs" } }, "sha512-6AogOpj2I5ieCMiMTjBtaDLqALdAh0MoV2aPikznaJJMpcL23xfuN544n+TeIFnC2VO0JEAtkrHupip4PAiZVg=="],
 
     "rxjs": ["rxjs@7.8.1", "", { "dependencies": { "tslib": "^2.1.0" } }, "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg=="],
 
@@ -907,7 +911,7 @@
 
     "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
 
-    "tombi": ["tombi@1.1.2", "", { "optionalDependencies": { "@tombi-toml/cli-darwin-arm64": "1.1.2", "@tombi-toml/cli-darwin-x64": "1.1.2", "@tombi-toml/cli-linux-arm64": "1.1.2", "@tombi-toml/cli-linux-arm64-musl": "1.1.2", "@tombi-toml/cli-linux-x64": "1.1.2", "@tombi-toml/cli-linux-x64-musl": "1.1.2", "@tombi-toml/cli-win32-arm64": "1.1.2", "@tombi-toml/cli-win32-x64": "1.1.2" }, "bin": { "tombi": "bin/tombi" } }, "sha512-2f9wXy6vbyuJ++ForbHkgHMvOeli8UgrD0Da/gTBKbiKruDB4prgAVuAjwqvWdinXzn/3QVk2CJjmDq03lZCkA=="],
+    "tombi": ["tombi@1.1.4", "", { "optionalDependencies": { "@tombi-toml/cli-darwin-arm64": "1.1.4", "@tombi-toml/cli-darwin-x64": "1.1.4", "@tombi-toml/cli-linux-arm64": "1.1.4", "@tombi-toml/cli-linux-arm64-musl": "1.1.4", "@tombi-toml/cli-linux-x64": "1.1.4", "@tombi-toml/cli-linux-x64-musl": "1.1.4", "@tombi-toml/cli-win32-arm64": "1.1.4", "@tombi-toml/cli-win32-x64": "1.1.4" }, "bin": { "tombi": "bin/tombi" } }, "sha512-HRpe1bO/rx6fMJWTGG3Aw5zxvvxGM+iwLCs8grE2fQ1Fw9q1/qnl1dHGhA/wUSuKfpApCeRr7I7fWvOGc2XB1A=="],
 
     "totalist": ["totalist@3.0.1", "", {}, "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -19,7 +19,7 @@
       "version": "0.0.1",
       "devDependencies": {
         "@eslint/js": "^10.0.1",
-        "@sveltejs/adapter-auto": "^7.0.1",
+        "@sveltejs/adapter-static": "^3.0.10",
         "@sveltejs/kit": "^2.63.0",
         "@sveltejs/vite-plugin-svelte": "^7.1.2",
         "@types/node": "^24",
@@ -237,7 +237,7 @@
 
     "@sveltejs/acorn-typescript": ["@sveltejs/acorn-typescript@1.0.10", "", { "peerDependencies": { "acorn": "^8.9.0" } }, "sha512-4WfKk68eTih+MiJD4fSbxN7E8kVBmTMPWHUPYjvl2N0rMs53YLTT8/YjKU5Dtnz5LqDjl7LEw4U7lXR2W3J5WA=="],
 
-    "@sveltejs/adapter-auto": ["@sveltejs/adapter-auto@7.0.1", "", { "peerDependencies": { "@sveltejs/kit": "^2.0.0" } }, "sha512-dvuPm1E7M9NI/+canIQ6KKQDU2AkEefEZ2Dp7cY6uKoPq9Z/PhOXABe526UdW2mN986gjVkuSLkOYIBnS/M2LQ=="],
+    "@sveltejs/adapter-static": ["@sveltejs/adapter-static@3.0.10", "", { "peerDependencies": { "@sveltejs/kit": "^2.0.0" } }, "sha512-7D9lYFWJmB7zxZyTE/qxjksvMqzMuYrrsyh1f4AlZqeZeACPRySjbC3aFiY55wb1tWUaKOQG9PVbm74JcN2Iew=="],
 
     "@sveltejs/kit": ["@sveltejs/kit@2.65.2", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "@sveltejs/acorn-typescript": "^1.0.9", "@types/cookie": "^0.6.0", "acorn": "^8.16.0", "cookie": "^0.6.0", "devalue": "^5.8.1", "esm-env": "^1.2.2", "kleur": "^4.1.5", "magic-string": "^0.30.5", "mrmime": "^2.0.0", "set-cookie-parser": "^3.0.0", "sirv": "^3.0.0" }, "peerDependencies": { "@opentelemetry/api": "^1.0.0", "@sveltejs/vite-plugin-svelte": "^3.0.0 || ^4.0.0-next.1 || ^5.0.0 || ^6.0.0-next.0 || ^7.0.0", "svelte": "^4.0.0 || ^5.0.0-next.0", "typescript": "^5.3.3 || ^6.0.0", "vite": "^5.0.3 || ^6.0.0 || ^7.0.0-beta.0 || ^8.0.0" }, "optionalPeers": ["@opentelemetry/api", "typescript"], "bin": { "svelte-kit": "svelte-kit.js" } }, "sha512-ZIkyEmxT1gcq50Opn1ZIIx6vc/yt2zNN0rF5hS6op95gqHtNw8QMKDhjJI+RyjMcbvECRw+FzEeAoBe/MOz9AA=="],
 

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,0 +1,23 @@
+node_modules
+
+# Output
+.output
+.vercel
+.netlify
+.wrangler
+/.svelte-kit
+/build
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Env
+.env
+.env.*
+!.env.example
+!.env.test
+
+# Vite
+vite.config.js.timestamp-*
+vite.config.ts.timestamp-*

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,0 +1,34 @@
+## Project Configuration
+
+- **Language**: TypeScript
+- **Package Manager**: bun
+- **Add-ons**: mcp, vitest, eslint
+
+---
+
+You are able to use the Svelte MCP server, where you have access to comprehensive Svelte 5 and SvelteKit documentation.
+Here's how to use the available tools effectively:
+
+## Available Svelte MCP Tools:
+
+### 1. list-sections
+
+Use this FIRST to discover all available documentation sections. Returns a structured list with titles, use_cases, and
+paths. When asked about Svelte or SvelteKit topics, ALWAYS use this tool at the start of the chat to find relevant
+sections.
+
+### 2. get-documentation
+
+Retrieves full documentation content for specific sections. Accepts single or multiple sections. After calling the
+list-sections tool, you MUST analyze the returned documentation sections (especially the use_cases field) and then use
+the get-documentation tool to fetch ALL documentation sections that are relevant for the user's task.
+
+### 3. svelte-autofixer
+
+Analyzes Svelte code and returns issues and suggestions. You MUST use this tool whenever writing Svelte code before
+sending it to the user. Keep calling it until no issues or suggestions are returned.
+
+### 4. playground-link
+
+Generates a Svelte Playground link with the provided code. After completing the code, ask the user if they want a
+playground link. Only call this tool after user confirmation and NEVER if code was written to files in their project.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,44 +1,35 @@
-# sv
+# kp2bw Migration Planner
 
-Everything you need to build a Svelte project, powered by [`sv`](https://github.com/sveltejs/cli).
+This docs site helps you choose the safest KeePass-to-Bitwarden migration shape
+before running `kp2bw`.
 
-## Creating a project
+Open these pages in the docs site:
 
-If you're seeing this, you've probably already done this step. Congrats!
+- [Migration planner](./src/routes/+page.svelte) (served at `/`): choose
+  options, preview the trees, copy the command.
+- [Detailed option guide](./src/routes/docs/+page.svelte) (served at `/docs`):
+  learn what each choice means before running it.
 
-```sh
-# create a new project
-npx sv create my-app
-```
+The planner shows the source KeePass tree beside the Bitwarden result tree and
+turns your choices into the exact `.env` values and `kp2bw` command to run.
 
-To recreate this project with the same configuration:
+## What It Helps Decide
 
-```sh
-# recreate this project
-bun x sv@0.16.1 create --template minimal --types ts --add mcp="ide:claude-code,opencode,other+setup:remote" vitest="usages:unit,component" eslint --install bun docs
-```
+- Personal vault import with folders, or a flat personal import.
+- Organization import into nested collections, top-level collections, one fixed
+  collection, or no generated hierarchy.
+- Whether an organization import should also create personal folders with
+  `--folder`.
+- Whether a rerun should protect Bitwarden edits, skip updates, or force KeePass
+  to win.
+- Which tags, expired entries, and Recycle Bin entries are included.
 
-## Developing
+## Important Defaults
 
-Once you've created a project and installed dependencies with `npm install` (or `pnpm install` or `yarn`), start a
-development server:
-
-```sh
-npm run dev
-
-# or start the server and open the app in a new browser tab
-npm run dev -- --open
-```
-
-## Building
-
-To create a production version of your app:
-
-```sh
-npm run build
-```
-
-You can preview the production build with `npm run preview`.
-
-> To deploy your app, you may need to install an [adapter](https://svelte.dev/docs/kit/adapters) for your target
-> environment.
+- Personal vault is the no-flag default: `kp2bw vault.kdbx`.
+- Organization imports default to collections only; personal folders stay off
+  unless `--folder` is selected.
+- Expired entries are included unless `--skip-expired` is selected.
+- Recycle Bin entries are excluded unless `--include-recycle-bin` is selected.
+- Tag-filtered commands include `--` before the KeePass file so the file path is
+  not parsed as another tag.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,44 @@
+# sv
+
+Everything you need to build a Svelte project, powered by [`sv`](https://github.com/sveltejs/cli).
+
+## Creating a project
+
+If you're seeing this, you've probably already done this step. Congrats!
+
+```sh
+# create a new project
+npx sv create my-app
+```
+
+To recreate this project with the same configuration:
+
+```sh
+# recreate this project
+bun x sv@0.16.1 create --template minimal --types ts --add mcp="ide:claude-code,opencode,other+setup:remote" vitest="usages:unit,component" eslint --install bun docs
+```
+
+## Developing
+
+Once you've created a project and installed dependencies with `npm install` (or `pnpm install` or `yarn`), start a
+development server:
+
+```sh
+npm run dev
+
+# or start the server and open the app in a new browser tab
+npm run dev -- --open
+```
+
+## Building
+
+To create a production version of your app:
+
+```sh
+npm run build
+```
+
+You can preview the production build with `npm run preview`.
+
+> To deploy your app, you may need to install an [adapter](https://svelte.dev/docs/kit/adapters) for your target
+> environment.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,35 +1,32 @@
 # kp2bw Migration Planner
 
-This docs site helps you choose the safest KeePass-to-Bitwarden migration shape
-before running `kp2bw`.
+This docs site helps you choose the safest KeePass-to-Bitwarden migration shape before running `kp2bw`.
 
 Open these pages in the docs site:
 
-- [Migration planner](./src/routes/+page.svelte) (served at `/`): choose
-  options, preview the trees, copy the command.
-- [Detailed option guide](./src/routes/docs/+page.svelte) (served at `/docs`):
-  learn what each choice means before running it.
+- [Migration planner](https://kjanat.github.io/kp2bw/): choose options, preview the trees, copy the command.
+- [Detailed option guide](https://kjanat.github.io/kp2bw/docs/): learn what each choice means before running it.
 
-The planner shows the source KeePass tree beside the Bitwarden result tree and
-turns your choices into the exact `.env` values and `kp2bw` command to run.
+Source routes:
+
+- [Planner route](./src/routes/+page.svelte)
+- [Details route](./src/routes/docs/+page.svelte)
+
+The planner shows the source KeePass tree beside the Bitwarden result tree and turns your choices into the exact `.env`
+values and `kp2bw` command to run.
 
 ## What It Helps Decide
 
 - Personal vault import with folders, or a flat personal import.
-- Organization import into nested collections, top-level collections, one fixed
-  collection, or no generated hierarchy.
-- Whether an organization import should also create personal folders with
-  `--folder`.
-- Whether a rerun should protect Bitwarden edits, skip updates, or force KeePass
-  to win.
+- Organization import into nested collections, top-level collections, one fixed collection, or no generated hierarchy.
+- Whether an organization import should also create personal folders with `--folder`.
+- Whether a rerun should protect Bitwarden edits, skip updates, or force KeePass to win.
 - Which tags, expired entries, and Recycle Bin entries are included.
 
 ## Important Defaults
 
 - Personal vault is the no-flag default: `kp2bw vault.kdbx`.
-- Organization imports default to collections only; personal folders stay off
-  unless `--folder` is selected.
+- Organization imports default to collections only; personal folders stay off unless `--folder` is selected.
 - Expired entries are included unless `--skip-expired` is selected.
 - Recycle Bin entries are excluded unless `--include-recycle-bin` is selected.
-- Tag-filtered commands include `--` before the KeePass file so the file path is
-  not parsed as another tag.
+- Tag-filtered commands include `--` before the KeePass file so the file path is not parsed as another tag.

--- a/docs/eslint.config.js
+++ b/docs/eslint.config.js
@@ -1,0 +1,38 @@
+import js from '@eslint/js';
+import svelte from 'eslint-plugin-svelte';
+import { defineConfig, includeIgnoreFile } from 'eslint/config';
+import globals from 'globals';
+import path from 'node:path';
+import ts from 'typescript-eslint';
+
+const gitignorePath = path.resolve(import.meta.dirname, '.gitignore');
+
+export default defineConfig(
+	includeIgnoreFile(gitignorePath),
+	js.configs.recommended,
+	ts.configs.recommended,
+	svelte.configs.recommended,
+	{
+		languageOptions: { globals: { ...globals.browser, ...globals.node } },
+		rules: {
+			// typescript-eslint strongly recommend that you do not use the no-undef lint rule on TypeScript projects.
+			// see: https://typescript-eslint.io/troubleshooting/faqs/eslint/#i-get-errors-from-the-no-undef-rule-about-global-variables-not-being-defined-even-though-there-are-no-typescript-errors
+			'no-undef': 'off',
+		},
+	},
+	{
+		files: ['**/*.svelte', '**/*.svelte.ts', '**/*.svelte.js'],
+		languageOptions: {
+			parserOptions: {
+				projectService: true,
+				extraFileExtensions: ['.svelte'],
+				parser: ts.parser,
+			},
+		},
+	},
+	{
+		// Override or add rule settings here, such as:
+		// 'svelte/button-has-type': 'error'
+		rules: {},
+	},
+);

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,0 +1,36 @@
+{
+	"name": "docs",
+	"private": true,
+	"version": "0.0.1",
+	"type": "module",
+	"scripts": {
+		"dev": "vite dev",
+		"build": "vite build",
+		"preview": "vite preview",
+		"prepare": "svelte-kit sync || echo ''",
+		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
+		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
+		"test:unit": "vitest",
+		"test": "npm run test:unit -- --run",
+		"lint": "eslint ."
+	},
+	"devDependencies": {
+		"@eslint/js": "^10.0.1",
+		"@sveltejs/adapter-auto": "^7.0.1",
+		"@sveltejs/kit": "^2.63.0",
+		"@sveltejs/vite-plugin-svelte": "^7.1.2",
+		"@types/node": "^24",
+		"@vitest/browser-playwright": "^4.1.8",
+		"eslint": "^10.4.1",
+		"eslint-plugin-svelte": "^3.19.0",
+		"globals": "^17.6.0",
+		"playwright": "^1.60.0",
+		"svelte": "^5.56.1",
+		"svelte-check": "^4.6.0",
+		"typescript": "^6.0.3",
+		"typescript-eslint": "^8.60.1",
+		"vite": "^8.0.16",
+		"vitest": "^4.1.8",
+		"vitest-browser-svelte": "^2.1.1"
+	}
+}

--- a/docs/package.json
+++ b/docs/package.json
@@ -16,7 +16,7 @@
 	},
 	"devDependencies": {
 		"@eslint/js": "^10.0.1",
-		"@sveltejs/adapter-auto": "^7.0.1",
+		"@sveltejs/adapter-static": "^3.0.10",
 		"@sveltejs/kit": "^2.63.0",
 		"@sveltejs/vite-plugin-svelte": "^7.1.2",
 		"@types/node": "^24",

--- a/docs/package.json
+++ b/docs/package.json
@@ -7,12 +7,12 @@
 		"dev": "vite dev",
 		"build": "vite build",
 		"preview": "vite preview",
-		"prepare": "svelte-kit sync || echo ''",
+		"prepare": "svelte-kit sync 2>&1",
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
 		"test:unit": "vitest",
-		"test": "npm run test:unit -- --run",
-		"lint": "eslint ."
+		"test": "run test:unit run",
+		"lint": "eslint"
 	},
 	"devDependencies": {
 		"@eslint/js": "^10.0.1",
@@ -25,6 +25,7 @@
 		"eslint-plugin-svelte": "^3.19.0",
 		"globals": "^17.6.0",
 		"playwright": "^1.60.0",
+		"runner-run": "catalog:",
 		"svelte": "^5.56.1",
 		"svelte-check": "^4.6.0",
 		"typescript": "^6.0.3",

--- a/docs/src/app.d.ts
+++ b/docs/src/app.d.ts
@@ -1,0 +1,13 @@
+// See https://svelte.dev/docs/kit/types#app.d.ts
+// for information about these interfaces
+declare global {
+	namespace App {
+		// interface Error {}
+		// interface Locals {}
+		// interface PageData {}
+		// interface PageState {}
+		// interface Platform {}
+	}
+}
+
+export {};

--- a/docs/src/app.html
+++ b/docs/src/app.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, initial-scale=1">
+		<meta name="text-scale" content="scale">
+		%sveltekit.head%
+	</head>
+	<body data-sveltekit-preload-data="hover">
+		<div style="display: contents">%sveltekit.body%</div>
+	</body>
+</html>

--- a/docs/src/lib/assets/favicon.svg
+++ b/docs/src/lib/assets/favicon.svg
@@ -1,0 +1,8 @@
+<svg width="64" height="64" viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
+	<title>
+		kp2bw
+	</title>
+	<rect width="64" height="64" fill="#111411" />
+	<rect x="9" y="9" width="46" height="46" fill="none" stroke="#8ecf9f" stroke-width="4" />
+	<path d="M22 18v28h6V35l10 11h8L33 32l12-14h-8L28 29V18z" fill="#eee9da" />
+</svg>

--- a/docs/src/lib/components/CommandBox.svelte
+++ b/docs/src/lib/components/CommandBox.svelte
@@ -1,68 +1,114 @@
 <script lang="ts">
-	let { command, envFile, copied, onCopy }: {
-		command: string;
-		envFile: string;
-		copied: boolean;
-		onCopy: () => void;
-	} = $props();
+	import { onDestroy } from 'svelte';
+
+	let { command, envFile }: { command: string; envFile: string } = $props();
+
+	// Which box was last copied, so each Copy button flips to "Copied" on its own.
+	let copied = $state<'env' | 'run' | null>(null);
+	let resetTimer: ReturnType<typeof setTimeout> | undefined;
+
+	async function copy(which: 'env' | 'run', text: string): Promise<void> {
+		try {
+			await navigator.clipboard.writeText(text);
+		} catch {
+			return;
+		}
+		copied = which;
+		if (resetTimer !== undefined) clearTimeout(resetTimer);
+		resetTimer = setTimeout(() => {
+			copied = null;
+		}, 1200);
+	}
+
+	onDestroy(() => {
+		if (resetTimer !== undefined) clearTimeout(resetTimer);
+	});
 </script>
 
 <section class="command">
-	<div class="head">
-		<h2>Command</h2>
-		<button type="button" onclick={onCopy}>{copied ? 'Copied' : 'Copy'}</button>
-		<span class="sr-only" aria-live="polite" aria-atomic="true">
-			{copied ? 'Command copied to clipboard' : ''}
-		</span>
-	</div>
+	<h2>Command</h2>
 	<div class="blocks">
-		<div>
-			<h3>.env</h3>
+		<div class="block">
+			<div class="block-head">
+				<h3>.env</h3>
+				<button type="button" onclick={() => copy('env', envFile)}>
+					{copied === 'env' ? 'Copied' : 'Copy'}
+				</button>
+			</div>
 			<pre><code>{envFile}</code></pre>
 		</div>
-		<div>
-			<h3>Run</h3>
+		<div class="block">
+			<div class="block-head">
+				<h3>Run</h3>
+				<button type="button" onclick={() => copy('run', command)}>
+					{copied === 'run' ? 'Copied' : 'Copy'}
+				</button>
+			</div>
 			<pre><code>{command}</code></pre>
 		</div>
 	</div>
+	<span class="sr-only" aria-live="polite" aria-atomic="true">
+		{
+			copied === 'env'
+			? '.env copied to clipboard'
+			: copied === 'run'
+			? 'Command copied to clipboard'
+			: ''
+		}
+	</span>
 </section>
 
 <style>
 	.command {
 		grid-column: 1 / -1;
-		border: 1px solid #2f372f;
-		background: #151914;
+		border: 1px solid var(--edge);
+		background: var(--panel);
 		padding: 14px;
 	}
 
-	.head {
-		display: flex;
-		justify-content: space-between;
-		gap: 12px;
-		margin-bottom: 10px;
-	}
-
-	h2,
-	h3 {
-		margin: 0;
-		color: #aab0a3;
-		font-size: 0.72rem;
+	h2 {
+		margin: 0 0 10px;
+		color: var(--text-muted);
+		font-size: var(--fs-label);
 		letter-spacing: 0;
 		text-transform: uppercase;
 	}
 
+	h3 {
+		margin: 0;
+		color: var(--text-muted);
+		font-size: var(--fs-label);
+		letter-spacing: 0;
+		text-transform: uppercase;
+	}
+
+	.blocks {
+		display: grid;
+		grid-template-columns: minmax(220px, 0.7fr) minmax(260px, 1.3fr);
+		gap: 10px;
+	}
+
+	.block-head {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 12px;
+		min-height: 28px;
+	}
+
 	button {
-		min-height: 34px;
-		border: 1px solid #3b4239;
+		min-height: 28px;
+		border: 1px solid var(--edge-strong);
 		background: #1f241e;
-		color: #f0ecdc;
+		color: var(--text);
 		padding: 0 12px;
 		font: inherit;
+		font-size: var(--fs-small);
 		cursor: pointer;
 	}
 
 	button:hover {
-		border-color: #8ecf9f;
+		border-color: var(--accent);
 	}
 
 	.sr-only {
@@ -77,17 +123,11 @@
 		clip-path: inset(50%);
 	}
 
-	.blocks {
-		display: grid;
-		grid-template-columns: minmax(220px, 0.7fr) minmax(260px, 1.3fr);
-		gap: 10px;
-	}
-
 	pre {
 		overflow: auto;
 		margin: 6px 0 0;
-		border: 1px solid #31513f;
-		background: #0f1812;
+		border: 1px solid var(--code-edge);
+		background: var(--code-bg);
 		padding: 10px;
 		color: #d8f3df;
 		white-space: pre;

--- a/docs/src/lib/components/CommandBox.svelte
+++ b/docs/src/lib/components/CommandBox.svelte
@@ -1,0 +1,105 @@
+<script lang="ts">
+	let { command, envFile, copied, onCopy }: {
+		command: string;
+		envFile: string;
+		copied: boolean;
+		onCopy: () => void;
+	} = $props();
+</script>
+
+<section class="command">
+	<div class="head">
+		<h2>Command</h2>
+		<button type="button" onclick={onCopy}>{copied ? 'Copied' : 'Copy'}</button>
+		<span class="sr-only" aria-live="polite" aria-atomic="true">
+			{copied ? 'Command copied to clipboard' : ''}
+		</span>
+	</div>
+	<div class="blocks">
+		<div>
+			<h3>.env</h3>
+			<pre><code>{envFile}</code></pre>
+		</div>
+		<div>
+			<h3>Run</h3>
+			<pre><code>{command}</code></pre>
+		</div>
+	</div>
+</section>
+
+<style>
+	.command {
+		grid-column: 1 / -1;
+		border: 1px solid #2f372f;
+		background: #151914;
+		padding: 14px;
+	}
+
+	.head {
+		display: flex;
+		justify-content: space-between;
+		gap: 12px;
+		margin-bottom: 10px;
+	}
+
+	h2,
+	h3 {
+		margin: 0;
+		color: #aab0a3;
+		font-size: 0.72rem;
+		letter-spacing: 0;
+		text-transform: uppercase;
+	}
+
+	button {
+		min-height: 34px;
+		border: 1px solid #3b4239;
+		background: #1f241e;
+		color: #f0ecdc;
+		padding: 0 12px;
+		font: inherit;
+		cursor: pointer;
+	}
+
+	button:hover {
+		border-color: #8ecf9f;
+	}
+
+	.sr-only {
+		position: absolute;
+		overflow: hidden;
+		width: 1px;
+		height: 1px;
+		margin: -1px;
+		border: 0;
+		padding: 0;
+		white-space: nowrap;
+		clip-path: inset(50%);
+	}
+
+	.blocks {
+		display: grid;
+		grid-template-columns: minmax(220px, 0.7fr) minmax(260px, 1.3fr);
+		gap: 10px;
+	}
+
+	pre {
+		overflow: auto;
+		margin: 6px 0 0;
+		border: 1px solid #31513f;
+		background: #0f1812;
+		padding: 10px;
+		color: #d8f3df;
+		white-space: pre;
+	}
+
+	code {
+		font: inherit;
+	}
+
+	@media (max-width: 820px) {
+		.blocks {
+			grid-template-columns: 1fr;
+		}
+	}
+</style>

--- a/docs/src/lib/components/HelpMark.svelte
+++ b/docs/src/lib/components/HelpMark.svelte
@@ -1,0 +1,78 @@
+<script lang="ts">
+	import { resolve } from '$app/paths';
+
+	type DocsHref = '/docs' | `/docs#${string}`;
+
+	let { text, href = '/docs' }: { text: string; href?: DocsHref } = $props();
+</script>
+
+<span class="wrap">
+	<button class="help" type="button" aria-label={text}>?</button>
+	<span class="popover" role="tooltip">
+		{text}
+		<a href={resolve(href)}>continue reading</a>
+	</span>
+</span>
+
+<style>
+	.wrap {
+		position: relative;
+		display: inline-grid;
+	}
+
+	.help {
+		display: inline-grid;
+		place-items: center;
+		width: 1.25rem;
+		height: 1.25rem;
+		border: 1px solid #667267;
+		background: transparent;
+		color: #d9ded2;
+		font: inherit;
+		font-size: 0.78rem;
+		line-height: 1;
+		cursor: help;
+	}
+
+	.help:hover,
+	.help:focus-visible {
+		border-color: #8ecf9f;
+		color: #8ecf9f;
+		outline: none;
+	}
+
+	.popover {
+		position: absolute;
+		z-index: 5;
+		top: calc(100% + 7px);
+		right: 0;
+		display: none;
+		width: min(250px, 78vw);
+		border: 1px solid #4b594d;
+		background: #111411;
+		padding: 10px;
+		color: #f0ecdc;
+		font-size: 0.78rem;
+		line-height: 1.4;
+		text-transform: none;
+		box-shadow: 0 10px 24px rgba(0, 0, 0, 0.35);
+	}
+
+	.wrap:hover .popover,
+	.wrap:focus-within .popover {
+		display: grid;
+		gap: 8px;
+	}
+
+	a {
+		width: fit-content;
+		color: #8ecf9f;
+		text-decoration: none;
+	}
+
+	a:hover,
+	a:focus-visible {
+		text-decoration: underline;
+		outline: none;
+	}
+</style>

--- a/docs/src/lib/components/HelpMark.svelte
+++ b/docs/src/lib/components/HelpMark.svelte
@@ -25,20 +25,19 @@
 		place-items: center;
 		width: 1.25rem;
 		height: 1.25rem;
-		border: 1px solid #667267;
+		border: 1px solid var(--edge-strong);
 		background: transparent;
-		color: #d9ded2;
+		color: var(--text-dim);
 		font: inherit;
-		font-size: 0.78rem;
+		font-size: var(--fs-small);
 		line-height: 1;
 		cursor: help;
 	}
 
 	.help:hover,
 	.help:focus-visible {
-		border-color: #8ecf9f;
-		color: #8ecf9f;
-		outline: none;
+		border-color: var(--accent);
+		color: var(--accent);
 	}
 
 	.popover {
@@ -48,11 +47,11 @@
 		right: 0;
 		display: none;
 		width: min(250px, 78vw);
-		border: 1px solid #4b594d;
-		background: #111411;
+		border: 1px solid var(--edge-strong);
+		background: var(--bg);
 		padding: 10px;
-		color: #f0ecdc;
-		font-size: 0.78rem;
+		color: var(--text);
+		font-size: var(--fs-small);
 		line-height: 1.4;
 		text-transform: none;
 		box-shadow: 0 10px 24px rgba(0, 0, 0, 0.35);
@@ -66,13 +65,12 @@
 
 	a {
 		width: fit-content;
-		color: #8ecf9f;
+		color: var(--accent);
 		text-decoration: none;
 	}
 
 	a:hover,
 	a:focus-visible {
 		text-decoration: underline;
-		outline: none;
 	}
 </style>

--- a/docs/src/lib/components/PathTable.svelte
+++ b/docs/src/lib/components/PathTable.svelte
@@ -135,20 +135,20 @@
 
 	.panel {
 		min-width: 0;
-		border: 1px solid #2f372f;
-		background: #151914;
+		border: 1px solid var(--edge);
+		background: var(--panel);
 		padding: 12px;
 	}
 
 	.head {
-		border-bottom: 1px solid #30372f;
+		border-bottom: 1px solid var(--edge);
 		padding-bottom: 8px;
 	}
 
 	h2,
 	span {
 		margin: 0;
-		color: #aab0a3;
+		color: var(--text-muted);
 		font-size: 0.72rem;
 		letter-spacing: 0;
 		text-transform: uppercase;
@@ -169,7 +169,7 @@
 
 	li li {
 		margin-left: 15px;
-		border-left: 1px solid #30372f;
+		border-left: 1px solid var(--edge);
 		padding-left: 10px;
 	}
 
@@ -194,7 +194,7 @@
 	}
 
 	.root {
-		color: #f0ecdc;
+		color: var(--text);
 		font-weight: 700;
 	}
 
@@ -235,7 +235,7 @@
 		height: 22px;
 		border: 0;
 		background: transparent;
-		color: #8ecf9f;
+		color: var(--accent);
 		padding: 0;
 		font: inherit;
 		font-size: 0.85rem;
@@ -249,8 +249,8 @@
 
 	button.twist:hover,
 	button.twist:focus-visible {
-		color: #f0ecdc;
-		outline: 1px solid #8ecf9f;
+		color: var(--text);
+		outline: 1px solid var(--accent);
 		outline-offset: 1px;
 	}
 
@@ -273,7 +273,7 @@
 
 	.icon[data-kind="root"],
 	.icon[data-kind="bucket"] {
-		border-color: #8ecf9f;
+		border-color: var(--accent);
 	}
 
 	.icon[data-kind="folder"] {
@@ -288,19 +288,19 @@
 		height: 4px;
 		border: 1px solid #d2b56f;
 		border-bottom: 0;
-		background: #151914;
+		background: var(--panel);
 	}
 
 	.icon[data-kind="collection"] {
 		width: 14px;
 		height: 14px;
-		border-color: #8ecf9f;
+		border-color: var(--accent);
 		background: #101d16;
 	}
 
 	.icon[data-kind="collection"]::before {
 		inset: 3px;
-		border: 1px solid #8ecf9f;
+		border: 1px solid var(--accent);
 	}
 
 	.icon[data-kind="collection"]::after {
@@ -308,8 +308,11 @@
 		left: -4px;
 		width: 2px;
 		height: 2px;
-		background: #8ecf9f;
-		box-shadow: 16px 0 0 #8ecf9f, 8px -6px 0 #8ecf9f, 8px 6px 0 #8ecf9f;
+		background: var(--accent);
+		box-shadow:
+			16px 0 0 var(--accent),
+			8px -6px 0 var(--accent),
+			8px 6px 0 var(--accent);
 	}
 
 	.icon[data-kind="recycle"] {
@@ -324,7 +327,7 @@
 		width: 16px;
 		height: 2px;
 		border: 1px solid #d48670;
-		background: #151914;
+		background: var(--panel);
 	}
 
 	.icon[data-kind="recycle"]::after {
@@ -366,15 +369,18 @@
 	}
 
 	.name {
-		overflow-wrap: anywhere;
+		min-width: 0;
 		color: inherit;
+		/* break-word wraps at spaces first (so "Production SSH" never splits
+		   mid-word like "Productio n"); only an unbreakable token breaks. */
+		overflow-wrap: break-word;
 		text-transform: none;
 	}
 
 	.count {
-		border: 1px solid #30372f;
+		border: 1px solid var(--edge);
 		padding: 1px 6px;
-		color: #8ecf9f;
+		color: var(--accent);
 		font-size: 0.68rem;
 	}
 
@@ -387,9 +393,9 @@
 
 	.action,
 	.delta {
-		border: 1px solid #30372f;
+		border: 1px solid var(--edge);
 		padding: 1px 6px;
-		color: #c7c9bd;
+		color: var(--text-dim);
 		font-size: 0.64rem;
 		line-height: 1.25;
 		text-transform: uppercase;
@@ -401,7 +407,7 @@
 	}
 
 	.delta[data-delta="new-in-keepass"] {
-		border-color: #8ecf9f;
+		border-color: var(--accent);
 		color: #9ff0ba;
 	}
 
@@ -421,7 +427,7 @@
 	}
 
 	.action[data-action="create"] {
-		border-color: #8ecf9f;
+		border-color: var(--accent);
 		background: #112016;
 		color: #9ff0ba;
 	}

--- a/docs/src/lib/components/PathTable.svelte
+++ b/docs/src/lib/components/PathTable.svelte
@@ -1,0 +1,459 @@
+<script lang="ts">
+	import type { PreviewNode } from '$lib/planner';
+	import { SvelteSet } from 'svelte/reactivity';
+
+	type Tree = {
+		title: string;
+		nodes: PreviewNode[];
+	};
+
+	let { keepass, bitwarden }: { keepass: Tree; bitwarden: Tree } = $props();
+
+	let collapsed = new SvelteSet<string>();
+
+	function toggleNode(nodeId: string): void {
+		if (collapsed.has(nodeId)) {
+			collapsed.delete(nodeId);
+		} else {
+			collapsed.add(nodeId);
+		}
+	}
+
+	function actionLabel(action: PreviewNode['action']): string {
+		if (action === undefined) return '';
+		if (action === 'create') return 'create';
+		if (action === 'update') return 'sync to BW';
+		if (action === 'protected') return 'protect BW';
+		if (action === 'overwrite') return 'KP wins';
+		if (action === 'left-alone') return 'leave';
+		if (action === 'unchanged') return 'same';
+		if (action === 'skip') return 'skip';
+		const exhaustive: never = action;
+		return exhaustive;
+	}
+
+	function deltaLabel(delta: PreviewNode['delta']): string {
+		if (delta === undefined || delta === 'unchanged') return '';
+		if (delta === 'new-in-keepass') return 'new in KP';
+		if (delta === 'keepass-changed') return 'KP changed';
+		if (delta === 'bitwarden-changed') return 'BW changed';
+		if (delta === 'both-changed') return 'both changed';
+		const exhaustive: never = delta;
+		return exhaustive;
+	}
+
+	function showDelta(node: PreviewNode): boolean {
+		return Boolean(node.delta && node.delta !== 'unchanged');
+	}
+</script>
+
+{#snippet branch(nodes: PreviewNode[], prefix = '')}
+	<ul>
+		{#each nodes as node, i (`${prefix}/${i}`)}
+			{@const nodeId = `${prefix}/${i}`}
+			{@const canCollapse = node.children.length > 0}
+			{@const isCollapsed = collapsed.has(nodeId)}
+			<li>
+				<div
+					class="node"
+					class:root={node.kind === 'root'}
+					class:folder={node.kind === 'folder'}
+					class:collection={node.kind === 'collection'}
+					class:recycle={node.kind === 'recycle'}
+					class:item={node.kind === 'item'}
+					class:empty={node.kind === 'empty'}
+					class:skipped={node.action === 'skip' || node.muted}
+					class:conflicted={node.action === 'protected' || node.action === 'overwrite'}
+				>
+					{#if canCollapse}
+						<button
+							class="twist"
+							type="button"
+							aria-label={`${isCollapsed ? 'Expand' : 'Collapse'} ${node.name}`}
+							aria-expanded={!isCollapsed}
+							onclick={() => toggleNode(nodeId)}
+						>
+							{isCollapsed ? '›' : '⌄'}
+						</button>
+					{:else}
+						<span class="twist" aria-hidden="true"></span>
+					{/if}
+					<span class="icon" data-kind={node.kind}></span>
+					<span class="name">{node.name}</span>
+					{#if node.count !== undefined && node.kind !== 'item'}
+						<span class="count">{node.count}</span>
+					{:else if node.kind === 'item' && (node.action || showDelta(node))}
+						<span class="badges">
+							{#if showDelta(node)}
+								<span class="delta" data-delta={node.delta}>
+									{deltaLabel(node.delta)}
+								</span>
+							{/if}
+							{#if node.action}
+								<span class="action" data-action={node.action}>
+									{actionLabel(node.action)}
+								</span>
+							{/if}
+						</span>
+					{/if}
+				</div>
+				{#if canCollapse && !isCollapsed}
+					{@render branch(node.children, nodeId)}
+				{/if}
+			</li>
+		{/each}
+	</ul>
+{/snippet}
+
+<section class="preview" aria-label="Migration tree preview">
+	<div class="panel">
+		<div class="head">
+			<h2>{keepass.title}</h2>
+		</div>
+		<div class="tree">
+			{@render branch(keepass.nodes, 'keepass')}
+		</div>
+	</div>
+	<div class="panel">
+		<div class="head">
+			<h2>{bitwarden.title}</h2>
+		</div>
+		<div class="tree">
+			{@render branch(bitwarden.nodes, 'bitwarden')}
+		</div>
+	</div>
+</section>
+
+<style>
+	.preview {
+		grid-column: span 2;
+		display: grid;
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+		gap: 12px;
+		min-width: 0;
+	}
+
+	.panel {
+		min-width: 0;
+		border: 1px solid #2f372f;
+		background: #151914;
+		padding: 12px;
+	}
+
+	.head {
+		border-bottom: 1px solid #30372f;
+		padding-bottom: 8px;
+	}
+
+	h2,
+	span {
+		margin: 0;
+		color: #aab0a3;
+		font-size: 0.72rem;
+		letter-spacing: 0;
+		text-transform: uppercase;
+	}
+
+	.tree {
+		overflow: auto;
+		padding-top: 8px;
+	}
+
+	ul {
+		display: grid;
+		gap: 2px;
+		margin: 0;
+		padding: 0;
+		list-style: none;
+	}
+
+	li li {
+		margin-left: 15px;
+		border-left: 1px solid #30372f;
+		padding-left: 10px;
+	}
+
+	.node {
+		display: grid;
+		grid-template-columns: 14px 16px minmax(0, 1fr) auto;
+		align-items: center;
+		gap: 6px;
+		min-width: 0;
+		min-height: 28px;
+		border-radius: 3px;
+		padding: 2px 4px;
+		transition:
+			background-color 180ms ease,
+			color 180ms ease,
+			opacity 220ms ease,
+			filter 220ms ease;
+	}
+
+	.node:hover {
+		background: #1d241d;
+	}
+
+	.root {
+		color: #f0ecdc;
+		font-weight: 700;
+	}
+
+	.folder {
+		color: #d2b56f;
+	}
+
+	.collection {
+		color: #85d7ad;
+	}
+
+	.recycle {
+		color: #d48670;
+	}
+
+	.item {
+		color: #d4d0c3;
+	}
+
+	.skipped {
+		opacity: 0.46;
+		filter: grayscale(1);
+	}
+
+	.conflicted {
+		background: #241916;
+	}
+
+	.empty {
+		color: #7e897d;
+		font-style: italic;
+	}
+
+	.twist {
+		display: grid;
+		place-items: center;
+		width: 14px;
+		height: 22px;
+		border: 0;
+		background: transparent;
+		color: #8ecf9f;
+		padding: 0;
+		font: inherit;
+		font-size: 0.85rem;
+		line-height: 1;
+		cursor: pointer;
+	}
+
+	span.twist {
+		cursor: default;
+	}
+
+	button.twist:hover,
+	button.twist:focus-visible {
+		color: #f0ecdc;
+		outline: 1px solid #8ecf9f;
+		outline-offset: 1px;
+	}
+
+	.icon {
+		position: relative;
+		width: 14px;
+		height: 12px;
+		border: 1px solid #95a195;
+	}
+
+	.icon::before {
+		position: absolute;
+		content: "";
+	}
+
+	.icon::after {
+		position: absolute;
+		content: "";
+	}
+
+	.icon[data-kind="root"],
+	.icon[data-kind="bucket"] {
+		border-color: #8ecf9f;
+	}
+
+	.icon[data-kind="folder"] {
+		border-color: #d2b56f;
+		background: #211d12;
+	}
+
+	.icon[data-kind="folder"]::before {
+		top: -4px;
+		left: 1px;
+		width: 7px;
+		height: 4px;
+		border: 1px solid #d2b56f;
+		border-bottom: 0;
+		background: #151914;
+	}
+
+	.icon[data-kind="collection"] {
+		width: 14px;
+		height: 14px;
+		border-color: #8ecf9f;
+		background: #101d16;
+	}
+
+	.icon[data-kind="collection"]::before {
+		inset: 3px;
+		border: 1px solid #8ecf9f;
+	}
+
+	.icon[data-kind="collection"]::after {
+		top: 5px;
+		left: -4px;
+		width: 2px;
+		height: 2px;
+		background: #8ecf9f;
+		box-shadow: 16px 0 0 #8ecf9f, 8px -6px 0 #8ecf9f, 8px 6px 0 #8ecf9f;
+	}
+
+	.icon[data-kind="recycle"] {
+		border-color: #d48670;
+		border-radius: 0 0 4px 4px;
+		background: #251713;
+	}
+
+	.icon[data-kind="recycle"]::before {
+		top: -4px;
+		left: -2px;
+		width: 16px;
+		height: 2px;
+		border: 1px solid #d48670;
+		background: #151914;
+	}
+
+	.icon[data-kind="recycle"]::after {
+		top: 3px;
+		left: 3px;
+		width: 1px;
+		height: 6px;
+		background: #d48670;
+		box-shadow: 4px 0 0 #d48670;
+	}
+
+	.icon[data-kind="item"] {
+		width: 10px;
+		height: 13px;
+		border-color: #868c83;
+	}
+
+	.icon[data-kind="item"]::before {
+		top: 2px;
+		left: 2px;
+		width: 4px;
+		height: 1px;
+		background: #868c83;
+		box-shadow: 0 3px 0 #868c83, 0 6px 0 #868c83;
+	}
+
+	.icon[data-kind="empty"] {
+		border-color: #5c655b;
+		border-style: dashed;
+		opacity: 0.75;
+	}
+
+	.icon[data-kind="empty"]::before {
+		top: 5px;
+		left: 3px;
+		width: 6px;
+		height: 1px;
+		background: #7e897d;
+	}
+
+	.name {
+		overflow-wrap: anywhere;
+		color: inherit;
+		text-transform: none;
+	}
+
+	.count {
+		border: 1px solid #30372f;
+		padding: 1px 6px;
+		color: #8ecf9f;
+		font-size: 0.68rem;
+	}
+
+	.badges {
+		display: flex;
+		flex-wrap: wrap;
+		justify-content: end;
+		gap: 4px;
+	}
+
+	.action,
+	.delta {
+		border: 1px solid #30372f;
+		padding: 1px 6px;
+		color: #c7c9bd;
+		font-size: 0.64rem;
+		line-height: 1.25;
+		text-transform: uppercase;
+		white-space: nowrap;
+		transition:
+			border-color 180ms ease,
+			background-color 180ms ease,
+			color 180ms ease;
+	}
+
+	.delta[data-delta="new-in-keepass"] {
+		border-color: #8ecf9f;
+		color: #9ff0ba;
+	}
+
+	.delta[data-delta="keepass-changed"] {
+		border-color: #d2b56f;
+		color: #e3c77d;
+	}
+
+	.delta[data-delta="bitwarden-changed"] {
+		border-color: #7da2d8;
+		color: #9dbdec;
+	}
+
+	.delta[data-delta="both-changed"] {
+		border-color: #d48670;
+		color: #f0a58d;
+	}
+
+	.action[data-action="create"] {
+		border-color: #8ecf9f;
+		background: #112016;
+		color: #9ff0ba;
+	}
+
+	.action[data-action="update"] {
+		border-color: #d2b56f;
+		background: #211d12;
+		color: #e3c77d;
+	}
+
+	.action[data-action="protected"] {
+		border-color: #7da2d8;
+		background: #111a25;
+		color: #9dbdec;
+	}
+
+	.action[data-action="overwrite"] {
+		border-color: #d48670;
+		background: #271711;
+		color: #f0a58d;
+	}
+
+	.action[data-action="left-alone"],
+	.action[data-action="skip"] {
+		border-color: #5c655b;
+		color: #9ba397;
+	}
+
+	@media (max-width: 820px) {
+		.preview {
+			grid-column: auto;
+			grid-template-columns: 1fr;
+		}
+	}
+</style>

--- a/docs/src/lib/components/PathTable.svelte
+++ b/docs/src/lib/components/PathTable.svelte
@@ -11,6 +11,39 @@
 
 	let collapsed = new SvelteSet<string>();
 
+	type RenderNode = {
+		id: string;
+		node: PreviewNode;
+		path: string[];
+	};
+
+	function renderNodes(
+		nodes: readonly PreviewNode[],
+		parentPath: readonly string[],
+	): RenderNode[] {
+		return nodes.map((node, index) => {
+			const ordinal = siblingOrdinal(nodes, node, index);
+			const path = [...parentPath, node.kind, node.name, String(ordinal)];
+
+			return { id: JSON.stringify(path), node, path };
+		});
+	}
+
+	function siblingOrdinal(
+		nodes: readonly PreviewNode[],
+		node: PreviewNode,
+		index: number,
+	): number {
+		let ordinal = 0;
+		for (let siblingIndex = 0; siblingIndex < index; siblingIndex += 1) {
+			const sibling = nodes[siblingIndex];
+			if (sibling?.kind === node.kind && sibling.name === node.name) {
+				ordinal += 1;
+			}
+		}
+		return ordinal;
+	}
+
 	function toggleNode(nodeId: string): void {
 		if (collapsed.has(nodeId)) {
 			collapsed.delete(nodeId);
@@ -47,10 +80,11 @@
 	}
 </script>
 
-{#snippet branch(nodes: PreviewNode[], prefix = '')}
+{#snippet branch(nodes: PreviewNode[], path: readonly string[])}
 	<ul>
-		{#each nodes as node, i (`${prefix}/${i}`)}
-			{@const nodeId = `${prefix}/${i}`}
+		{#each renderNodes(nodes, path) as entry (entry.id)}
+			{@const node = entry.node}
+			{@const nodeId = entry.id}
 			{@const canCollapse = node.children.length > 0}
 			{@const isCollapsed = collapsed.has(nodeId)}
 			<li>
@@ -98,7 +132,7 @@
 					{/if}
 				</div>
 				{#if canCollapse && !isCollapsed}
-					{@render branch(node.children, nodeId)}
+					{@render branch(node.children, entry.path)}
 				{/if}
 			</li>
 		{/each}
@@ -111,7 +145,7 @@
 			<h2>{keepass.title}</h2>
 		</div>
 		<div class="tree">
-			{@render branch(keepass.nodes, 'keepass')}
+			{@render branch(keepass.nodes, ['keepass'])}
 		</div>
 	</div>
 	<div class="panel">
@@ -119,7 +153,7 @@
 			<h2>{bitwarden.title}</h2>
 		</div>
 		<div class="tree">
-			{@render branch(bitwarden.nodes, 'bitwarden')}
+			{@render branch(bitwarden.nodes, ['bitwarden'])}
 		</div>
 	</div>
 </section>
@@ -199,15 +233,15 @@
 	}
 
 	.folder {
-		color: #d2b56f;
+		color: var(--icon-folder);
 	}
 
 	.collection {
-		color: #85d7ad;
+		color: var(--icon-collection);
 	}
 
 	.recycle {
-		color: #d48670;
+		color: var(--icon-recycle);
 	}
 
 	.item {
@@ -277,8 +311,8 @@
 	}
 
 	.icon[data-kind="folder"] {
-		border-color: #d2b56f;
-		background: #211d12;
+		border-color: var(--icon-folder);
+		background: var(--icon-folder-bg);
 	}
 
 	.icon[data-kind="folder"]::before {
@@ -286,7 +320,7 @@
 		left: 1px;
 		width: 7px;
 		height: 4px;
-		border: 1px solid #d2b56f;
+		border: 1px solid var(--icon-folder);
 		border-bottom: 0;
 		background: var(--panel);
 	}
@@ -294,13 +328,13 @@
 	.icon[data-kind="collection"] {
 		width: 14px;
 		height: 14px;
-		border-color: var(--accent);
-		background: #101d16;
+		border-color: var(--icon-collection);
+		background: var(--icon-collection-bg);
 	}
 
 	.icon[data-kind="collection"]::before {
 		inset: 3px;
-		border: 1px solid var(--accent);
+		border: 1px solid var(--icon-collection);
 	}
 
 	.icon[data-kind="collection"]::after {
@@ -308,17 +342,17 @@
 		left: -4px;
 		width: 2px;
 		height: 2px;
-		background: var(--accent);
+		background: var(--icon-collection);
 		box-shadow:
-			16px 0 0 var(--accent),
-			8px -6px 0 var(--accent),
-			8px 6px 0 var(--accent);
+			16px 0 0 var(--icon-collection),
+			8px -6px 0 var(--icon-collection),
+			8px 6px 0 var(--icon-collection);
 	}
 
 	.icon[data-kind="recycle"] {
-		border-color: #d48670;
+		border-color: var(--icon-recycle);
 		border-radius: 0 0 4px 4px;
-		background: #251713;
+		background: var(--icon-recycle-bg);
 	}
 
 	.icon[data-kind="recycle"]::before {
@@ -326,7 +360,7 @@
 		left: -2px;
 		width: 16px;
 		height: 2px;
-		border: 1px solid #d48670;
+		border: 1px solid var(--icon-recycle);
 		background: var(--panel);
 	}
 
@@ -335,8 +369,8 @@
 		left: 3px;
 		width: 1px;
 		height: 6px;
-		background: #d48670;
-		box-shadow: 4px 0 0 #d48670;
+		background: var(--icon-recycle);
+		box-shadow: 4px 0 0 var(--icon-recycle);
 	}
 
 	.icon[data-kind="item"] {

--- a/docs/src/lib/components/PlannerOptions.svelte
+++ b/docs/src/lib/components/PlannerOptions.svelte
@@ -6,78 +6,31 @@
 	type Choice<T extends string> = {
 		value: T;
 		label: string;
-		help: string;
-		href: `/docs#${string}`;
 	};
 
 	let { state }: { state: PlannerState } = $props();
 
+	// Labels are self-describing; the per-option rationale lives in the docs
+	// page, reached via the section-level help marks (Tree mapping / Running
+	// again), so the controls stay compact instead of a wall of ? buttons.
 	const orgMappings: Choice<Mapping>[] = [
-		{
-			value: 'org-nested',
-			label: 'Org collections: full paths',
-			help:
-				'KeePass group Work/Servers becomes organization collection Work/Servers.',
-			href: '/docs#full-path-collections',
-		},
-		{
-			value: 'org-top',
-			label: 'Org collections: top folder only',
-			help:
-				'KeePass Work/Servers and Work/Engineering both land in collection Work.',
-			href: '/docs#top-folder-collections',
-		},
-		{
-			value: 'org-fixed',
-			label: 'One existing collection',
-			help:
-				'Every item lands in the collection ID below. KeePass groups are not recreated.',
-			href: '/docs#single-collection',
-		},
-		{
-			value: 'org-flat',
-			label: 'Flat organization import',
-			help: 'No generated collections and no personal folders.',
-			href: '/docs#flat-org',
-		},
+		{ value: 'org-nested', label: 'Org collections: full paths' },
+		{ value: 'org-top', label: 'Org collections: top folder only' },
+		{ value: 'org-fixed', label: 'One existing collection' },
+		{ value: 'org-flat', label: 'Flat organization import' },
 	];
 
 	const personalMappings: Choice<Mapping>[] = [
-		{
-			value: 'personal-folders',
-			label: 'Personal folders',
-			help: 'KeePass groups become personal Bitwarden folders.',
-			href: '/docs#personal-folders',
-		},
-		{
-			value: 'personal-flat',
-			label: 'Flat personal import',
-			help: 'No Bitwarden folders. Items stay at the personal vault root.',
-			href: '/docs#flat-personal',
-		},
+		{ value: 'personal-folders', label: 'Personal folders' },
+		{ value: 'personal-flat', label: 'Flat personal import' },
 	];
 
 	const reruns: Choice<RerunMode>[] = [
-		{
-			value: 'keepass-wins',
-			label: 'KeePass is still my main vault',
-			help:
-				'Use KeePass as the source of truth and push it over Bitwarden edits.',
-			href: '/docs#force-update',
-		},
-		{
-			value: 'safe',
-			label: 'Mostly Bitwarden, sync forgotten KeePass edits',
-			help:
-				'Update migrated items when Bitwarden has not been edited since the last kp2bw run.',
-			href: '/docs#safe-rerun',
-		},
+		{ value: 'keepass-wins', label: 'KeePass is still my main vault' },
+		{ value: 'safe', label: 'Mostly Bitwarden, sync forgotten KeePass edits' },
 		{
 			value: 'no-update',
 			label: 'Testing migrations; keep the existing Vaultwarden DB',
-			help:
-				'Create missing items only and leave existing migrated Bitwarden items untouched.',
-			href: '/docs#no-update',
 		},
 	];
 
@@ -103,6 +56,80 @@
 </script>
 
 <section class="options">
+	<!--
+		Target-independent options first. Toggling Target adds/removes Org ID,
+		swaps the mapping list (4 org vs 2 personal) and the folders opt-in, so
+		keeping it below means a toggle only reflows the bottom of the panel
+		instead of shoving every field down.
+	-->
+	<div class="fields">
+		<label class="field file-field">
+			<span>KeePass file</span>
+			<input bind:value={state.keepassFile} spellcheck="false">
+		</label>
+		<label class="field file-field">
+			<span>Key file</span>
+			<input bind:value={state.keyFile} spellcheck="false">
+		</label>
+		<label class="field tag-field">
+			<span>Tags</span>
+			<input bind:value={state.tagInput} spellcheck="false">
+		</label>
+		<div
+			class="tag-chips"
+			aria-label="Available tags in the mock KeePass vault"
+		>
+			{#each tagChoices as tag (tag)}
+				<button
+					type="button"
+					class:active={activeTags.includes(tag)}
+					aria-pressed={activeTags.includes(tag)}
+					onclick={() => toggleTag(tag)}
+				>
+					{tag}
+				</button>
+			{/each}
+		</div>
+	</div>
+
+	<fieldset class="filters">
+		<legend>Filters</legend>
+		<div class="choice">
+			<label>
+				<input type="checkbox" bind:checked={state.includeExpired}>
+				Expired
+			</label>
+		</div>
+		<div class="choice">
+			<label>
+				<input type="checkbox" bind:checked={state.includeRecycleBin}>
+				Recycle bin
+			</label>
+		</div>
+	</fieldset>
+
+	<fieldset>
+		<legend>
+			Running again <HelpMark
+				text="Pick the situation you are in when this command hits an existing Bitwarden vault."
+				href="/docs#reruns"
+			/>
+		</legend>
+		{#each reruns as rerun (rerun.value)}
+			<div class="choice">
+				<label>
+					<input
+						type="radio"
+						name="rerun"
+						value={rerun.value}
+						bind:group={state.rerunMode}
+					>
+					{rerun.label}
+				</label>
+			</div>
+		{/each}
+	</fieldset>
+
 	<fieldset class="target">
 		<legend>
 			Target <HelpMark
@@ -114,28 +141,25 @@
 			<input
 				type="radio"
 				name="destination"
-				checked={state.destination === 'org'}
-				onchange={() => setDestination('org')}
-			>
-			Organization
-		</label>
-		<label>
-			<input
-				type="radio"
-				name="destination"
 				checked={state.destination === 'personal'}
 				onchange={() => setDestination('personal')}
 			>
 			Personal
 		</label>
+		<label>
+			<input
+				type="radio"
+				name="destination"
+				checked={state.destination === 'org'}
+				onchange={() => setDestination('org')}
+			>
+			Organization
+		</label>
 	</fieldset>
 
 	{#if state.destination === 'org'}
 		<label class="field">
-			<span>Org ID <HelpMark
-					text="Bitwarden organization ID passed to kp2bw."
-					href="/docs#organization-id"
-				/></span>
+			<span>Org ID</span>
 			<input bind:value={state.organizationId} spellcheck="false">
 		</label>
 	{/if}
@@ -158,118 +182,36 @@
 					>
 					{mapping.label}
 				</label>
-				<HelpMark text={mapping.help} href={mapping.href} />
 			</div>
 		{/each}
 	</fieldset>
+
+	{#if state.destination === 'org'}
+		<div class="choice">
+			<label>
+				<input type="checkbox" bind:checked={state.orgFolders}>
+				Also create personal folders
+			</label>
+			<HelpMark
+				text="Org imports skip personal folders by default. Tick this to also build the KeePass folder tree in your personal vault (kp2bw --folder)."
+				href="/docs#personal-folders-under-org"
+			/>
+		</div>
+	{/if}
 
 	{#if state.mapping === 'org-fixed'}
 		<label class="field">
-			<span>Collection ID <HelpMark
-					text="Existing collection all imported items should land in."
-					href="/docs#collection-id"
-				/></span>
+			<span>Collection ID</span>
 			<input bind:value={state.collectionId} spellcheck="false">
 		</label>
 	{/if}
-
-	<div class="fields">
-		<label class="field file-field">
-			<span>KeePass file <HelpMark
-					text="Path to the KeePass database."
-					href="/docs#keepass-file"
-				/></span>
-			<input bind:value={state.keepassFile} spellcheck="false">
-		</label>
-		<label class="field file-field">
-			<span>Key file <HelpMark
-					text="Optional KeePass key file."
-					href="/docs#key-file"
-				/></span>
-			<input bind:value={state.keyFile} spellcheck="false">
-		</label>
-		<label class="field tag-field">
-			<span>Tags <HelpMark
-					text="Comma-separated KeePass tags to import. Empty imports all tags."
-					href="/docs#tag-filter"
-				/></span>
-			<input bind:value={state.tagInput} spellcheck="false">
-		</label>
-		<div
-			class="tag-chips"
-			aria-label="Available tags in the mock KeePass vault"
-		>
-			{#each tagChoices as tag (tag)}
-				<button
-					type="button"
-					class:active={activeTags.includes(tag)}
-					aria-pressed={activeTags.includes(tag)}
-					onclick={() => toggleTag(tag)}
-				>
-					{tag}
-				</button>
-			{/each}
-		</div>
-	</div>
-
-	<fieldset class="filters">
-		<legend>
-			Filters <HelpMark
-				text="Controls which KeePass entries are omitted."
-				href="/docs#filters"
-			/>
-		</legend>
-		<div class="choice">
-			<label>
-				<input type="checkbox" bind:checked={state.skipExpired}>
-				Skip expired
-			</label>
-			<HelpMark
-				text="Expired entries are imported by default. This omits them."
-				href="/docs#skip-expired"
-			/>
-		</div>
-		<div class="choice">
-			<label>
-				<input type="checkbox" bind:checked={state.includeRecycleBin}>
-				Include Recycle Bin
-			</label>
-			<HelpMark
-				text="Recycle Bin entries are excluded by default."
-				href="/docs#recycle-bin"
-			/>
-		</div>
-	</fieldset>
-
-	<fieldset>
-		<legend>
-			Running again <HelpMark
-				text="Pick the situation you are in when this command hits an existing Bitwarden vault."
-				href="/docs#reruns"
-			/>
-		</legend>
-		{#each reruns as rerun (rerun.value)}
-			<div class="choice">
-				<label>
-					<input
-						type="radio"
-						name="rerun"
-						value={rerun.value}
-						bind:group={state.rerunMode}
-					>
-					{rerun.label}
-				</label>
-				<HelpMark text={rerun.help} href={rerun.href} />
-			</div>
-		{/each}
-	</fieldset>
 </section>
 
 <style>
 	.options {
 		min-width: 0;
-		border: 1px solid #2f372f;
-		background: #151914;
+		border: 1px solid var(--edge);
+		background: var(--panel);
 		padding: 14px;
 	}
 
@@ -302,7 +244,7 @@
 		align-items: center;
 		gap: 6px;
 		margin-bottom: 6px;
-		color: #aab0a3;
+		color: var(--text-muted);
 		font-size: 0.72rem;
 		text-transform: uppercase;
 	}
@@ -314,9 +256,9 @@
 		gap: 8px;
 		justify-content: space-between;
 		min-width: 0;
-		border: 1px solid #2d342d;
+		border: 1px solid var(--edge);
 		padding: 8px;
-		color: #f0ecdc;
+		color: var(--text);
 	}
 
 	.target > label {
@@ -338,15 +280,15 @@
 
 	input[type="radio"],
 	input[type="checkbox"] {
-		accent-color: #8ecf9f;
+		accent-color: var(--accent);
 	}
 
 	input:not([type="radio"]):not([type="checkbox"]) {
 		width: 100%;
 		min-height: 34px;
-		border: 1px solid #303a31;
-		background: #10130f;
-		color: #f0ecdc;
+		border: 1px solid var(--edge);
+		background: var(--field);
+		color: var(--text);
 		padding: 0 8px;
 	}
 
@@ -364,24 +306,24 @@
 
 	.tag-chips button {
 		min-height: 26px;
-		border: 1px solid #303a31;
-		background: #10130f;
-		color: #c7c9bd;
+		border: 1px solid var(--edge);
+		background: var(--field);
+		color: var(--text-dim);
 		padding: 0 8px;
 		font: inherit;
-		font-size: 0.78rem;
+		font-size: var(--fs-small);
 		cursor: pointer;
 	}
 
+	/* Focus is intentionally NOT merged with :hover/.active here: a keyboard
+	   user needs the global :focus-visible ring to tell focus from selected. */
 	.tag-chips button:hover,
-	.tag-chips button:focus-visible,
 	.tag-chips button.active {
-		border-color: #8ecf9f;
-		color: #f0ecdc;
-		outline: none;
+		border-color: var(--accent);
+		color: var(--text);
 	}
 
 	.tag-chips button.active {
-		background: #112016;
+		background: var(--accent-deep);
 	}
 </style>

--- a/docs/src/lib/components/PlannerOptions.svelte
+++ b/docs/src/lib/components/PlannerOptions.svelte
@@ -1,0 +1,387 @@
+<script lang="ts">
+	import { availableTags, selectedTags } from '$lib/planner';
+	import type { Mapping, PlannerState, RerunMode } from '$lib/planner';
+	import HelpMark from './HelpMark.svelte';
+
+	type Choice<T extends string> = {
+		value: T;
+		label: string;
+		help: string;
+		href: `/docs#${string}`;
+	};
+
+	let { state }: { state: PlannerState } = $props();
+
+	const orgMappings: Choice<Mapping>[] = [
+		{
+			value: 'org-nested',
+			label: 'Org collections: full paths',
+			help:
+				'KeePass group Work/Servers becomes organization collection Work/Servers.',
+			href: '/docs#full-path-collections',
+		},
+		{
+			value: 'org-top',
+			label: 'Org collections: top folder only',
+			help:
+				'KeePass Work/Servers and Work/Engineering both land in collection Work.',
+			href: '/docs#top-folder-collections',
+		},
+		{
+			value: 'org-fixed',
+			label: 'One existing collection',
+			help:
+				'Every item lands in the collection ID below. KeePass groups are not recreated.',
+			href: '/docs#single-collection',
+		},
+		{
+			value: 'org-flat',
+			label: 'Flat organization import',
+			help: 'No generated collections and no personal folders.',
+			href: '/docs#flat-org',
+		},
+	];
+
+	const personalMappings: Choice<Mapping>[] = [
+		{
+			value: 'personal-folders',
+			label: 'Personal folders',
+			help: 'KeePass groups become personal Bitwarden folders.',
+			href: '/docs#personal-folders',
+		},
+		{
+			value: 'personal-flat',
+			label: 'Flat personal import',
+			help: 'No Bitwarden folders. Items stay at the personal vault root.',
+			href: '/docs#flat-personal',
+		},
+	];
+
+	const reruns: Choice<RerunMode>[] = [
+		{
+			value: 'keepass-wins',
+			label: 'KeePass is still my main vault',
+			help:
+				'Use KeePass as the source of truth and push it over Bitwarden edits.',
+			href: '/docs#force-update',
+		},
+		{
+			value: 'safe',
+			label: 'Mostly Bitwarden, sync forgotten KeePass edits',
+			help:
+				'Update migrated items when Bitwarden has not been edited since the last kp2bw run.',
+			href: '/docs#safe-rerun',
+		},
+		{
+			value: 'no-update',
+			label: 'Testing migrations; keep the existing Vaultwarden DB',
+			help:
+				'Create missing items only and leave existing migrated Bitwarden items untouched.',
+			href: '/docs#no-update',
+		},
+	];
+
+	let mappings = $derived(
+		state.destination === 'org' ? orgMappings : personalMappings,
+	);
+	const tagChoices = availableTags();
+	let activeTags = $derived(selectedTags(state.tagInput));
+
+	function setDestination(destination: PlannerState['destination']): void {
+		state.destination = destination;
+		state.mapping = destination === 'org' ? 'org-nested' : 'personal-folders';
+	}
+
+	function toggleTag(tag: string): void {
+		const current = selectedTags(state.tagInput);
+		if (current.includes(tag)) {
+			state.tagInput = current.filter((entry) => entry !== tag).join(', ');
+		} else {
+			state.tagInput = [...current, tag].join(', ');
+		}
+	}
+</script>
+
+<section class="options">
+	<fieldset class="target">
+		<legend>
+			Target <HelpMark
+				text="Choose whether items land in an organization or your personal vault."
+				href="/docs#target-vault"
+			/>
+		</legend>
+		<label>
+			<input
+				type="radio"
+				name="destination"
+				checked={state.destination === 'org'}
+				onchange={() => setDestination('org')}
+			>
+			Organization
+		</label>
+		<label>
+			<input
+				type="radio"
+				name="destination"
+				checked={state.destination === 'personal'}
+				onchange={() => setDestination('personal')}
+			>
+			Personal
+		</label>
+	</fieldset>
+
+	{#if state.destination === 'org'}
+		<label class="field">
+			<span>Org ID <HelpMark
+					text="Bitwarden organization ID passed to kp2bw."
+					href="/docs#organization-id"
+				/></span>
+			<input bind:value={state.organizationId} spellcheck="false">
+		</label>
+	{/if}
+
+	<fieldset>
+		<legend>
+			Tree mapping <HelpMark
+				text="Controls how KeePass groups become Bitwarden placement."
+				href="/docs#mapping"
+			/>
+		</legend>
+		{#each mappings as mapping (mapping.value)}
+			<div class="choice">
+				<label>
+					<input
+						type="radio"
+						name="mapping"
+						value={mapping.value}
+						bind:group={state.mapping}
+					>
+					{mapping.label}
+				</label>
+				<HelpMark text={mapping.help} href={mapping.href} />
+			</div>
+		{/each}
+	</fieldset>
+
+	{#if state.mapping === 'org-fixed'}
+		<label class="field">
+			<span>Collection ID <HelpMark
+					text="Existing collection all imported items should land in."
+					href="/docs#collection-id"
+				/></span>
+			<input bind:value={state.collectionId} spellcheck="false">
+		</label>
+	{/if}
+
+	<div class="fields">
+		<label class="field file-field">
+			<span>KeePass file <HelpMark
+					text="Path to the KeePass database."
+					href="/docs#keepass-file"
+				/></span>
+			<input bind:value={state.keepassFile} spellcheck="false">
+		</label>
+		<label class="field file-field">
+			<span>Key file <HelpMark
+					text="Optional KeePass key file."
+					href="/docs#key-file"
+				/></span>
+			<input bind:value={state.keyFile} spellcheck="false">
+		</label>
+		<label class="field tag-field">
+			<span>Tags <HelpMark
+					text="Comma-separated KeePass tags to import. Empty imports all tags."
+					href="/docs#tag-filter"
+				/></span>
+			<input bind:value={state.tagInput} spellcheck="false">
+		</label>
+		<div
+			class="tag-chips"
+			aria-label="Available tags in the mock KeePass vault"
+		>
+			{#each tagChoices as tag (tag)}
+				<button
+					type="button"
+					class:active={activeTags.includes(tag)}
+					aria-pressed={activeTags.includes(tag)}
+					onclick={() => toggleTag(tag)}
+				>
+					{tag}
+				</button>
+			{/each}
+		</div>
+	</div>
+
+	<fieldset class="filters">
+		<legend>
+			Filters <HelpMark
+				text="Controls which KeePass entries are omitted."
+				href="/docs#filters"
+			/>
+		</legend>
+		<div class="choice">
+			<label>
+				<input type="checkbox" bind:checked={state.skipExpired}>
+				Skip expired
+			</label>
+			<HelpMark
+				text="Expired entries are imported by default. This omits them."
+				href="/docs#skip-expired"
+			/>
+		</div>
+		<div class="choice">
+			<label>
+				<input type="checkbox" bind:checked={state.includeRecycleBin}>
+				Include Recycle Bin
+			</label>
+			<HelpMark
+				text="Recycle Bin entries are excluded by default."
+				href="/docs#recycle-bin"
+			/>
+		</div>
+	</fieldset>
+
+	<fieldset>
+		<legend>
+			Running again <HelpMark
+				text="Pick the situation you are in when this command hits an existing Bitwarden vault."
+				href="/docs#reruns"
+			/>
+		</legend>
+		{#each reruns as rerun (rerun.value)}
+			<div class="choice">
+				<label>
+					<input
+						type="radio"
+						name="rerun"
+						value={rerun.value}
+						bind:group={state.rerunMode}
+					>
+					{rerun.label}
+				</label>
+				<HelpMark text={rerun.help} href={rerun.href} />
+			</div>
+		{/each}
+	</fieldset>
+</section>
+
+<style>
+	.options {
+		min-width: 0;
+		border: 1px solid #2f372f;
+		background: #151914;
+		padding: 14px;
+	}
+
+	fieldset,
+	.fields {
+		display: grid;
+		gap: 8px;
+		margin: 0 0 14px;
+		border: 0;
+		padding: 0;
+	}
+
+	.target {
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+	}
+
+	.target legend,
+	.filters legend {
+		grid-column: 1 / -1;
+	}
+
+	.fields,
+	.filters {
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+	}
+
+	legend,
+	.field > span {
+		display: flex;
+		align-items: center;
+		gap: 6px;
+		margin-bottom: 6px;
+		color: #aab0a3;
+		font-size: 0.72rem;
+		text-transform: uppercase;
+	}
+
+	fieldset > label:not(.field),
+	.choice {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+		justify-content: space-between;
+		min-width: 0;
+		border: 1px solid #2d342d;
+		padding: 8px;
+		color: #f0ecdc;
+	}
+
+	.target > label {
+		min-height: 34px;
+		padding: 6px 8px;
+	}
+
+	.filters .choice {
+		min-height: 34px;
+		padding: 6px 8px;
+	}
+
+	.choice label {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+		min-width: 0;
+	}
+
+	input[type="radio"],
+	input[type="checkbox"] {
+		accent-color: #8ecf9f;
+	}
+
+	input:not([type="radio"]):not([type="checkbox"]) {
+		width: 100%;
+		min-height: 34px;
+		border: 1px solid #303a31;
+		background: #10130f;
+		color: #f0ecdc;
+		padding: 0 8px;
+	}
+
+	.tag-field,
+	.tag-chips {
+		grid-column: 1 / -1;
+	}
+
+	.tag-chips {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 6px;
+		margin-top: -4px;
+	}
+
+	.tag-chips button {
+		min-height: 26px;
+		border: 1px solid #303a31;
+		background: #10130f;
+		color: #c7c9bd;
+		padding: 0 8px;
+		font: inherit;
+		font-size: 0.78rem;
+		cursor: pointer;
+	}
+
+	.tag-chips button:hover,
+	.tag-chips button:focus-visible,
+	.tag-chips button.active {
+		border-color: #8ecf9f;
+		color: #f0ecdc;
+		outline: none;
+	}
+
+	.tag-chips button.active {
+		background: #112016;
+	}
+</style>

--- a/docs/src/lib/components/TreeLegend.svelte
+++ b/docs/src/lib/components/TreeLegend.svelte
@@ -12,7 +12,7 @@
 		justify-content: center;
 		gap: 6px 12px;
 		min-height: 22px;
-		color: #c7c9bd;
+		color: var(--text-dim);
 		font-size: 0.68rem;
 		line-height: 1;
 	}
@@ -50,19 +50,19 @@
 		height: 3px;
 		border: 1px solid #d2b56f;
 		border-bottom: 0;
-		background: #111411;
+		background: var(--bg);
 	}
 
 	.collection {
 		width: 11px;
 		height: 11px;
-		border-color: #8ecf9f;
+		border-color: var(--accent);
 		background: #101d16;
 	}
 
 	.collection::before {
 		inset: 2px;
-		border: 1px solid #8ecf9f;
+		border: 1px solid var(--accent);
 	}
 
 	.collection::after {
@@ -70,8 +70,11 @@
 		left: -3px;
 		width: 2px;
 		height: 2px;
-		background: #8ecf9f;
-		box-shadow: 13px 0 0 #8ecf9f, 6px -5px 0 #8ecf9f, 6px 5px 0 #8ecf9f;
+		background: var(--accent);
+		box-shadow:
+			13px 0 0 var(--accent),
+			6px -5px 0 var(--accent),
+			6px 5px 0 var(--accent);
 	}
 
 	.recycle {
@@ -86,7 +89,7 @@
 		width: 13px;
 		height: 2px;
 		border: 1px solid #d48670;
-		background: #111411;
+		background: var(--bg);
 	}
 
 	.recycle::after {

--- a/docs/src/lib/components/TreeLegend.svelte
+++ b/docs/src/lib/components/TreeLegend.svelte
@@ -1,0 +1,100 @@
+<div class="legend" aria-label="Tree legend">
+	<span><i class="icon folder"></i>Folder</span>
+	<span><i class="icon collection"></i>Collection</span>
+	<span><i class="icon recycle"></i>Recycle Bin</span>
+</div>
+
+<style>
+	.legend {
+		display: flex;
+		flex-wrap: wrap;
+		align-items: center;
+		justify-content: center;
+		gap: 6px 12px;
+		min-height: 22px;
+		color: #c7c9bd;
+		font-size: 0.68rem;
+		line-height: 1;
+	}
+
+	.legend > span {
+		display: inline-flex;
+		align-items: center;
+		gap: 5px;
+		white-space: nowrap;
+	}
+
+	.icon {
+		position: relative;
+		display: inline-block;
+		width: 11px;
+		height: 10px;
+		border: 1px solid #95a195;
+	}
+
+	.icon::before,
+	.icon::after {
+		position: absolute;
+		content: "";
+	}
+
+	.folder {
+		border-color: #d2b56f;
+		background: #211d12;
+	}
+
+	.folder::before {
+		top: -4px;
+		left: 1px;
+		width: 6px;
+		height: 3px;
+		border: 1px solid #d2b56f;
+		border-bottom: 0;
+		background: #111411;
+	}
+
+	.collection {
+		width: 11px;
+		height: 11px;
+		border-color: #8ecf9f;
+		background: #101d16;
+	}
+
+	.collection::before {
+		inset: 2px;
+		border: 1px solid #8ecf9f;
+	}
+
+	.collection::after {
+		top: 4px;
+		left: -3px;
+		width: 2px;
+		height: 2px;
+		background: #8ecf9f;
+		box-shadow: 13px 0 0 #8ecf9f, 6px -5px 0 #8ecf9f, 6px 5px 0 #8ecf9f;
+	}
+
+	.recycle {
+		border-color: #d48670;
+		border-radius: 0 0 3px 3px;
+		background: #251713;
+	}
+
+	.recycle::before {
+		top: -4px;
+		left: -2px;
+		width: 13px;
+		height: 2px;
+		border: 1px solid #d48670;
+		background: #111411;
+	}
+
+	.recycle::after {
+		top: 3px;
+		left: 3px;
+		width: 1px;
+		height: 5px;
+		background: #d48670;
+		box-shadow: 3px 0 0 #d48670;
+	}
+</style>

--- a/docs/src/lib/components/TreeLegend.svelte
+++ b/docs/src/lib/components/TreeLegend.svelte
@@ -39,8 +39,8 @@
 	}
 
 	.folder {
-		border-color: #d2b56f;
-		background: #211d12;
+		border-color: var(--icon-folder);
+		background: var(--icon-folder-bg);
 	}
 
 	.folder::before {
@@ -48,7 +48,7 @@
 		left: 1px;
 		width: 6px;
 		height: 3px;
-		border: 1px solid #d2b56f;
+		border: 1px solid var(--icon-folder);
 		border-bottom: 0;
 		background: var(--bg);
 	}
@@ -56,13 +56,13 @@
 	.collection {
 		width: 11px;
 		height: 11px;
-		border-color: var(--accent);
-		background: #101d16;
+		border-color: var(--icon-collection);
+		background: var(--icon-collection-bg);
 	}
 
 	.collection::before {
 		inset: 2px;
-		border: 1px solid var(--accent);
+		border: 1px solid var(--icon-collection);
 	}
 
 	.collection::after {
@@ -70,17 +70,17 @@
 		left: -3px;
 		width: 2px;
 		height: 2px;
-		background: var(--accent);
+		background: var(--icon-collection);
 		box-shadow:
-			13px 0 0 var(--accent),
-			6px -5px 0 var(--accent),
-			6px 5px 0 var(--accent);
+			13px 0 0 var(--icon-collection),
+			6px -5px 0 var(--icon-collection),
+			6px 5px 0 var(--icon-collection);
 	}
 
 	.recycle {
-		border-color: #d48670;
+		border-color: var(--icon-recycle);
 		border-radius: 0 0 3px 3px;
-		background: #251713;
+		background: var(--icon-recycle-bg);
 	}
 
 	.recycle::before {
@@ -88,7 +88,7 @@
 		left: -2px;
 		width: 13px;
 		height: 2px;
-		border: 1px solid #d48670;
+		border: 1px solid var(--icon-recycle);
 		background: var(--bg);
 	}
 
@@ -97,7 +97,7 @@
 		left: 3px;
 		width: 1px;
 		height: 5px;
-		background: #d48670;
-		box-shadow: 3px 0 0 #d48670;
+		background: var(--icon-recycle);
+		box-shadow: 3px 0 0 var(--icon-recycle);
 	}
 </style>

--- a/docs/src/lib/index.ts
+++ b/docs/src/lib/index.ts
@@ -1,0 +1,1 @@
+// place files you want to import through the `$lib` alias in this folder.

--- a/docs/src/lib/planner.spec.ts
+++ b/docs/src/lib/planner.spec.ts
@@ -77,6 +77,15 @@ describe('planner', () => {
 		);
 	});
 
+	it('escapes backslashes before quotes in command arguments', () => {
+		expect(
+			commandForState({
+				...defaultPlannerState,
+				keepassFile: String.raw`C:\Vaults\test\".kdbx`,
+			}),
+		).toBe(String.raw`kp2bw "C:\\Vaults\\test\\\".kdbx"`);
+	});
+
 	it('maps top-level organization collections', () => {
 		const state = {
 			...orgState,

--- a/docs/src/lib/planner.spec.ts
+++ b/docs/src/lib/planner.spec.ts
@@ -1,0 +1,234 @@
+import { describe, expect, it } from 'vitest';
+import {
+	availableTags,
+	bitwardenTree,
+	buildMigrationPlan,
+	commandForState,
+	defaultPlannerState,
+	deltaForItem,
+	envFileForState,
+	filteredItems,
+	previewFixture,
+	previewForState,
+	sampleOrganizationId,
+	sourceTree,
+} from './planner';
+import type { PreviewNode } from './planner';
+
+describe('planner', () => {
+	it('defaults to nested organization collections without personal folders', () => {
+		expect(defaultPlannerState).toMatchObject({
+			destination: 'org',
+			mapping: 'org-nested',
+			keepassFile: 'vault.kdbx',
+			organizationId: sampleOrganizationId,
+		});
+		expect(bitwardenTree(defaultPlannerState).map((node) => node.name)).toEqual([
+			'My vault',
+			'Organization vault',
+		]);
+		expect(bitwardenTree(defaultPlannerState)[0]).toMatchObject({
+			name: 'My vault',
+			count: 0,
+			children: [expect.objectContaining({ name: 'No personal folders created' })],
+		});
+		expect(bitwardenTree(defaultPlannerState)[1]).toMatchObject({
+			name: 'Organization vault',
+			children: [
+				{
+					name: 'Collections',
+					children: expect.arrayContaining([
+						expect.objectContaining({ name: 'Work', kind: 'collection' }),
+					]),
+				},
+			],
+		});
+	});
+
+	it('builds an organization command from state values', () => {
+		const state = {
+			...defaultPlannerState,
+			organizationId: '22222222-2222-2222-2222-222222222222',
+			keepassFile: 'source vault.kdbx',
+		};
+
+		expect(commandForState(state)).toBe(
+			'kp2bw -o 22222222-2222-2222-2222-222222222222 -c nested --no-folder "source vault.kdbx"',
+		);
+	});
+
+	it('maps top-level organization collections', () => {
+		const state = {
+			...defaultPlannerState,
+			mapping: 'org-top' as const,
+			keepassFile: 'source.kdbx',
+		};
+
+		expect(commandForState(state)).toBe(
+			`kp2bw -o ${sampleOrganizationId} -c auto --no-folder source.kdbx`,
+		);
+		const collections = bitwardenTree(state)[1]?.children[0]?.children;
+		expect(collections?.find((node) => node.name === 'Work')?.count).toBe(4);
+	});
+
+	it('shows both Bitwarden scopes for personal imports too', () => {
+		const state = {
+			...defaultPlannerState,
+			destination: 'personal' as const,
+			mapping: 'personal-folders' as const,
+		};
+
+		expect(bitwardenTree(state).map((node) => node.name)).toEqual([
+			'My vault',
+			'Organization vault',
+		]);
+		expect(bitwardenTree(state)[0]?.children[0]).toMatchObject({
+			name: 'Folders',
+			children: expect.arrayContaining([
+				expect.objectContaining({ name: 'Work', kind: 'folder' }),
+			]),
+		});
+		expect(bitwardenTree(state)[1]).toMatchObject({
+			name: 'Organization vault',
+			count: 0,
+			children: [expect.objectContaining({ name: 'No organization changes' })],
+		});
+	});
+
+	it('builds both trees from the same preview fixture', () => {
+		const preview = previewForState(defaultPlannerState);
+
+		expect(preview.items).toEqual(filteredItems(defaultPlannerState, previewFixture.keepass));
+		expect(preview.keepass[0]?.count).toBe(previewFixture.keepass.length);
+		expect(preview.bitwarden.map((node) => node.name)).toEqual([
+			'My vault',
+			'Organization vault',
+		]);
+	});
+
+	it('discovers tag choices from the source fixture', () => {
+		expect(availableTags()).toEqual(['admin', 'dev', 'finance', 'hr', 'legacy', 'ops']);
+	});
+
+	it('derives item state from KeePass and Bitwarden revisions', () => {
+		const byName = new Map(previewFixture.keepass.map((item) => [item.name, item]));
+
+		// Fixture state must come from side-specific inventories, not precomputed sync labels.
+		expect(previewFixture.keepass.some((item) => 'bitwarden' in item || 'sync' in item)).toBe(false);
+		expect(deltaForItem(byName.get('Root Admin')!)).toBe('new-in-keepass');
+		expect(deltaForItem(byName.get('Stripe')!)).toBe('unchanged');
+		expect(deltaForItem(byName.get('Payroll')!)).toBe('keepass-changed');
+		expect(deltaForItem(byName.get('Production SSH')!)).toBe('bitwarden-changed');
+		expect(deltaForItem(byName.get('GitHub')!)).toBe('both-changed');
+	});
+
+	it('keeps skipped entries visible and marks them skipped in Bitwarden', () => {
+		const preview = previewForState({
+			...defaultPlannerState,
+			skipExpired: true,
+		});
+
+		expect(treeNames(preview.keepass)).toContain('Archive Box');
+		expect(treeNames(preview.bitwarden)).toContain('Archive Box');
+		expect(findTreeNode(preview.keepass, 'Archive Box')?.action).toBeUndefined();
+		expect(findTreeNode(preview.keepass, 'Archive Box')?.muted).toBeUndefined();
+		expect(findTreeNode(preview.bitwarden, 'Archive Box')?.action).toBe('skip');
+		expect(preview.stats.items).toBe(filteredItems({ ...defaultPlannerState, skipExpired: true }).length);
+	});
+
+	it('keeps Recycle Bin visible in KeePass while excluding it from Bitwarden by default', () => {
+		const preview = previewForState(defaultPlannerState);
+		const withRecycleBin = previewForState({
+			...defaultPlannerState,
+			includeRecycleBin: true,
+		});
+
+		expect(treeNames(preview.keepass)).toContain('Recycle Bin');
+		expect(treeNames(preview.keepass)).toContain('Old SaaS');
+		expect(treeNames(preview.bitwarden)).toContain('Old SaaS');
+		expect(lastNode(preview.keepass[0]?.children)).toMatchObject({
+			name: 'Recycle Bin',
+			kind: 'recycle',
+		});
+		expect(lastNode(preview.bitwarden[1]?.children[0]?.children)).toMatchObject({
+			name: 'Recycle Bin',
+			kind: 'recycle',
+		});
+		expect(findTreeNode(preview.bitwarden, 'Old SaaS')?.action).toBe('skip');
+		expect(treeNames(withRecycleBin.bitwarden)).toContain('Old SaaS');
+		expect(findTreeNode(withRecycleBin.bitwarden, 'Old SaaS')?.action).toBe('create');
+		expect(findTreeNode(withRecycleBin.keepass, 'Old SaaS')?.action).toBeUndefined();
+		expect(findTreeNode(withRecycleBin.bitwarden, 'Retired Jira')?.action).toBe('update');
+		expect(findTreeNode(preview.bitwarden, 'Deprecated VPN')?.action).toBe('protected');
+		expect(treeNames(findTreeNode(preview.bitwarden, 'Recycle Bin')?.children ?? []))
+			.toContain('Deprecated VPN');
+	});
+
+	it('plans rerun protection and selected resolutions like the converter', () => {
+		const safe = previewForState(defaultPlannerState);
+		const keepassWins = previewForState({
+			...defaultPlannerState,
+			rerunMode: 'keepass-wins',
+		});
+		const noUpdate = previewForState({
+			...defaultPlannerState,
+			rerunMode: 'no-update',
+		});
+
+		expect(findTreeNode(safe.bitwarden, 'GitHub')?.action).toBe('protected');
+		expect(findTreeNode(safe.bitwarden, 'Production SSH')?.action).toBe('protected');
+		expect(findTreeNode(keepassWins.bitwarden, 'GitHub')?.action).toBe('overwrite');
+		expect(findTreeNode(noUpdate.bitwarden, 'GitHub')?.action).toBe('left-alone');
+	});
+
+	it('keeps target actions out of the KeePass source tree', () => {
+		const preview = previewForState({
+			...defaultPlannerState,
+			includeRecycleBin: true,
+		});
+
+		expect(findTreeNode(preview.keepass, 'Old SaaS')?.action).toBeUndefined();
+		expect(findTreeNode(preview.keepass, 'Retired Jira')?.action).toBeUndefined();
+		const oldSaasPlan = buildMigrationPlan(defaultPlannerState).find((item) => item.source.name === 'Old SaaS');
+
+		expect(oldSaasPlan).toMatchObject({
+			action: 'skip',
+			exclusionReason: 'recycle-bin',
+		});
+	});
+
+	it('filters imports and keeps the KeePass source tree unchanged', () => {
+		const state = {
+			...defaultPlannerState,
+			tagInput: 'finance',
+			skipExpired: true,
+		};
+
+		expect(filteredItems(state).map((item) => item.name)).toEqual(['Stripe', 'Payroll']);
+		expect(sourceTree()[0]?.children.map((node) => node.name)).toContain('Recycle Bin');
+		expect(commandForState(state)).toContain('-t finance --skip-expired');
+	});
+
+	it('uses a .env block for credentials', () => {
+		expect(envFileForState()).toBe(
+			'KP2BW_KEEPASS_PASSWORD=<keepass password>\nKP2BW_BITWARDEN_PASSWORD=<bitwarden password>',
+		);
+	});
+});
+
+function treeNames(nodes: PreviewNode[]): string[] {
+	return nodes.flatMap((node) => [node.name, ...treeNames(node.children)]);
+}
+
+function findTreeNode(nodes: PreviewNode[], name: string): PreviewNode | undefined {
+	for (const node of nodes) {
+		if (node.name === name) return node;
+		const child = findTreeNode(node.children, name);
+		if (child) return child;
+	}
+	return undefined;
+}
+
+function lastNode(nodes: PreviewNode[] | undefined): PreviewNode | undefined {
+	return nodes?.[nodes.length - 1];
+}

--- a/docs/src/lib/planner.spec.ts
+++ b/docs/src/lib/planner.spec.ts
@@ -3,6 +3,7 @@ import {
 	availableTags,
 	bitwardenTree,
 	buildMigrationPlan,
+	commandDisplayForState,
 	commandForState,
 	defaultPlannerState,
 	deltaForItem,
@@ -11,28 +12,47 @@ import {
 	previewFixture,
 	previewForState,
 	sampleOrganizationId,
+	sanitizePlannerState,
 	sourceTree,
 } from './planner';
 import type { PreviewNode } from './planner';
 
+// The default is now a personal import (mirrors `kp2bw vault.kdbx` with no -o);
+// org-specific behaviour is exercised from this explicit baseline.
+const orgState = {
+	...defaultPlannerState,
+	destination: 'org' as const,
+	mapping: 'org-nested' as const,
+};
+
 describe('planner', () => {
-	it('defaults to nested organization collections without personal folders', () => {
+	it('defaults to a personal-vault import with folders', () => {
 		expect(defaultPlannerState).toMatchObject({
-			destination: 'org',
-			mapping: 'org-nested',
+			destination: 'personal',
+			mapping: 'personal-folders',
 			keepassFile: 'vault.kdbx',
-			organizationId: sampleOrganizationId,
 		});
-		expect(bitwardenTree(defaultPlannerState).map((node) => node.name)).toEqual([
+		const [myVault, orgVault] = bitwardenTree(defaultPlannerState);
+		expect(myVault).toMatchObject({ name: 'My vault' });
+		expect(myVault?.children[0]).toMatchObject({ name: 'Folders' });
+		expect(orgVault).toMatchObject({
+			name: 'Organization vault',
+			count: 0,
+			children: [expect.objectContaining({ name: 'No organization changes' })],
+		});
+	});
+
+	it('builds nested organization collections without personal folders', () => {
+		expect(bitwardenTree(orgState).map((node) => node.name)).toEqual([
 			'My vault',
 			'Organization vault',
 		]);
-		expect(bitwardenTree(defaultPlannerState)[0]).toMatchObject({
+		expect(bitwardenTree(orgState)[0]).toMatchObject({
 			name: 'My vault',
 			count: 0,
 			children: [expect.objectContaining({ name: 'No personal folders created' })],
 		});
-		expect(bitwardenTree(defaultPlannerState)[1]).toMatchObject({
+		expect(bitwardenTree(orgState)[1]).toMatchObject({
 			name: 'Organization vault',
 			children: [
 				{
@@ -47,25 +67,25 @@ describe('planner', () => {
 
 	it('builds an organization command from state values', () => {
 		const state = {
-			...defaultPlannerState,
+			...orgState,
 			organizationId: '22222222-2222-2222-2222-222222222222',
 			keepassFile: 'source vault.kdbx',
 		};
 
 		expect(commandForState(state)).toBe(
-			'kp2bw -o 22222222-2222-2222-2222-222222222222 -c nested --no-folder "source vault.kdbx"',
+			'kp2bw -o 22222222-2222-2222-2222-222222222222 -c nested "source vault.kdbx"',
 		);
 	});
 
 	it('maps top-level organization collections', () => {
 		const state = {
-			...defaultPlannerState,
+			...orgState,
 			mapping: 'org-top' as const,
 			keepassFile: 'source.kdbx',
 		};
 
 		expect(commandForState(state)).toBe(
-			`kp2bw -o ${sampleOrganizationId} -c auto --no-folder source.kdbx`,
+			`kp2bw -o ${sampleOrganizationId} -c auto source.kdbx`,
 		);
 		const collections = bitwardenTree(state)[1]?.children[0]?.children;
 		expect(collections?.find((node) => node.name === 'Work')?.count).toBe(4);
@@ -125,7 +145,7 @@ describe('planner', () => {
 	it('keeps skipped entries visible and marks them skipped in Bitwarden', () => {
 		const preview = previewForState({
 			...defaultPlannerState,
-			skipExpired: true,
+			includeExpired: false,
 		});
 
 		expect(treeNames(preview.keepass)).toContain('Archive Box');
@@ -133,13 +153,13 @@ describe('planner', () => {
 		expect(findTreeNode(preview.keepass, 'Archive Box')?.action).toBeUndefined();
 		expect(findTreeNode(preview.keepass, 'Archive Box')?.muted).toBeUndefined();
 		expect(findTreeNode(preview.bitwarden, 'Archive Box')?.action).toBe('skip');
-		expect(preview.stats.items).toBe(filteredItems({ ...defaultPlannerState, skipExpired: true }).length);
+		expect(preview.stats.items).toBe(filteredItems({ ...defaultPlannerState, includeExpired: false }).length);
 	});
 
 	it('keeps Recycle Bin visible in KeePass while excluding it from Bitwarden by default', () => {
-		const preview = previewForState(defaultPlannerState);
+		const preview = previewForState(orgState);
 		const withRecycleBin = previewForState({
-			...defaultPlannerState,
+			...orgState,
 			includeRecycleBin: true,
 		});
 
@@ -201,12 +221,104 @@ describe('planner', () => {
 		const state = {
 			...defaultPlannerState,
 			tagInput: 'finance',
-			skipExpired: true,
+			includeExpired: false,
 		};
 
 		expect(filteredItems(state).map((item) => item.name)).toEqual(['Stripe', 'Payroll']);
 		expect(sourceTree()[0]?.children.map((node) => node.name)).toContain('Recycle Bin');
 		expect(commandForState(state)).toContain('-t finance --skip-expired');
+	});
+
+	it('adds --folder and a personal folder tree when org folders are enabled', () => {
+		const state = { ...orgState, orgFolders: true };
+
+		expect(commandForState(state)).toContain('-c nested --folder');
+
+		const [myVault, orgVault] = bitwardenTree(state);
+		expect(myVault).toMatchObject({ name: 'My vault' });
+		expect(myVault?.count).toBeGreaterThan(0);
+		expect(myVault?.children[0]).toMatchObject({ name: 'Folders' });
+		// --folder double-files: collections stay populated alongside folders.
+		expect(orgVault?.count).toBe(myVault?.count);
+	});
+
+	it('omits --folder for org imports unless opted in', () => {
+		const command = commandForState(orgState);
+		expect(command).not.toContain('--folder');
+		expect(bitwardenTree(orgState)[0]?.children[0]).toMatchObject({
+			name: 'No personal folders created',
+		});
+	});
+
+	it('treats the Expired filter as inclusion with the CLI default on', () => {
+		// Default keeps expired (no --skip-expired); unticking adds the flag.
+		expect(defaultPlannerState.includeExpired).toBe(true);
+		expect(commandForState(defaultPlannerState)).not.toContain('--skip-expired');
+		expect(
+			commandForState({ ...defaultPlannerState, includeExpired: false }),
+		).toContain('--skip-expired');
+	});
+
+	it('ends option parsing with -- so a trailing tag filter cannot swallow the file', () => {
+		// -t is nargs="+"; without -- argparse would read vault.kdbx as a tag.
+		const state = { ...defaultPlannerState, tagInput: 'ops' };
+		const command = commandForState(state);
+
+		expect(command).toContain('-t ops -- vault.kdbx');
+		expect(command.endsWith('-- vault.kdbx')).toBe(true);
+	});
+
+	it('omits the -- separator when no tag filter is set', () => {
+		expect(commandForState(defaultPlannerState)).not.toContain(' -- ');
+	});
+
+	it('keeps a short command on one line but wraps a long one with backslashes', () => {
+		expect(commandDisplayForState(defaultPlannerState)).not.toContain('\n');
+
+		const long = commandDisplayForState({
+			...defaultPlannerState,
+			tagInput: 'admin, dev, finance, hr, legacy, ops',
+			includeRecycleBin: true,
+			rerunMode: 'keepass-wins',
+		});
+		expect(long).toContain(' \\\n  ');
+		// Joining the wrapped lines back must reproduce the one-line command.
+		expect(long.replaceAll(' \\\n  ', ' ')).toBe(
+			commandForState({
+				...defaultPlannerState,
+				tagInput: 'admin, dev, finance, hr, legacy, ops',
+				includeRecycleBin: true,
+				rerunMode: 'keepass-wins',
+			}),
+		);
+	});
+
+	it('sanitizes persisted state: keeps valid values, repairs junk and mismatches', () => {
+		const custom = {
+			...defaultPlannerState,
+			destination: 'personal' as const,
+			mapping: 'personal-flat' as const,
+			tagInput: 'ops',
+			includeExpired: false,
+		};
+		expect(sanitizePlannerState(custom)).toEqual(custom);
+
+		// Non-objects and unknown/wrong-typed fields fall back to defaults.
+		expect(sanitizePlannerState(null)).toEqual(defaultPlannerState);
+		expect(sanitizePlannerState('nope')).toEqual(defaultPlannerState);
+		expect(
+			sanitizePlannerState({ destination: 'mars', includeExpired: 'yes' }),
+		).toMatchObject({
+			destination: defaultPlannerState.destination,
+			includeExpired: true,
+		});
+
+		// A mapping that doesn't belong to the destination is reset to that
+		// destination's default so the radio group is never left unselected.
+		expect(
+			sanitizePlannerState({ destination: 'personal', mapping: 'org-nested' })
+				.mapping,
+		).toBe('personal-folders');
 	});
 
 	it('uses a .env block for credentials', () => {

--- a/docs/src/lib/planner.ts
+++ b/docs/src/lib/planner.ts
@@ -1,0 +1,527 @@
+import previewFixtureData from './preview-fixture.json';
+
+export type Destination = 'org' | 'personal';
+export type Mapping =
+	| 'org-nested'
+	| 'org-top'
+	| 'org-fixed'
+	| 'org-flat'
+	| 'personal-folders'
+	| 'personal-flat';
+export type RerunMode = 'safe' | 'no-update' | 'keepass-wins';
+export type ItemDelta =
+	| 'new-in-keepass'
+	| 'unchanged'
+	| 'keepass-changed'
+	| 'bitwarden-changed'
+	| 'both-changed';
+export type PreviewAction =
+	| 'create'
+	| 'update'
+	| 'protected'
+	| 'overwrite'
+	| 'left-alone'
+	| 'unchanged'
+	| 'skip';
+export type ExclusionReason = 'tag-filter' | 'expired' | 'recycle-bin';
+
+export type KeePassEntry = {
+	id: string;
+	name: string;
+	group: string | null;
+	tags: string[];
+	keepassRevision: string;
+	expired?: boolean;
+	recycle?: boolean;
+	attachments?: number;
+	passkey?: boolean;
+};
+
+export type BitwardenItem = {
+	id: string;
+	kp2bwId: string;
+	name: string;
+	group: string | null;
+	syncedKeePassRevision: string;
+	syncedBitwardenRevision: string;
+	currentBitwardenRevision: string;
+	recycle?: boolean;
+	attachments?: number;
+	passkey?: boolean;
+	type?: 'login' | 'note' | 'card' | 'identity';
+};
+
+export type PlannerState = {
+	destination: Destination;
+	mapping: Mapping;
+	keepassFile: string;
+	keyFile: string;
+	organizationId: string;
+	collectionId: string;
+	tagInput: string;
+	skipExpired: boolean;
+	includeRecycleBin: boolean;
+	rerunMode: RerunMode;
+};
+
+export type PreviewFixture = {
+	name: string;
+	keepass: KeePassEntry[];
+	bitwarden: BitwardenItem[];
+};
+
+export type PreviewNode = {
+	name: string;
+	kind: 'root' | 'folder' | 'collection' | 'recycle' | 'bucket' | 'item' | 'empty';
+	count?: number;
+	delta?: ItemDelta;
+	action?: PreviewAction;
+	muted?: boolean;
+	children: PreviewNode[];
+};
+
+export type PlannedItem = {
+	source: KeePassEntry;
+	existing?: BitwardenItem;
+	included: boolean;
+	exclusionReason?: ExclusionReason;
+	delta: ItemDelta;
+	action: PreviewAction;
+	sourcePath: string;
+	targetPath: string;
+};
+
+export type MigrationPreview = {
+	items: KeePassEntry[];
+	plan: PlannedItem[];
+	keepass: PreviewNode[];
+	bitwarden: PreviewNode[];
+	stats: ReturnType<typeof statsForState>;
+};
+
+export const previewFixture: PreviewFixture = previewFixtureData;
+export const samples = previewFixture.keepass;
+export const sampleOrganizationId = '00000000-0000-0000-0000-000000000000';
+export const sampleCollectionId = '11111111-1111-1111-1111-111111111111';
+
+export const defaultPlannerState: PlannerState = {
+	destination: 'org',
+	mapping: 'org-nested',
+	keepassFile: 'vault.kdbx',
+	keyFile: '',
+	organizationId: sampleOrganizationId,
+	collectionId: sampleCollectionId,
+	tagInput: '',
+	skipExpired: false,
+	includeRecycleBin: false,
+	rerunMode: 'safe',
+};
+
+export function selectedTags(tagInput: string): string[] {
+	return tagInput.split(',').map((tag) => tag.trim()).filter(Boolean);
+}
+
+export function availableTags(items = samples): string[] {
+	return [...new Set(items.flatMap((item) => item.tags))].sort((a, b) => a.localeCompare(b));
+}
+
+export function filteredItems(state: PlannerState, items = samples): KeePassEntry[] {
+	return items.filter((item) => itemIncluded(state, item));
+}
+
+export function itemIncluded(state: PlannerState, item: KeePassEntry): boolean {
+	return exclusionReasonForItem(state, item) === undefined;
+}
+
+export function exclusionReasonForItem(
+	state: PlannerState,
+	item: KeePassEntry,
+): ExclusionReason | undefined {
+	const tags = selectedTags(state.tagInput);
+	if (!state.includeRecycleBin && item.recycle) return 'recycle-bin';
+	if (state.skipExpired && item.expired) return 'expired';
+	if (tags.length > 0 && !tags.some((tag) => item.tags.includes(tag))) {
+		return 'tag-filter';
+	}
+	return undefined;
+}
+
+export function deltaForItem(
+	item: KeePassEntry,
+	existing = existingForEntry(item),
+): ItemDelta {
+	if (!existing) return 'new-in-keepass';
+	const keepassChanged = item.keepassRevision !== existing.syncedKeePassRevision;
+	const bitwardenChanged = existing.currentBitwardenRevision !== existing.syncedBitwardenRevision;
+	if (keepassChanged && bitwardenChanged) return 'both-changed';
+	if (keepassChanged) return 'keepass-changed';
+	if (bitwardenChanged) return 'bitwarden-changed';
+	return 'unchanged';
+}
+
+export function actionForState(state: PlannerState, item: KeePassEntry): PreviewAction {
+	const existing = existingForEntry(item);
+	const included = itemIncluded(state, item);
+	return reconcileExisting(state, item, existing, included);
+}
+
+export function buildMigrationPlan(
+	state: PlannerState,
+	fixture = previewFixture,
+): PlannedItem[] {
+	const existingByKpId = new Map(fixture.bitwarden.map((item) => [item.kp2bwId, item]));
+	return fixture.keepass.map((source) => {
+		const existing = existingByKpId.get(source.id);
+		const exclusionReason = exclusionReasonForItem(state, source);
+		const included = exclusionReason === undefined;
+		const delta = deltaForItem(source, existing);
+		const action = reconcileExisting(state, source, existing, included);
+		return {
+			source,
+			existing,
+			included,
+			exclusionReason,
+			delta,
+			action,
+			sourcePath: source.group ?? 'Vault root',
+			targetPath: targetPathForPlan(source, existing, action),
+		};
+	});
+}
+
+export function previewForState(
+	state: PlannerState,
+	fixture = previewFixture,
+): MigrationPreview {
+	const plan = buildMigrationPlan(state, fixture);
+	const items = plan.filter((item) => item.included).map((item) => item.source);
+	return {
+		items,
+		plan,
+		keepass: sourceTree(state, fixture),
+		bitwarden: bitwardenTree(state, fixture),
+		stats: statsForState(state, items),
+	};
+}
+
+export function sourceTree(
+	state = defaultPlannerState,
+	fixture = previewFixture,
+): PreviewNode[] {
+	const plan = buildMigrationPlan(state, fixture);
+	return [
+		{
+			name: fixture.name,
+			kind: 'root',
+			count: fixture.keepass.length,
+			children: treeWithItems(
+				plan,
+				(item) => item.sourcePath,
+				'folder',
+				(item) => ({
+					delta: item.delta,
+				}),
+				() => true,
+			),
+		},
+	];
+}
+
+export function bitwardenTree(
+	state: PlannerState,
+	fixtureOrItems: PreviewFixture | KeePassEntry[] = previewFixture,
+): PreviewNode[] {
+	const fixture = Array.isArray(fixtureOrItems)
+		? { ...previewFixture, keepass: fixtureOrItems }
+		: fixtureOrItems;
+	const plan = buildMigrationPlan(state, fixture);
+	const importableCount = plan.filter((item) => item.included).length;
+
+	if (state.destination === 'personal') {
+		return [
+			{
+				name: 'My vault',
+				kind: 'root',
+				count: importableCount,
+				children: state.mapping === 'personal-folders'
+					? [
+						{
+							name: 'Folders',
+							kind: 'bucket',
+							count: importableCount,
+							children: treeWithItems(
+								plan,
+								(item) => item.targetPath,
+								'folder',
+								targetLeafState,
+							),
+						},
+					]
+					: [flatBucket('No folder', plan)],
+			},
+			{
+				name: 'Organization vault',
+				kind: 'root',
+				count: 0,
+				children: [emptyNode('No organization changes')],
+			},
+		];
+	}
+
+	const collectionChildren = (() => {
+		if (state.mapping === 'org-nested') {
+			return treeWithItems(
+				plan,
+				(item) => item.targetPath,
+				'collection',
+				targetLeafState,
+			);
+		}
+		if (state.mapping === 'org-top') {
+			return treeWithItems(
+				plan,
+				(item) => firstSegment(item.targetPath),
+				'collection',
+				targetLeafState,
+			);
+		}
+		if (state.mapping === 'org-fixed') {
+			return treeWithItems(
+				plan,
+				() => state.collectionId || sampleCollectionId,
+				'collection',
+				targetLeafState,
+			);
+		}
+		return [flatBucket('No collection', plan)];
+	})();
+
+	return [
+		{
+			name: 'My vault',
+			kind: 'root',
+			count: 0,
+			children: [emptyNode('No personal folders created')],
+		},
+		{
+			name: 'Organization vault',
+			kind: 'root',
+			count: importableCount,
+			children: state.mapping === 'org-flat'
+				? collectionChildren
+				: [
+					{
+						name: 'Collections',
+						kind: 'bucket',
+						count: importableCount,
+						children: collectionChildren,
+					},
+				],
+		},
+	];
+}
+
+export function commandForState(state: PlannerState): string {
+	const args = ['kp2bw'];
+
+	if (state.destination === 'org') {
+		args.push('-o', quoteArg(state.organizationId || sampleOrganizationId));
+		if (state.mapping === 'org-nested') args.push('-c', 'nested');
+		if (state.mapping === 'org-top') args.push('-c', 'auto');
+		if (state.mapping === 'org-fixed') {
+			args.push('-c', quoteArg(state.collectionId || sampleCollectionId));
+		}
+		args.push('--no-folder');
+	}
+
+	if (state.destination === 'personal' && state.mapping === 'personal-flat') {
+		args.push('--no-folder');
+	}
+
+	if (state.keyFile.trim()) args.push('-K', quoteArg(state.keyFile.trim()));
+	const tags = selectedTags(state.tagInput);
+	if (tags.length > 0) args.push('-t', ...tags.map(quoteArg));
+	if (state.skipExpired) args.push('--skip-expired');
+	if (state.includeRecycleBin) args.push('--include-recycle-bin');
+	if (state.rerunMode === 'no-update') args.push('--no-update');
+	if (state.rerunMode === 'keepass-wins') args.push('--force-update');
+
+	args.push(quoteArg(state.keepassFile || 'passwords.kdbx'));
+	return args.join(' ');
+}
+
+export function envFileForState(): string {
+	return [
+		'KP2BW_KEEPASS_PASSWORD=<keepass password>',
+		'KP2BW_BITWARDEN_PASSWORD=<bitwarden password>',
+	].join('\n');
+}
+
+export function statsForState(state: PlannerState, items = filteredItems(state)) {
+	return {
+		items: items.length,
+		attachments: items.reduce((total, item) => total + (item.attachments ?? 0), 0),
+		passkeys: items.filter((item) => item.passkey).length,
+	};
+}
+
+export function placementLabel(state: PlannerState): string {
+	if (state.mapping === 'org-nested') return 'KeePass paths -> org collections';
+	if (state.mapping === 'org-top') return 'Top folders -> org collections';
+	if (state.mapping === 'org-fixed') return 'Everything -> one collection';
+	if (state.mapping === 'org-flat') return 'Flat organization import';
+	if (state.mapping === 'personal-flat') return 'Flat personal import';
+	return 'KeePass paths -> personal folders';
+}
+
+function reconcileExisting(
+	state: PlannerState,
+	source: KeePassEntry,
+	existing: BitwardenItem | undefined,
+	included: boolean,
+): PreviewAction {
+	if (!included) return 'skip';
+	if (!existing) return 'create';
+	if (existing.type && existing.type !== 'login') return 'left-alone';
+	if (state.rerunMode === 'no-update') return 'left-alone';
+
+	const delta = deltaForItem(source, existing);
+	if (delta === 'unchanged') return 'unchanged';
+	if (state.rerunMode === 'keepass-wins') {
+		return delta === 'keepass-changed' ? 'update' : 'overwrite';
+	}
+	if (delta === 'keepass-changed') return 'update';
+	return 'protected';
+}
+
+function targetPathForPlan(
+	source: KeePassEntry,
+	existing: BitwardenItem | undefined,
+	action: PreviewAction,
+): string {
+	if (
+		existing
+		&& (
+			action === 'protected' || action === 'left-alone' || action === 'unchanged'
+			|| action === 'skip'
+		)
+	) {
+		return existing.group ?? source.group ?? 'Unfiled';
+	}
+	return source.group ?? 'Unfiled';
+}
+
+function existingForEntry(
+	entry: KeePassEntry,
+	fixture = previewFixture,
+): BitwardenItem | undefined {
+	return fixture.bitwarden.find((item) => item.kp2bwId === entry.id);
+}
+
+function targetLeafState(item: PlannedItem): Pick<PreviewNode, 'delta' | 'action' | 'muted'> {
+	return {
+		delta: item.delta,
+		action: item.action,
+		muted: item.action === 'skip',
+	};
+}
+
+function treeWithItems<T>(
+	items: T[],
+	getPath: (item: T) => string,
+	branchKind: PreviewNode['kind'],
+	getLeafState: (item: T) => Pick<PreviewNode, 'delta' | 'action' | 'muted'>,
+	countLeaf: (leaf: Pick<PreviewNode, 'delta' | 'action' | 'muted'>) => boolean = (
+		leaf,
+	) => leaf.action !== 'skip' && !leaf.muted,
+): PreviewNode[] {
+	const root: PreviewNode[] = [];
+	for (const item of items) {
+		const leafState = getLeafState(item);
+		let level = root;
+		for (const part of getPath(item).split('/').filter(Boolean)) {
+			let node = level.find((entry) => entry.name === part);
+			if (!node) {
+				node = {
+					name: part,
+					kind: branchKindForPart(part, branchKind),
+					count: 0,
+					children: [],
+				};
+				level.push(node);
+			}
+			if (countLeaf(leafState)) {
+				node.count = (node.count ?? 0) + 1;
+			}
+			level = node.children;
+		}
+		level.push({
+			name: itemName(item),
+			kind: 'item',
+			...leafState,
+			children: [],
+		});
+	}
+	return sortTree(root);
+}
+
+function flatBucket(name: string, plan: PlannedItem[]): PreviewNode {
+	return {
+		name,
+		kind: 'bucket',
+		count: plan.filter((item) => item.included).length,
+		children: sortTree(
+			plan.map((item) => ({
+				name: item.source.name,
+				kind: 'item' as const,
+				...targetLeafState(item),
+				children: [],
+			})),
+		),
+	};
+}
+
+function emptyNode(name: string): PreviewNode {
+	return {
+		name,
+		kind: 'empty',
+		children: [],
+	};
+}
+
+function sortTree(nodes: PreviewNode[]): PreviewNode[] {
+	return nodes
+		.sort((a, b) => {
+			if (a.kind === 'recycle' && b.kind !== 'recycle') return 1;
+			if (a.kind !== 'recycle' && b.kind === 'recycle') return -1;
+			if (a.kind === 'item' && b.kind !== 'item') return 1;
+			if (a.kind !== 'item' && b.kind === 'item') return -1;
+			return a.name.localeCompare(b.name);
+		})
+		.map((node) => ({ ...node, children: sortTree(node.children) }));
+}
+
+function itemName(item: unknown): string {
+	if (isPlannedItem(item)) return item.source.name;
+	return String(item);
+}
+
+function isPlannedItem(item: unknown): item is PlannedItem {
+	return Boolean(item && typeof item === 'object' && 'source' in item);
+}
+
+function firstSegment(path: string | null): string {
+	return path?.split('/').filter(Boolean)[0] ?? 'Unfiled';
+}
+
+function branchKindForPart(
+	part: string,
+	branchKind: PreviewNode['kind'],
+): PreviewNode['kind'] {
+	return part === 'Recycle Bin' ? 'recycle' : branchKind;
+}
+
+function quoteArg(value: string): string {
+	if (/^[A-Za-z0-9_./:=@+-]+$/.test(value)) return value;
+	return '"' + value.replaceAll('"', '\\"') + '"';
+}

--- a/docs/src/lib/planner.ts
+++ b/docs/src/lib/planner.ts
@@ -627,5 +627,5 @@ function branchKindForPart(
 
 function quoteArg(value: string): string {
 	if (/^[A-Za-z0-9_./:=@+-]+$/.test(value)) return value;
-	return '"' + value.replaceAll('"', '\\"') + '"';
+	return '"' + value.replaceAll('\\', '\\\\').replaceAll('"', '\\"') + '"';
 }

--- a/docs/src/lib/planner.ts
+++ b/docs/src/lib/planner.ts
@@ -59,8 +59,11 @@ export type PlannerState = {
 	organizationId: string;
 	collectionId: string;
 	tagInput: string;
-	skipExpired: boolean;
+	includeExpired: boolean;
 	includeRecycleBin: boolean;
+	/* Org imports default to collections only; opt in to also build the
+	   personal folder tree (kp2bw --folder). Ignored for personal targets. */
+	orgFolders: boolean;
 	rerunMode: RerunMode;
 };
 
@@ -105,17 +108,76 @@ export const sampleOrganizationId = '00000000-0000-0000-0000-000000000000';
 export const sampleCollectionId = '11111111-1111-1111-1111-111111111111';
 
 export const defaultPlannerState: PlannerState = {
-	destination: 'org',
-	mapping: 'org-nested',
+	// Personal vault is the CLI's no-flag default (org needs an explicit -o), so
+	// the planner opens there too; pick Organization to plan a shared-org import.
+	destination: 'personal',
+	mapping: 'personal-folders',
 	keepassFile: 'vault.kdbx',
 	keyFile: '',
 	organizationId: sampleOrganizationId,
 	collectionId: sampleCollectionId,
 	tagInput: '',
-	skipExpired: false,
+	// CLI defaults: expired entries ARE imported; Recycle Bin is NOT.
+	includeExpired: true,
 	includeRecycleBin: false,
+	orgFolders: false,
 	rerunMode: 'safe',
 };
+
+export const PLANNER_STORAGE_KEY = 'kp2bw-planner-v1';
+
+const DESTINATIONS: readonly Destination[] = ['org', 'personal'];
+const ORG_MAPPINGS: readonly Mapping[] = [
+	'org-nested',
+	'org-top',
+	'org-fixed',
+	'org-flat',
+];
+const PERSONAL_MAPPINGS: readonly Mapping[] = ['personal-folders', 'personal-flat'];
+const RERUN_MODES: readonly RerunMode[] = ['safe', 'no-update', 'keepass-wins'];
+
+/** Rebuild a trusted PlannerState from untrusted parsed JSON (localStorage is
+ *  user-editable). Unknown or wrong-typed fields fall back to the default, and
+ *  the mapping is forced to match the destination so the radio group is never
+ *  left with nothing selected. */
+export function sanitizePlannerState(raw: unknown): PlannerState {
+	const base = { ...defaultPlannerState };
+	if (typeof raw !== 'object' || raw === null) return base;
+	const record: Record<string, unknown> = { ...raw };
+
+	const str = (key: string, fallback: string): string => {
+		const value = record[key];
+		return typeof value === 'string' ? value : fallback;
+	};
+	const bool = (key: string, fallback: boolean): boolean => {
+		const value = record[key];
+		return typeof value === 'boolean' ? value : fallback;
+	};
+	const oneOf = <T extends string>(
+		key: string,
+		allowed: readonly T[],
+		fallback: T,
+	): T => allowed.find((candidate) => candidate === record[key]) ?? fallback;
+
+	const destination = oneOf('destination', DESTINATIONS, base.destination);
+	const mappingPool = destination === 'org' ? ORG_MAPPINGS : PERSONAL_MAPPINGS;
+	const mapping = mappingPool.find((candidate) => candidate === record['mapping'])
+		?? (destination === 'org' ? 'org-nested' : 'personal-folders');
+
+	return {
+		destination,
+		mapping,
+		keepassFile: str('keepassFile', base.keepassFile),
+		keyFile: str('keyFile', base.keyFile),
+		organizationId: str('organizationId', base.organizationId),
+		collectionId: str('collectionId', base.collectionId),
+		tagInput: str('tagInput', base.tagInput),
+		includeExpired: bool('includeExpired', base.includeExpired),
+		includeRecycleBin: bool('includeRecycleBin', base.includeRecycleBin),
+		orgFolders: bool('orgFolders', base.orgFolders),
+		rerunMode: oneOf('rerunMode', RERUN_MODES, base.rerunMode),
+	};
+}
 
 export function selectedTags(tagInput: string): string[] {
 	return tagInput.split(',').map((tag) => tag.trim()).filter(Boolean);
@@ -139,7 +201,7 @@ export function exclusionReasonForItem(
 ): ExclusionReason | undefined {
 	const tags = selectedTags(state.tagInput);
 	if (!state.includeRecycleBin && item.recycle) return 'recycle-bin';
-	if (state.skipExpired && item.expired) return 'expired';
+	if (!state.includeExpired && item.expired) return 'expired';
 	if (tags.length > 0 && !tags.some((tag) => item.tags.includes(tag))) {
 		return 'tag-filter';
 	}
@@ -300,8 +362,23 @@ export function bitwardenTree(
 		{
 			name: 'My vault',
 			kind: 'root',
-			count: 0,
-			children: [emptyNode('No personal folders created')],
+			count: state.orgFolders ? importableCount : 0,
+			// --folder double-files: items land in collections AND personal folders.
+			children: state.orgFolders
+				? [
+					{
+						name: 'Folders',
+						kind: 'bucket',
+						count: importableCount,
+						children: treeWithItems(
+							plan,
+							(item) => item.targetPath,
+							'folder',
+							targetLeafState,
+						),
+					},
+				]
+				: [emptyNode('No personal folders created')],
 		},
 		{
 			name: 'Organization vault',
@@ -321,33 +398,60 @@ export function bitwardenTree(
 	];
 }
 
-export function commandForState(state: PlannerState): string {
-	const args = ['kp2bw'];
+/** Logical command pieces — each a flag with its own values — so the command
+ *  can be joined on one line or wrapped onto backslash-continued lines. */
+export function commandSegmentsForState(state: PlannerState): string[] {
+	const segments: string[] = ['kp2bw'];
 
 	if (state.destination === 'org') {
-		args.push('-o', quoteArg(state.organizationId || sampleOrganizationId));
-		if (state.mapping === 'org-nested') args.push('-c', 'nested');
-		if (state.mapping === 'org-top') args.push('-c', 'auto');
+		segments.push(`-o ${quoteArg(state.organizationId || sampleOrganizationId)}`);
+		if (state.mapping === 'org-nested') segments.push('-c nested');
+		if (state.mapping === 'org-top') segments.push('-c auto');
 		if (state.mapping === 'org-fixed') {
-			args.push('-c', quoteArg(state.collectionId || sampleCollectionId));
+			segments.push(`-c ${quoteArg(state.collectionId || sampleCollectionId)}`);
 		}
-		args.push('--no-folder');
+		// kp2bw >=3.7.0 defaults personal folders off whenever -o is set, so
+		// --no-folder is redundant for every org mapping. --folder opts back in
+		// to ALSO build the personal folder tree alongside the collections.
+		if (state.orgFolders) segments.push('--folder');
 	}
 
 	if (state.destination === 'personal' && state.mapping === 'personal-flat') {
-		args.push('--no-folder');
+		segments.push('--no-folder');
 	}
 
-	if (state.keyFile.trim()) args.push('-K', quoteArg(state.keyFile.trim()));
+	if (state.keyFile.trim()) segments.push(`-K ${quoteArg(state.keyFile.trim())}`);
 	const tags = selectedTags(state.tagInput);
-	if (tags.length > 0) args.push('-t', ...tags.map(quoteArg));
-	if (state.skipExpired) args.push('--skip-expired');
-	if (state.includeRecycleBin) args.push('--include-recycle-bin');
-	if (state.rerunMode === 'no-update') args.push('--no-update');
-	if (state.rerunMode === 'keepass-wins') args.push('--force-update');
+	if (tags.length > 0) segments.push(`-t ${tags.map(quoteArg).join(' ')}`);
+	if (!state.includeExpired) segments.push('--skip-expired');
+	if (state.includeRecycleBin) segments.push('--include-recycle-bin');
+	if (state.rerunMode === 'no-update') segments.push('--no-update');
+	if (state.rerunMode === 'keepass-wins') segments.push('--force-update');
 
-	args.push(quoteArg(state.keepassFile || 'passwords.kdbx'));
-	return args.join(' ');
+	// -t is nargs="+" and the KeePass FILE is an optional positional, so with no
+	// flag between them argparse swallows the filename as a tag. End option
+	// parsing with -- so the file is always read as the database path.
+	const file = quoteArg(state.keepassFile || 'passwords.kdbx');
+	segments.push(tags.length > 0 ? `-- ${file}` : file);
+
+	return segments;
+}
+
+export function commandForState(state: PlannerState): string {
+	return commandSegmentsForState(state).join(' ');
+}
+
+/** Column width past which the one-liner is wrapped onto backslash-continued
+ *  lines, so the Run box never needs a long horizontal scroll. */
+const COMMAND_WRAP_COLUMNS = 76;
+
+/** The command as shown in the Run box: one line when short, otherwise each
+ *  segment on its own bash line-continuation (`\`). Still copy-paste runnable. */
+export function commandDisplayForState(state: PlannerState): string {
+	const segments = commandSegmentsForState(state);
+	const oneLine = segments.join(' ');
+	if (oneLine.length <= COMMAND_WRAP_COLUMNS) return oneLine;
+	return segments.join(' \\\n  ');
 }
 
 export function envFileForState(): string {

--- a/docs/src/lib/preview-fixture.json
+++ b/docs/src/lib/preview-fixture.json
@@ -1,0 +1,176 @@
+{
+	"name": "KeePass database",
+	"keepass": [
+		{
+			"id": "root-admin",
+			"name": "Root Admin",
+			"group": null,
+			"tags": ["admin"],
+			"keepassRevision": "root-admin-kp-1",
+			"attachments": 1
+		},
+		{
+			"id": "stripe",
+			"name": "Stripe",
+			"group": "Internet/Banking",
+			"tags": ["finance"],
+			"keepassRevision": "stripe-kp-1",
+			"attachments": 2
+		},
+		{
+			"id": "payroll",
+			"name": "Payroll",
+			"group": "Internet/Banking",
+			"tags": ["finance", "hr"],
+			"keepassRevision": "payroll-kp-2"
+		},
+		{
+			"id": "github",
+			"name": "GitHub",
+			"group": "Work/Engineering",
+			"tags": ["dev"],
+			"keepassRevision": "github-kp-2",
+			"passkey": true
+		},
+		{
+			"id": "production-ssh",
+			"name": "Production SSH",
+			"group": "Work/Servers",
+			"tags": ["dev", "ops"],
+			"keepassRevision": "production-ssh-kp-1",
+			"attachments": 1
+		},
+		{
+			"id": "router",
+			"name": "Router",
+			"group": "Work/Servers",
+			"tags": ["ops"],
+			"keepassRevision": "router-kp-1"
+		},
+		{
+			"id": "shared-vpn",
+			"name": "Shared VPN",
+			"group": "Work/Shared",
+			"tags": ["ops"],
+			"keepassRevision": "shared-vpn-kp-2"
+		},
+		{
+			"id": "deprecated-vpn",
+			"name": "Deprecated VPN",
+			"group": "Work/Shared",
+			"tags": ["legacy", "ops"],
+			"keepassRevision": "deprecated-vpn-kp-1"
+		},
+		{
+			"id": "archive-box",
+			"name": "Archive Box",
+			"group": "Archive/2021",
+			"tags": ["legacy"],
+			"keepassRevision": "archive-box-kp-1",
+			"expired": true
+		},
+		{
+			"id": "retired-jira",
+			"name": "Retired Jira",
+			"group": "Recycle Bin/Old",
+			"tags": ["legacy"],
+			"keepassRevision": "retired-jira-kp-2",
+			"recycle": true
+		},
+		{
+			"id": "old-saas",
+			"name": "Old SaaS",
+			"group": "Recycle Bin/Old",
+			"tags": ["legacy"],
+			"keepassRevision": "old-saas-kp-1",
+			"recycle": true
+		}
+	],
+	"bitwarden": [
+		{
+			"id": "bw-stripe",
+			"kp2bwId": "stripe",
+			"name": "Stripe",
+			"group": "Internet/Banking",
+			"syncedKeePassRevision": "stripe-kp-1",
+			"syncedBitwardenRevision": "stripe-bw-1",
+			"currentBitwardenRevision": "stripe-bw-1",
+			"attachments": 2
+		},
+		{
+			"id": "bw-payroll",
+			"kp2bwId": "payroll",
+			"name": "Payroll",
+			"group": "Internet/Banking",
+			"syncedKeePassRevision": "payroll-kp-1",
+			"syncedBitwardenRevision": "payroll-bw-1",
+			"currentBitwardenRevision": "payroll-bw-1"
+		},
+		{
+			"id": "bw-github",
+			"kp2bwId": "github",
+			"name": "GitHub",
+			"group": "Work/Engineering",
+			"syncedKeePassRevision": "github-kp-1",
+			"syncedBitwardenRevision": "github-bw-1",
+			"currentBitwardenRevision": "github-bw-2",
+			"passkey": true
+		},
+		{
+			"id": "bw-production-ssh",
+			"kp2bwId": "production-ssh",
+			"name": "Production SSH",
+			"group": "Work/Servers",
+			"syncedKeePassRevision": "production-ssh-kp-1",
+			"syncedBitwardenRevision": "production-ssh-bw-1",
+			"currentBitwardenRevision": "production-ssh-bw-2",
+			"attachments": 1
+		},
+		{
+			"id": "bw-router",
+			"kp2bwId": "router",
+			"name": "Router",
+			"group": "Work/Servers",
+			"syncedKeePassRevision": "router-kp-1",
+			"syncedBitwardenRevision": "router-bw-1",
+			"currentBitwardenRevision": "router-bw-1"
+		},
+		{
+			"id": "bw-shared-vpn",
+			"kp2bwId": "shared-vpn",
+			"name": "Shared VPN",
+			"group": "Work/Shared",
+			"syncedKeePassRevision": "shared-vpn-kp-1",
+			"syncedBitwardenRevision": "shared-vpn-bw-1",
+			"currentBitwardenRevision": "shared-vpn-bw-1"
+		},
+		{
+			"id": "bw-deprecated-vpn",
+			"kp2bwId": "deprecated-vpn",
+			"name": "Deprecated VPN",
+			"group": "Recycle Bin/Old",
+			"syncedKeePassRevision": "deprecated-vpn-kp-1",
+			"syncedBitwardenRevision": "deprecated-vpn-bw-1",
+			"currentBitwardenRevision": "deprecated-vpn-bw-2",
+			"recycle": true
+		},
+		{
+			"id": "bw-archive-box",
+			"kp2bwId": "archive-box",
+			"name": "Archive Box",
+			"group": "Archive/2021",
+			"syncedKeePassRevision": "archive-box-kp-1",
+			"syncedBitwardenRevision": "archive-box-bw-1",
+			"currentBitwardenRevision": "archive-box-bw-1"
+		},
+		{
+			"id": "bw-retired-jira",
+			"kp2bwId": "retired-jira",
+			"name": "Retired Jira",
+			"group": "Work/Shared",
+			"syncedKeePassRevision": "retired-jira-kp-1",
+			"syncedBitwardenRevision": "retired-jira-bw-1",
+			"currentBitwardenRevision": "retired-jira-bw-1"
+		}
+	]
+}

--- a/docs/src/routes/+layout.svelte
+++ b/docs/src/routes/+layout.svelte
@@ -7,10 +7,65 @@
 <svelte:head><link rel="icon" href={favicon}></svelte:head>
 {@render children()}
 
+<footer>
+	<nav aria-label="Project links">
+		<a href="https://github.com/kjanat/kp2bw" target="_blank" rel="noreferrer">
+			GitHub
+		</a>
+		<a href="https://pypi.org/project/kp2bw/" target="_blank" rel="noreferrer">
+			PyPI
+		</a>
+	</nav>
+	<span>kp2bw — KeePass → Bitwarden migration</span>
+</footer>
+
 <style>
 	:global(:root) {
 		color-scheme: dark;
-		background: #111411;
+
+		/* Surfaces — three steps only: page, raised panel, inset field/code. */
+		--bg: #111411;
+		--panel: #181c16;
+		--field: #10130f;
+		--code-bg: #0f1812;
+
+		/* Text — a real ladder; --muted is lifted to clear WCAG AA on panels. */
+		--text: #f0ecdc;
+		--text-dim: #cdcabb;
+		--text-muted: #b0b5a4;
+
+		/* Edges — two tiers, not eight. Hairline inside, stronger on raised. */
+		--edge: #333b31;
+		--edge-strong: #4a544757;
+		--code-edge: #31513f;
+
+		/* Accent + focus. */
+		--accent: #8ecf9f;
+		--accent-deep: #112016;
+		--focus: #9ff0ba;
+
+		/* Type scale — body speaks, labels whisper (not everything tiny). */
+		--fs-label: 0.72rem;
+		--fs-small: 0.8rem;
+		--fs-body: 0.9rem;
+
+		/* Spacing rhythm + one radius. */
+		--sp-1: 4px;
+		--sp-2: 8px;
+		--sp-3: 12px;
+		--sp-4: 18px;
+		--sp-5: 28px;
+		--radius: 4px;
+
+		--mono:
+			"Aptos Mono",
+			"Cascadia Mono",
+			"SFMono-Regular",
+			Consolas,
+			"Liberation Mono",
+			monospace;
+
+		background: var(--bg);
 	}
 
 	:global(html) {
@@ -20,18 +75,49 @@
 
 	:global(body) {
 		margin: 0;
-		background: #111411;
-		color: #f0ecdc;
-		font-family:
-			"Aptos Mono",
-			"Cascadia Mono",
-			"SFMono-Regular",
-			Consolas,
-			"Liberation Mono",
-			monospace;
+		background: var(--bg);
+		color: var(--text);
+		font-family: var(--mono);
+		font-size: var(--fs-body);
+		line-height: 1.5;
 	}
 
 	:global(*) {
 		box-sizing: border-box;
+	}
+
+	/* One focus treatment for the whole app — replaces the scattered, and in
+	   places removed, outlines. Keyboard users always get a visible ring. */
+	:global(:focus-visible) {
+		outline: 2px solid var(--focus);
+		outline-offset: 1px;
+	}
+
+	footer {
+		display: flex;
+		flex-wrap: wrap;
+		align-items: center;
+		justify-content: space-between;
+		gap: var(--sp-2) var(--sp-4);
+		max-width: 1320px;
+		margin: var(--sp-5) auto 0;
+		border-top: 1px solid var(--edge);
+		padding: var(--sp-4) var(--sp-5) var(--sp-5);
+		color: var(--text-muted);
+		font-size: var(--fs-label);
+	}
+
+	footer nav {
+		display: flex;
+		gap: var(--sp-4);
+	}
+
+	footer a {
+		color: var(--accent);
+		text-decoration: none;
+	}
+
+	footer a:hover {
+		text-decoration: underline;
 	}
 </style>

--- a/docs/src/routes/+layout.svelte
+++ b/docs/src/routes/+layout.svelte
@@ -44,6 +44,14 @@
 		--accent-deep: #112016;
 		--focus: #9ff0ba;
 
+		/* Icon colors. */
+		--icon-folder: #d2b56f;
+		--icon-folder-bg: #211d12;
+		--icon-collection: var(--accent);
+		--icon-collection-bg: #101d16;
+		--icon-recycle: #d48670;
+		--icon-recycle-bg: #251713;
+
 		/* Type scale — body speaks, labels whisper (not everything tiny). */
 		--fs-label: 0.72rem;
 		--fs-small: 0.8rem;

--- a/docs/src/routes/+layout.svelte
+++ b/docs/src/routes/+layout.svelte
@@ -1,0 +1,37 @@
+<script lang="ts">
+	import favicon from '$lib/assets/favicon.svg';
+
+	let { children } = $props();
+</script>
+
+<svelte:head><link rel="icon" href={favicon}></svelte:head>
+{@render children()}
+
+<style>
+	:global(:root) {
+		color-scheme: dark;
+		background: #111411;
+	}
+
+	:global(html) {
+		min-width: 320px;
+		min-height: 100%;
+	}
+
+	:global(body) {
+		margin: 0;
+		background: #111411;
+		color: #f0ecdc;
+		font-family:
+			"Aptos Mono",
+			"Cascadia Mono",
+			"SFMono-Regular",
+			Consolas,
+			"Liberation Mono",
+			monospace;
+	}
+
+	:global(*) {
+		box-sizing: border-box;
+	}
+</style>

--- a/docs/src/routes/+layout.ts
+++ b/docs/src/routes/+layout.ts
@@ -1,0 +1,2 @@
+export const prerender = true;
+export const trailingSlash = 'always';

--- a/docs/src/routes/+page.svelte
+++ b/docs/src/routes/+page.svelte
@@ -1,0 +1,174 @@
+<script lang="ts">
+	import { resolve } from '$app/paths';
+	import CommandBox from '$lib/components/CommandBox.svelte';
+	import PathTable from '$lib/components/PathTable.svelte';
+	import PlannerOptions from '$lib/components/PlannerOptions.svelte';
+	import TreeLegend from '$lib/components/TreeLegend.svelte';
+	import {
+		commandForState,
+		defaultPlannerState,
+		envFileForState,
+		placementLabel,
+		previewForState,
+	} from '$lib/planner';
+	import type { PlannerState } from '$lib/planner';
+	import { onDestroy } from 'svelte';
+
+	let planner: PlannerState = $state({ ...defaultPlannerState });
+	let copied = $state(false);
+	let copyResetTimer: ReturnType<typeof setTimeout> | undefined = $state();
+
+	let preview = $derived(previewForState(planner));
+	let command = $derived(commandForState(planner));
+	let envFile = $derived(envFileForState());
+	let stats = $derived(preview.stats);
+	let title = $derived(placementLabel(planner));
+	let copyText = $derived(`# .env\n${envFile}\n\n${command}`);
+
+	onDestroy(() => {
+		if (copyResetTimer !== undefined) clearTimeout(copyResetTimer);
+	});
+
+	async function copyCommand(): Promise<void> {
+		try {
+			await navigator.clipboard.writeText(copyText);
+		} catch {
+			copied = false;
+			return;
+		}
+
+		copied = true;
+		if (copyResetTimer !== undefined) clearTimeout(copyResetTimer);
+		copyResetTimer = setTimeout(() => {
+			copied = false;
+			copyResetTimer = undefined;
+		}, 1200);
+	}
+</script>
+
+<svelte:head>
+	<title>kp2bw migration planner</title>
+	<meta
+		name="description"
+		content="Plan a KeePass to Bitwarden migration and preview how the tree maps into Bitwarden."
+	>
+</svelte:head>
+
+<main>
+	<header>
+		<div>
+			<p>migration planner</p>
+			<h1>kp2bw</h1>
+		</div>
+		<a href={resolve('/docs')}>details</a>
+	</header>
+
+	<div class="summary">
+		<strong>{title}</strong>
+		<TreeLegend />
+		<span>{stats.items} items · {stats.attachments} attachments · {
+				stats.passkeys
+			} passkey{stats.passkeys === 1 ? '' : 's'}</span>
+	</div>
+
+	<div class="grid">
+		<PathTable
+			keepass={{ title: 'Tree in KeePass', nodes: preview.keepass }}
+			bitwarden={{ title: 'Tree in Bitwarden', nodes: preview.bitwarden }}
+		/>
+		<PlannerOptions state={planner} />
+
+		<CommandBox {command} {envFile} {copied} onCopy={copyCommand} />
+	</div>
+</main>
+
+<style>
+	main {
+		min-height: 100vh;
+		padding: 22px;
+	}
+
+	header {
+		display: flex;
+		align-items: end;
+		justify-content: space-between;
+		gap: 18px;
+		max-width: 1320px;
+		margin: 0 auto 12px;
+		border-bottom: 1px solid #30372f;
+		padding-bottom: 12px;
+	}
+
+	p {
+		margin: 0 0 4px;
+		color: #aab0a3;
+		font-size: 0.72rem;
+		text-transform: uppercase;
+	}
+
+	h1 {
+		margin: 0;
+		font-family: Georgia, "Times New Roman", serif;
+		font-size: clamp(2.4rem, 4vw, 4rem);
+		letter-spacing: 0;
+		line-height: 1;
+	}
+
+	a {
+		color: #8ecf9f;
+		text-decoration: none;
+	}
+
+	a:hover {
+		text-decoration: underline;
+	}
+
+	.summary {
+		display: grid;
+		grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
+		align-items: center;
+		gap: 10px;
+		max-width: 1320px;
+		margin: 0 auto 12px;
+		color: #c7c9bd;
+	}
+
+	.summary strong {
+		color: #f0ecdc;
+	}
+
+	.summary > span:last-child {
+		text-align: right;
+	}
+
+	.grid {
+		display: grid;
+		grid-template-columns:
+			minmax(260px, 1fr) minmax(260px, 1fr) minmax(320px, 0.9fr);
+		gap: 12px;
+		max-width: 1320px;
+		margin: 0 auto;
+	}
+
+	@media (max-width: 980px) {
+		main {
+			padding: 14px;
+		}
+
+		header {
+			align-items: start;
+		}
+
+		.summary {
+			grid-template-columns: 1fr;
+		}
+
+		.summary > span:last-child {
+			text-align: left;
+		}
+
+		.grid {
+			grid-template-columns: 1fr;
+		}
+	}
+</style>

--- a/docs/src/routes/+page.svelte
+++ b/docs/src/routes/+page.svelte
@@ -5,44 +5,60 @@
 	import PlannerOptions from '$lib/components/PlannerOptions.svelte';
 	import TreeLegend from '$lib/components/TreeLegend.svelte';
 	import {
-		commandForState,
+		commandDisplayForState,
 		defaultPlannerState,
 		envFileForState,
-		placementLabel,
+		PLANNER_STORAGE_KEY,
+		previewFixture,
 		previewForState,
+		sanitizePlannerState,
+		statsForState,
 	} from '$lib/planner';
 	import type { PlannerState } from '$lib/planner';
-	import { onDestroy } from 'svelte';
+	import { onMount } from 'svelte';
 
 	let planner: PlannerState = $state({ ...defaultPlannerState });
-	let copied = $state(false);
-	let copyResetTimer: ReturnType<typeof setTimeout> | undefined = $state();
 
-	let preview = $derived(previewForState(planner));
-	let command = $derived(commandForState(planner));
-	let envFile = $derived(envFileForState());
-	let stats = $derived(preview.stats);
-	let title = $derived(placementLabel(planner));
-	let copyText = $derived(`# .env\n${envFile}\n\n${command}`);
+	// Persist selections so a refresh keeps them. Load on mount (client only, so
+	// SSR still renders defaults and hydration matches); the guard stops the save
+	// effect from clobbering stored state with defaults before that load runs.
+	let hydrated = false;
 
-	onDestroy(() => {
-		if (copyResetTimer !== undefined) clearTimeout(copyResetTimer);
+	onMount(() => {
+		try {
+			const stored = localStorage.getItem(PLANNER_STORAGE_KEY);
+			if (stored) {
+				Object.assign(planner, sanitizePlannerState(JSON.parse(stored)));
+			}
+		} catch {
+			// corrupt JSON or storage unavailable — keep the defaults
+		}
+		hydrated = true;
 	});
 
-	async function copyCommand(): Promise<void> {
+	$effect(() => {
+		const snapshot = JSON.stringify(planner);
+		if (!hydrated) return;
 		try {
-			await navigator.clipboard.writeText(copyText);
+			localStorage.setItem(PLANNER_STORAGE_KEY, snapshot);
 		} catch {
-			copied = false;
-			return;
+			// storage full or disabled — selections just won't persist
 		}
+	});
 
-		copied = true;
-		if (copyResetTimer !== undefined) clearTimeout(copyResetTimer);
-		copyResetTimer = setTimeout(() => {
-			copied = false;
-			copyResetTimer = undefined;
-		}, 1200);
+	let preview = $derived(previewForState(planner));
+	let command = $derived(commandDisplayForState(planner));
+	let envFile = $derived(envFileForState());
+	let stats = $derived(preview.stats);
+	// KeePass-side totals (the whole source vault, pre-filter) so the Bitwarden
+	// result count has something to be measured against.
+	let sourceStats = $derived(statsForState(planner, previewFixture.keepass));
+
+	// Selections persist, so give people a way back to a clean slate. Mutating in
+	// place keeps the deep-reactive references the child controls bind to; the
+	// save effect then writes the defaults back to storage.
+	function resetPlanner(): void {
+		Object.assign(planner, { ...defaultPlannerState });
 	}
 </script>
 
@@ -60,15 +76,25 @@
 			<p>migration planner</p>
 			<h1>kp2bw</h1>
 		</div>
-		<a href={resolve('/docs')}>details</a>
+		<div class="header-actions">
+			<button type="button" class="reset" onclick={resetPlanner}>Reset</button>
+			<a href={resolve('/docs')}>details</a>
+		</div>
 	</header>
 
 	<div class="summary">
-		<strong>{title}</strong>
+		<span class="tally">
+			<span class="tally-label">KeePass</span>
+			{sourceStats.items} items · {sourceStats.attachments} attachments · {
+				sourceStats.passkeys
+			} passkey{sourceStats.passkeys === 1 ? '' : 's'}
+		</span>
 		<TreeLegend />
-		<span>{stats.items} items · {stats.attachments} attachments · {
-				stats.passkeys
-			} passkey{stats.passkeys === 1 ? '' : 's'}</span>
+		<span class="tally tally-right">
+			<span class="tally-label">Bitwarden</span>
+			{stats.items} items · {stats.attachments} attachments · {stats.passkeys}
+			passkey{stats.passkeys === 1 ? '' : 's'}
+		</span>
 	</div>
 
 	<div class="grid">
@@ -78,13 +104,12 @@
 		/>
 		<PlannerOptions state={planner} />
 
-		<CommandBox {command} {envFile} {copied} onCopy={copyCommand} />
+		<CommandBox {command} {envFile} />
 	</div>
 </main>
 
 <style>
 	main {
-		min-height: 100vh;
 		padding: 22px;
 	}
 
@@ -95,32 +120,69 @@
 		gap: 18px;
 		max-width: 1320px;
 		margin: 0 auto 12px;
-		border-bottom: 1px solid #30372f;
+		border-bottom: 1px solid var(--edge);
 		padding-bottom: 12px;
 	}
 
 	p {
 		margin: 0 0 4px;
-		color: #aab0a3;
-		font-size: 0.72rem;
+		color: var(--text-muted);
+		font-size: var(--fs-label);
 		text-transform: uppercase;
 	}
 
 	h1 {
 		margin: 0;
-		font-family: Georgia, "Times New Roman", serif;
+		font-family: var(--mono);
 		font-size: clamp(2.4rem, 4vw, 4rem);
-		letter-spacing: 0;
+		font-weight: 700;
+		letter-spacing: -0.02em;
 		line-height: 1;
 	}
 
-	a {
-		color: #8ecf9f;
+	/* The route to the docs — was bare green text lost in the tree noise.
+	   Now a bordered pill with a clear hover fill so it reads as a control. */
+	header a {
+		flex: none;
+		align-self: center;
+		border: 1px solid var(--accent);
+		border-radius: var(--radius);
+		padding: 7px 14px;
+		color: var(--accent);
 		text-decoration: none;
+		white-space: nowrap;
 	}
 
-	a:hover {
-		text-decoration: underline;
+	header a::after {
+		content: " \2192";
+	}
+
+	header a:hover,
+	header a:focus-visible {
+		background: var(--accent);
+		color: var(--bg);
+	}
+
+	.header-actions {
+		display: flex;
+		align-items: center;
+		gap: 10px;
+	}
+
+	/* Secondary to the accent "details" pill — a quiet ghost button. */
+	.reset {
+		border: 1px solid var(--edge-strong);
+		border-radius: var(--radius);
+		background: transparent;
+		color: var(--text-muted);
+		padding: 7px 14px;
+		font: inherit;
+		cursor: pointer;
+	}
+
+	.reset:hover {
+		border-color: var(--accent);
+		color: var(--text);
 	}
 
 	.summary {
@@ -130,14 +192,17 @@
 		gap: 10px;
 		max-width: 1320px;
 		margin: 0 auto 12px;
-		color: #c7c9bd;
+		color: var(--text-dim);
 	}
 
-	.summary strong {
-		color: #f0ecdc;
+	.tally-label {
+		margin-right: 6px;
+		color: var(--text-muted);
+		font-size: var(--fs-label);
+		text-transform: uppercase;
 	}
 
-	.summary > span:last-child {
+	.tally-right {
 		text-align: right;
 	}
 
@@ -163,7 +228,7 @@
 			grid-template-columns: 1fr;
 		}
 
-		.summary > span:last-child {
+		.tally-right {
 			text-align: left;
 		}
 

--- a/docs/src/routes/docs/+page.svelte
+++ b/docs/src/routes/docs/+page.svelte
@@ -183,35 +183,43 @@
 					collections and no personal folders. That keeps shared data in the org
 					model instead of creating a private folder tree beside it.
 				</p>
+				<p id="personal-folders-under-org">
+					Want both? Pass <code>--folder</code> alongside <code>-o</code> (the
+					planner's <strong>Also create personal folders</strong> toggle) and
+					every item is filed into its org collection <em>and</em> a personal
+					folder — the same double-filing Bitwarden's own org import does.
+					Leave it off unless you specifically want that private copy.
+				</p>
 				<div class="fact-grid">
 					<article id="full-path-collections">
 						<h3>Full-path collections</h3>
 						<p>
-							<code>-c nested --no-folder</code>: KeePass
-							<code>Work/Servers</code> becomes collection
-							<code>Work/Servers</code>.
+							<code>-c nested</code>: KeePass <code>Work/Servers</code> becomes
+							collection <code>Work/Servers</code>. With <code>-o</code> set,
+							personal folders are already off, so no extra flag is needed.
 						</p>
 					</article>
 					<article id="top-folder-collections">
 						<h3>Top-folder collections</h3>
 						<p>
-							<code>-c auto --no-folder</code>: KeePass
-							<code>Work/Servers</code> and <code>Work/Engineering</code> both
-							land in collection <code>Work</code>.
+							<code>-c auto</code>: KeePass <code>Work/Servers</code> and
+							<code>Work/Engineering</code> both land in collection
+							<code>Work</code>.
 						</p>
 					</article>
 					<article id="single-collection">
 						<h3>Single collection</h3>
 						<p>
-							<code>-c 11111111-1111-1111-1111-111111111111 --no-folder</code>:
-							every imported item lands in one existing collection.
+							<code>-c 11111111-1111-1111-1111-111111111111</code>: every
+							imported item lands in one existing collection.
 						</p>
 					</article>
 					<article id="flat-org">
 						<h3>Flat organization</h3>
 						<p>
-							<code>--no-folder</code> without collection creation: items are
-							created without a generated hierarchy.
+							<code>-o</code> with no collection mapping: items are created in
+							the organization without a generated hierarchy or personal
+							folders.
 						</p>
 					</article>
 					<article id="personal-folders">
@@ -241,7 +249,7 @@
 KP2BW_KEEPASS_PASSWORD=&lt;keepass password&gt;
 KP2BW_BITWARDEN_PASSWORD=&lt;bitwarden password&gt;
 
-kp2bw -o 00000000-0000-0000-0000-000000000000 -c nested --no-folder vault.kdbx</code></pre>
+kp2bw -o 00000000-0000-0000-0000-000000000000 -c nested vault.kdbx</code></pre>
 				<p>
 					Choose top-level collections if you need fewer collections. Choose one
 					existing collection only when you intentionally want to flatten the
@@ -351,15 +359,8 @@ KP2BW_BITWARDEN_PASSWORD=&lt;bitwarden password&gt;</code></pre>
 
 <style>
 	.docs-page {
-		min-height: 100vh;
 		padding: 28px;
-		font-family:
-			"Aptos Mono",
-			"Cascadia Mono",
-			"SFMono-Regular",
-			Consolas,
-			"Liberation Mono",
-			monospace;
+		/* font-family inherited from :global(body) — no need to redeclare. */
 	}
 
 	.docs-hero,
@@ -371,13 +372,13 @@ KP2BW_BITWARDEN_PASSWORD=&lt;bitwarden password&gt;</code></pre>
 	.docs-hero {
 		display: grid;
 		gap: 10px;
-		border-bottom: 1px solid #30372f;
+		border-bottom: 1px solid var(--edge);
 		padding-bottom: 18px;
 	}
 
 	a {
 		width: fit-content;
-		color: #8ed9aa;
+		color: var(--accent);
 		text-decoration: none;
 	}
 
@@ -390,8 +391,8 @@ KP2BW_BITWARDEN_PASSWORD=&lt;bitwarden password&gt;</code></pre>
 	nav a,
 	h3 {
 		margin: 0;
-		color: #9c9587;
-		font-size: 0.74rem;
+		color: var(--text-muted);
+		font-size: var(--fs-label);
 		text-transform: uppercase;
 	}
 
@@ -403,16 +404,18 @@ KP2BW_BITWARDEN_PASSWORD=&lt;bitwarden password&gt;</code></pre>
 	}
 
 	h1 {
-		max-width: 12ch;
+		max-width: 16ch;
 		margin: 0;
-		font-family: Georgia, "Times New Roman", serif;
-		font-size: clamp(2.4rem, 5vw, 4.5rem);
-		line-height: 1;
+		font-family: var(--mono);
+		font-size: clamp(2.2rem, 4.5vw, 3.6rem);
+		font-weight: 700;
+		letter-spacing: -0.02em;
+		line-height: 1.05;
 	}
 
 	.docs-hero span {
 		max-width: 74ch;
-		color: #bcb5a5;
+		color: var(--text-dim);
 		line-height: 1.55;
 	}
 
@@ -434,8 +437,8 @@ KP2BW_BITWARDEN_PASSWORD=&lt;bitwarden password&gt;</code></pre>
 		align-content: start;
 		gap: 10px;
 		height: fit-content;
-		border: 1px solid #30372f;
-		background: #171a16;
+		border: 1px solid var(--edge);
+		background: var(--panel);
 		padding: 14px;
 	}
 
@@ -446,21 +449,23 @@ KP2BW_BITWARDEN_PASSWORD=&lt;bitwarden password&gt;</code></pre>
 
 	section {
 		min-width: 0;
-		border: 1px solid #30372f;
-		background: #171a16;
-		padding: 20px;
+		border: 1px solid var(--edge);
+		background: var(--panel);
+		padding: 24px 24px 26px;
 	}
 
 	section > h2 {
-		margin: 5px 0 10px;
-		font-size: 1.25rem;
-		line-height: 1.35;
+		margin: 4px 0 14px;
+		color: var(--text);
+		font-size: clamp(1.2rem, 2vw, 1.45rem);
+		font-weight: 700;
+		line-height: 1.3;
 	}
 
 	p,
 	li {
 		max-width: 78ch;
-		color: #d6ceb9;
+		color: var(--text-dim);
 		line-height: 1.62;
 	}
 
@@ -471,8 +476,8 @@ KP2BW_BITWARDEN_PASSWORD=&lt;bitwarden password&gt;</code></pre>
 
 	pre {
 		overflow: auto;
-		border: 1px solid #31513f;
-		background: #0f1812;
+		border: 1px solid var(--code-edge);
+		background: var(--code-bg);
 		padding: 14px;
 		color: #d8f3df;
 		white-space: pre;
@@ -481,14 +486,16 @@ KP2BW_BITWARDEN_PASSWORD=&lt;bitwarden password&gt;</code></pre>
 	.fact-grid {
 		display: grid;
 		grid-template-columns: repeat(2, minmax(0, 1fr));
-		gap: 10px;
-		margin-top: 14px;
+		gap: 6px 22px;
+		margin-top: 16px;
 	}
 
+	/* Was a bordered box inside a bordered section (box-in-box). A left rule
+	   groups each fact without stacking another full border on the panel. */
 	.fact-grid article {
 		min-width: 0;
-		border: 1px solid #2b302a;
-		padding: 14px;
+		border-left: 2px solid var(--edge);
+		padding: 2px 0 6px 14px;
 	}
 
 	.fact-grid p {
@@ -499,19 +506,19 @@ KP2BW_BITWARDEN_PASSWORD=&lt;bitwarden password&gt;</code></pre>
 		display: grid;
 		grid-template-columns: repeat(4, minmax(0, 1fr));
 		margin: 16px 0;
-		border-top: 1px solid #30372f;
-		border-left: 1px solid #30372f;
+		border-top: 1px solid var(--edge);
+		border-left: 1px solid var(--edge);
 	}
 
 	.mapping-grid > div {
 		min-width: 0;
-		border-right: 1px solid #30372f;
-		border-bottom: 1px solid #30372f;
+		border-right: 1px solid var(--edge);
+		border-bottom: 1px solid var(--edge);
 		padding: 10px;
 	}
 
 	.mapping-head {
-		color: #9c9587;
+		color: var(--text-muted);
 		font-size: 0.74rem;
 		text-transform: uppercase;
 	}
@@ -568,12 +575,12 @@ KP2BW_BITWARDEN_PASSWORD=&lt;bitwarden password&gt;</code></pre>
 			display: flex;
 			justify-content: space-between;
 			gap: 14px;
-			border-top: 1px solid #30372f;
+			border-top: 1px solid var(--edge);
 		}
 
 		.mapping-grid span {
 			display: inline;
-			color: #9c9587;
+			color: var(--text-muted);
 			font-size: 0.68rem;
 			text-transform: uppercase;
 		}

--- a/docs/src/routes/docs/+page.svelte
+++ b/docs/src/routes/docs/+page.svelte
@@ -1,0 +1,581 @@
+<script lang="ts">
+	import { resolve } from '$app/paths';
+</script>
+
+<svelte:head>
+	<title>kp2bw migration notes</title>
+	<meta
+		name="description"
+		content="How kp2bw maps KeePass entries, folders, metadata, URLs, and reruns into Bitwarden."
+	>
+</svelte:head>
+
+<main class="docs-page">
+	<header class="docs-hero">
+		<a href={resolve('/')}>Back to planner</a>
+		<p>migration notes</p>
+		<h1>How kp2bw moves a vault</h1>
+		<span>
+			The planner gives you a command. This page explains the Bitwarden model
+			behind it, especially the folder and collection choices that matter for
+			organization migrations.
+		</span>
+	</header>
+
+	<div class="docs-layout">
+		<nav aria-label="Documentation sections">
+			<a href={resolve('/docs#moves')}>What moves</a>
+			<a href={resolve('/docs#options')}>Planner options</a>
+			<a href={resolve('/docs#mapping')}>Folders vs collections</a>
+			<a href={resolve('/docs#recommended')}>Default org command</a>
+			<a href={resolve('/docs#reruns')}>Running again</a>
+			<a href={resolve('/docs#urls')}>URL handling</a>
+			<a href={resolve('/docs#after')}>After migration</a>
+			<a href={resolve('/docs#credentials')}>Credentials</a>
+		</nav>
+
+		<div class="content">
+			<section id="moves">
+				<p class="eyebrow">what moves</p>
+				<h2>kp2bw is not just a CSV-style import</h2>
+				<p>
+					It reads a KeePass 2.x database and creates Bitwarden items through
+					<code>bw serve</code>. Entries, group paths, attachments,
+					passkey-related fields, OTP-related fields, tags, expiry data, and
+					login URIs are mapped into Bitwarden shapes instead of being dumped as
+					plain notes.
+				</p>
+				<div class="fact-grid">
+					<article>
+						<h3>Entries</h3>
+						<p>
+							Titles, usernames, passwords, notes, custom fields, and identities
+							are migrated as Bitwarden item data.
+						</p>
+					</article>
+					<article>
+						<h3>Attachments</h3>
+						<p>
+							Files attached to KeePass entries are uploaded after their
+							Bitwarden item exists.
+						</p>
+					</article>
+					<article>
+						<h3>Metadata</h3>
+						<p>
+							Tags and expiry are kept in a readable <code>KP2BW_META</code>
+							field when Bitwarden has no native slot.
+						</p>
+					</article>
+					<article>
+						<h3>Identity stamps</h3>
+						<p>
+							<code>KP2BW_ID</code> lets reruns match the same KeePass entry
+							instead of guessing by title.
+						</p>
+					</article>
+				</div>
+			</section>
+
+			<section id="options">
+				<p class="eyebrow">planner options</p>
+				<h2>Each option changes placement, filtering, or rerun behavior</h2>
+				<div class="fact-grid">
+					<article id="target-vault">
+						<h3>Target vault</h3>
+						<p>
+							Organization means shared Bitwarden collections. Personal means
+							your own vault and optional personal folders.
+						</p>
+					</article>
+					<article id="organization-id">
+						<h3>Organization ID</h3>
+						<p>
+							The value passed with <code>-o</code>. Use the Bitwarden
+							organization ID for the destination org.
+						</p>
+					</article>
+					<article id="collection-id">
+						<h3>Collection ID</h3>
+						<p>
+							The value passed with <code>-c</code> when every imported item
+							should land in one existing collection.
+						</p>
+					</article>
+					<article id="keepass-file">
+						<h3>KeePass file</h3>
+						<p>
+							The final command argument. Point it at the <code>.kdbx</code>
+							database to migrate.
+						</p>
+					</article>
+					<article id="key-file">
+						<h3>Key file</h3>
+						<p>
+							Adds <code>-K</code> when the KeePass database also needs a key
+							file.
+						</p>
+					</article>
+					<article id="tag-filter">
+						<h3>Tag filter</h3>
+						<p>
+							Adds <code>-t</code> values. Empty means every non-excluded entry
+							is included.
+						</p>
+					</article>
+					<article id="filters">
+						<h3>Filters</h3>
+						<p>
+							Filters decide which KeePass entries are part of the plan before
+							collections or folders are calculated.
+						</p>
+					</article>
+					<article id="skip-expired">
+						<h3>Skip expired</h3>
+						<p>
+							Adds <code>--skip-expired</code>. Expired KeePass entries are
+							included unless this is enabled.
+						</p>
+					</article>
+					<article id="recycle-bin">
+						<h3>Recycle Bin</h3>
+						<p>
+							Adds <code>--include-recycle-bin</code>. Recycle Bin entries are
+							excluded by default.
+						</p>
+					</article>
+				</div>
+			</section>
+
+			<section id="mapping">
+				<p class="eyebrow">folders vs collections</p>
+				<h2>
+					Bitwarden folders are personal. Organization structure is collections.
+				</h2>
+				<p>
+					This is the main migration trap. KeePass groups look like folders, but
+					a Bitwarden organization does not have org folders. Shared structure
+					in an organization is made with collections. Nested collections are
+					names with slashes, such as <code>Work/Servers</code>.
+				</p>
+				<div class="mapping-grid" aria-label="KeePass group mapping examples">
+					<div class="mapping-head">KeePass group</div>
+					<div class="mapping-head">Nested org collections</div>
+					<div class="mapping-head">Top-level org collections</div>
+					<div class="mapping-head">Personal folders</div>
+
+					<div><span>KeePass group</span><code>Work/Servers</code></div>
+					<div>
+						<span>Nested org collections</span><code>Work/Servers</code>
+					</div>
+					<div><span>Top-level org collections</span><code>Work</code></div>
+					<div><span>Personal folders</span><code>Work/Servers</code></div>
+
+					<div><span>KeePass group</span><code>Internet/Banking</code></div>
+					<div>
+						<span>Nested org collections</span><code>Internet/Banking</code>
+					</div>
+					<div><span>Top-level org collections</span><code>Internet</code></div>
+					<div><span>Personal folders</span><code>Internet/Banking</code></div>
+				</div>
+				<p>
+					For a Vaultwarden organization migration, the usual shape is nested
+					collections and no personal folders. That keeps shared data in the org
+					model instead of creating a private folder tree beside it.
+				</p>
+				<div class="fact-grid">
+					<article id="full-path-collections">
+						<h3>Full-path collections</h3>
+						<p>
+							<code>-c nested --no-folder</code>: KeePass
+							<code>Work/Servers</code> becomes collection
+							<code>Work/Servers</code>.
+						</p>
+					</article>
+					<article id="top-folder-collections">
+						<h3>Top-folder collections</h3>
+						<p>
+							<code>-c auto --no-folder</code>: KeePass
+							<code>Work/Servers</code> and <code>Work/Engineering</code> both
+							land in collection <code>Work</code>.
+						</p>
+					</article>
+					<article id="single-collection">
+						<h3>Single collection</h3>
+						<p>
+							<code>-c 11111111-1111-1111-1111-111111111111 --no-folder</code>:
+							every imported item lands in one existing collection.
+						</p>
+					</article>
+					<article id="flat-org">
+						<h3>Flat organization</h3>
+						<p>
+							<code>--no-folder</code> without collection creation: items are
+							created without a generated hierarchy.
+						</p>
+					</article>
+					<article id="personal-folders">
+						<h3>Personal folders</h3>
+						<p>
+							KeePass groups become personal Bitwarden folders. Use this only
+							when importing into a personal vault.
+						</p>
+					</article>
+					<article id="flat-personal">
+						<h3>Flat personal</h3>
+						<p>
+							<code>--no-folder</code>: items stay at the personal vault root.
+						</p>
+					</article>
+				</div>
+			</section>
+
+			<section id="recommended">
+				<p class="eyebrow">recommended org migration</p>
+				<h2>Start with full-path organization collections</h2>
+				<p>
+					Use an organization ID, map full KeePass group paths to collections,
+					and omit personal folders:
+				</p>
+				<pre><code># .env
+KP2BW_KEEPASS_PASSWORD=&lt;keepass password&gt;
+KP2BW_BITWARDEN_PASSWORD=&lt;bitwarden password&gt;
+
+kp2bw -o 00000000-0000-0000-0000-000000000000 -c nested --no-folder vault.kdbx</code></pre>
+				<p>
+					Choose top-level collections if you need fewer collections. Choose one
+					existing collection only when you intentionally want to flatten the
+					KeePass group tree into a single shared place.
+				</p>
+			</section>
+
+			<section id="reruns">
+				<p class="eyebrow">running again</p>
+				<h2>Choose the situation, not the flag name</h2>
+				<p>
+					Every migrated item carries <code>KP2BW_ID</code>, the KeePass UUID
+					used to match the same item next time. kp2bw also writes a
+					<code>KP2BW_SYNC</code> content stamp. Those markers let kp2bw decide
+					whether an existing Bitwarden item is still safe to update.
+				</p>
+				<ul>
+					<li>
+						KeePass is still my main vault: use <code>--force-update</code>.
+					</li>
+					<li>
+						Mostly Bitwarden, sync forgotten KeePass edits: default mode.
+					</li>
+					<li>
+						Testing migrations against an existing Vaultwarden DB: use
+						<code>--no-update</code>.
+					</li>
+				</ul>
+				<div class="fact-grid">
+					<article id="force-update">
+						<h3>KeePass is still my main vault</h3>
+						<p>
+							<code>--force-update</code>: KeePass content wins over later
+							Bitwarden edits. Use this when KeePass is still the source of
+							truth.
+						</p>
+					</article>
+					<article id="safe-rerun">
+						<h3>Mostly Bitwarden, sync forgotten KeePass edits</h3>
+						<p>
+							Default mode. kp2bw updates migrated items when Bitwarden has not
+							been edited since the last kp2bw run.
+						</p>
+					</article>
+					<article id="no-update">
+						<h3>Testing migrations; keep the existing Vaultwarden DB</h3>
+						<p>
+							<code>--no-update</code>: create missing items only. Existing
+							migrated items stay untouched, so you do not need to wipe the DB
+							just to try another pass.
+						</p>
+					</article>
+				</div>
+			</section>
+
+			<section id="urls">
+				<p class="eyebrow">url handling</p>
+				<h2>Additional URLs become real login URIs</h2>
+				<p>
+					KeePass fields like <code>KP2A_URL</code>, <code>URL_1</code>, and
+					<code>AndroidApp</code> are folded into Bitwarden login URIs where
+					they can drive autofill. Free-text fields like <code>API Url</code>
+					stay as custom fields so API endpoints do not accidentally become
+					login matches.
+				</p>
+				<p>
+					Plain URLs use your Bitwarden account default. KeePassXC-style quoted
+					URLs become exact matches, and wildcards become starts-with or regex
+					matches. If too many subdomains surface together, use the URI
+					collision report to inspect the problem before changing match
+					behavior.
+				</p>
+			</section>
+
+			<section id="after">
+				<p class="eyebrow">after migration</p>
+				<h2>Only strip kp2bw stamps when you are truly done</h2>
+				<p>
+					<code>kp2bw --strip-ids</code> removes <code>KP2BW_ID</code> and
+					<code>KP2BW_SYNC</code> from migrated items. That is final adoption:
+					Bitwarden becomes the source of truth and future KeePass reruns become
+					unreliable because kp2bw can no longer match by KeePass UUID.
+				</p>
+				<p class="warning">
+					This is irreversible. Do not run it while you still expect to rerun a
+					KeePass migration.
+				</p>
+			</section>
+
+			<section id="credentials">
+				<p class="eyebrow">credentials</p>
+				<h2>Use a .env file for passwords</h2>
+				<p>
+					The command can prompt for passwords. For repeated runs, put secrets
+					in <code>.env</code> instead of in command arguments.
+				</p>
+				<pre><code>KP2BW_KEEPASS_PASSWORD=&lt;keepass password&gt;
+KP2BW_BITWARDEN_PASSWORD=&lt;bitwarden password&gt;</code></pre>
+				<p>
+					kp2bw loads <code>.env</code> automatically. Real environment
+					variables still win when both are set.
+				</p>
+			</section>
+		</div>
+	</div>
+</main>
+
+<style>
+	.docs-page {
+		min-height: 100vh;
+		padding: 28px;
+		font-family:
+			"Aptos Mono",
+			"Cascadia Mono",
+			"SFMono-Regular",
+			Consolas,
+			"Liberation Mono",
+			monospace;
+	}
+
+	.docs-hero,
+	.docs-layout {
+		max-width: 1120px;
+		margin: 0 auto;
+	}
+
+	.docs-hero {
+		display: grid;
+		gap: 10px;
+		border-bottom: 1px solid #30372f;
+		padding-bottom: 18px;
+	}
+
+	a {
+		width: fit-content;
+		color: #8ed9aa;
+		text-decoration: none;
+	}
+
+	a:hover {
+		text-decoration: underline;
+	}
+
+	.docs-hero p,
+	.eyebrow,
+	nav a,
+	h3 {
+		margin: 0;
+		color: #9c9587;
+		font-size: 0.74rem;
+		text-transform: uppercase;
+	}
+
+	h1,
+	h2,
+	h3,
+	p {
+		letter-spacing: 0;
+	}
+
+	h1 {
+		max-width: 12ch;
+		margin: 0;
+		font-family: Georgia, "Times New Roman", serif;
+		font-size: clamp(2.4rem, 5vw, 4.5rem);
+		line-height: 1;
+	}
+
+	.docs-hero span {
+		max-width: 74ch;
+		color: #bcb5a5;
+		line-height: 1.55;
+	}
+
+	.docs-layout {
+		display: grid;
+		grid-template-columns: 220px minmax(0, 1fr);
+		gap: 28px;
+		padding-top: 24px;
+	}
+
+	.docs-layout > * {
+		min-width: 0;
+	}
+
+	nav {
+		position: sticky;
+		top: 24px;
+		display: grid;
+		align-content: start;
+		gap: 10px;
+		height: fit-content;
+		border: 1px solid #30372f;
+		background: #171a16;
+		padding: 14px;
+	}
+
+	.content {
+		display: grid;
+		gap: 18px;
+	}
+
+	section {
+		min-width: 0;
+		border: 1px solid #30372f;
+		background: #171a16;
+		padding: 20px;
+	}
+
+	section > h2 {
+		margin: 5px 0 10px;
+		font-size: 1.25rem;
+		line-height: 1.35;
+	}
+
+	p,
+	li {
+		max-width: 78ch;
+		color: #d6ceb9;
+		line-height: 1.62;
+	}
+
+	code {
+		color: #d8f3df;
+		font: inherit;
+	}
+
+	pre {
+		overflow: auto;
+		border: 1px solid #31513f;
+		background: #0f1812;
+		padding: 14px;
+		color: #d8f3df;
+		white-space: pre;
+	}
+
+	.fact-grid {
+		display: grid;
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+		gap: 10px;
+		margin-top: 14px;
+	}
+
+	.fact-grid article {
+		min-width: 0;
+		border: 1px solid #2b302a;
+		padding: 14px;
+	}
+
+	.fact-grid p {
+		margin-bottom: 0;
+	}
+
+	.mapping-grid {
+		display: grid;
+		grid-template-columns: repeat(4, minmax(0, 1fr));
+		margin: 16px 0;
+		border-top: 1px solid #30372f;
+		border-left: 1px solid #30372f;
+	}
+
+	.mapping-grid > div {
+		min-width: 0;
+		border-right: 1px solid #30372f;
+		border-bottom: 1px solid #30372f;
+		padding: 10px;
+	}
+
+	.mapping-head {
+		color: #9c9587;
+		font-size: 0.74rem;
+		text-transform: uppercase;
+	}
+
+	.mapping-grid span {
+		display: none;
+	}
+
+	.warning {
+		border: 1px solid #7a5a40;
+		background: #201a13;
+		padding: 12px;
+		color: #f0c08a;
+	}
+
+	@media (max-width: 820px) {
+		.docs-page {
+			padding: 16px;
+		}
+
+		.docs-layout,
+		.fact-grid,
+		.mapping-grid {
+			grid-template-columns: 1fr;
+		}
+
+		nav {
+			position: static;
+		}
+
+		pre {
+			overflow-wrap: anywhere;
+			white-space: pre-wrap;
+		}
+
+		p,
+		li,
+		h2,
+		h3,
+		code,
+		nav a {
+			overflow-wrap: anywhere;
+		}
+
+		.mapping-head {
+			display: none;
+		}
+
+		.mapping-grid {
+			border-top: 0;
+		}
+
+		.mapping-grid > div {
+			display: flex;
+			justify-content: space-between;
+			gap: 14px;
+			border-top: 1px solid #30372f;
+		}
+
+		.mapping-grid span {
+			display: inline;
+			color: #9c9587;
+			font-size: 0.68rem;
+			text-transform: uppercase;
+		}
+	}
+</style>

--- a/docs/static/robots.txt
+++ b/docs/static/robots.txt
@@ -1,0 +1,3 @@
+# allow crawling everything by default
+User-agent: *
+Disallow:

--- a/docs/svelte.config.js
+++ b/docs/svelte.config.js
@@ -1,0 +1,14 @@
+import adapter from '@sveltejs/adapter-auto';
+import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
+
+const config = {
+	compilerOptions: {
+		runes: true,
+	},
+	kit: {
+		adapter: adapter(),
+	},
+	preprocess: vitePreprocess(),
+};
+
+export default config;

--- a/docs/svelte.config.js
+++ b/docs/svelte.config.js
@@ -1,4 +1,4 @@
-import adapter from '@sveltejs/adapter-auto';
+import adapter from '@sveltejs/adapter-static';
 import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
 
 const config = {
@@ -6,7 +6,8 @@ const config = {
 		runes: true,
 	},
 	kit: {
-		adapter: adapter(),
+		adapter: adapter({ fallback: '404.html' }),
+		paths: { base: process.argv.includes('dev') ? '' : process.env.BASE_PATH },
 	},
 	preprocess: vitePreprocess(),
 };

--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -1,0 +1,20 @@
+{
+	"extends": "./.svelte-kit/tsconfig.json",
+	"compilerOptions": {
+		"rewriteRelativeImportExtensions": true,
+		"allowJs": true,
+		"checkJs": true,
+		"esModuleInterop": true,
+		"forceConsistentCasingInFileNames": true,
+		"resolveJsonModule": true,
+		"skipLibCheck": true,
+		"sourceMap": true,
+		"strict": true,
+		"moduleResolution": "bundler"
+	}
+	// Path aliases are handled by https://svelte.dev/docs/kit/configuration#alias
+	// except $lib which is handled by https://svelte.dev/docs/kit/configuration#files
+	//
+	// To make changes to top-level options such as include and exclude, we recommend extending
+	// the generated config; see https://svelte.dev/docs/kit/configuration#typescript
+}

--- a/docs/vite.config.ts
+++ b/docs/vite.config.ts
@@ -1,0 +1,35 @@
+import { sveltekit } from '@sveltejs/kit/vite';
+import { playwright } from '@vitest/browser-playwright';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+	plugins: [sveltekit()],
+	test: {
+		expect: { requireAssertions: true },
+		projects: [
+			{
+				extends: './vite.config.ts',
+				test: {
+					name: 'client',
+					browser: {
+						enabled: true,
+						provider: playwright(),
+						instances: [{ browser: 'chromium', headless: true }],
+					},
+					include: ['src/**/*.svelte.{test,spec}.{js,ts}'],
+					exclude: ['src/lib/server/**'],
+				},
+			},
+
+			{
+				extends: './vite.config.ts',
+				test: {
+					name: 'server',
+					environment: 'node',
+					include: ['src/**/*.{test,spec}.{js,ts}'],
+					exclude: ['src/**/*.svelte.{test,spec}.{js,ts}'],
+				},
+			},
+		],
+	},
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
 	"private": true,
 	"type": "module",
+	"workspaces": ["docs"],
 	"scripts": {
 		"basedpyright": "uv run basedpyright",
 		"dprint:update": "dprint config update --yes --recursive",

--- a/package.json
+++ b/package.json
@@ -21,11 +21,14 @@
 		"@actions/github-script": "github:actions/github-script",
 		"@bitwarden/cli": "^2026.5.0",
 		"@types/bun": "^1.3.14",
-		"@typescript/native-preview": "^7.0.0-dev.20260607.1",
+		"@typescript/native-preview": "^7.0.0-dev",
 		"dprint": "^0.54.0",
-		"runner-run": "^0.12.1",
-		"tombi": "^1.1.2",
+		"runner-run": "catalog:",
+		"tombi": "^1.1.4",
 		"typescript": "^6.0.3"
+	},
+	"catalog": {
+	  "runner-run": "^0.13.1"
 	},
 	"packageManager": "bun@1.3.14"
 }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
 		"typescript": "^6.0.3"
 	},
 	"catalog": {
-	  "runner-run": "^0.13.1"
+		"runner-run": "^0.13.1"
 	},
 	"packageManager": "bun@1.3.14"
 }


### PR DESCRIPTION
## Summary
- add SvelteKit migration planner docs workspace
- align planner defaults with kp2bw 3.7 org/personal folder behavior
- persist selections, reset, wrapped commands, and split .env/run copy
- polish shared docs theme, footer, and planner docs